### PR TITLE
travis: run native tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 os: osx
 
-cache: ccache
+cache:
+  directories:
+    - $HOME/.ccache
 
 install:
   - brew update


### PR DESCRIPTION
This enables running test on travis (using the 'native'-target). However, since native compilation of each test is quite slow, this ends up taking around 30 minutes. So to combat that, I added ccache to the compile to bring time back down to around 10 minutes.