### PR TITLE
fix bad merge with semi-colon

### DIFF
--- a/Source/Fuse.Maps/iOS/MapViewDelegate.h
+++ b/Source/Fuse.Maps/iOS/MapViewDelegate.h
@@ -25,7 +25,7 @@ typedef void (^TouchesEventBlock)(NSSet * touches, UIEvent * event);
 	longitude:(double)lng
 	icon:(NSString*)iconPath
 	iconX:(float)iconX
-	iconY:(float)iconY;
+	iconY:(float)iconY
 	markerID:(int)markerID;
 	-(BOOL)authorized;
 	-(void)removeMarker:(int)identifier;


### PR DESCRIPTION
Looks like I did a bad merge, and ended up with an extra semi-colon in the MapView file, which xcode doesn't like.