### PR TITLE
Add a way to unload items from memory quickly

### DIFF
--- a/Source/Fuse.Common/Resources/MemoryPolicy.uno
+++ b/Source/Fuse.Common/Resources/MemoryPolicy.uno
@@ -26,6 +26,17 @@ namespace Fuse.Resources
 			UnusedTimeout = 60,
 			UnpinInvisible = true,
 			};
+
+		[UXGlobalResource("QuickUnload")]
+		/**
+			This policy causes the resource to be loaded as required and then unloads it as soon as possible when no longer required (after a  timeout of 1s).
+			This is useful when you have several images being loaded dynamically one after the other in your app.
+		*/
+		public static MemoryPolicy QuickUnload = new MemoryPolicy{
+			UnloadInBackground = true,
+			UnusedTimeout = 1,
+			UnpinInvisible = true,
+			};
 			
 		[UXGlobalResource("UnloadInBackground")]
 		/**


### PR DESCRIPTION
This adds a memory policy called `QuickUnload`, which is the same as `UnloadUnused` but with a timeout of 1 second. The main motivation for this is to make it easier to create apps which use multiple large temporary images, without needing the user to define their own memory policy.

