### PR TITLE
Fuse.Nodes: give Fuse.Input.Gestures an internal constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Gestures
+- Fuse.Input.Gesture now only has an internal constructor. This means that external code can't instantiate it. But before, they already couldn't do so in a *meaningful* way, so this shouldn't really affect any applications.
+
 ## Native TextInput
 - Fixed issue where focusing a `<TextInput />` or `<TextView />` by tapping it would not update the caret position accordingly. 
 

--- a/Source/Fuse.Nodes/Input/Gesture.uno
+++ b/Source/Fuse.Nodes/Input/Gesture.uno
@@ -101,13 +101,26 @@ namespace Fuse.Input
 	*/
 	public class Gesture : IPropertyListener
 	{
-		internal IGesture Handler;
-		internal GestureType Type;
-		internal Visual Target;
+		internal readonly IGesture Handler;
+		internal readonly GestureType Type;
+		internal readonly Visual Target;
 		
 		CaptureType _captureType = CaptureType.None;
 		int _down = -1;
-		
+
+		internal Gesture(IGesture handler, GestureType type, Visual target)
+		{
+			if (handler == null)
+				throw new ArgumentNullException( nameof(handler) );
+
+			if (target == null)
+				throw new ArgumentNullException( nameof(target) );
+
+			Handler = handler;
+			Type = type;
+			Target = target;
+		}
+
 		void HandleRequest( GestureRequest req, PointerEventArgs args )
 		{
 			switch (req)
@@ -260,11 +273,7 @@ namespace Fuse.Input
 			if (!type.HasFlag(GestureType.Primary))
 				throw new ArgumentException( "Invalid gesture type" );
 				
-			var g = new Gesture{ 
-				Handler = handler ,
-				Type = type,
-				Target = target,
-			};
+			var g = new Gesture(handler, type, target);
 			_gestures[handler] = g;
 		
 			//ideally we will merge this into the generate pointer handling to avoid needing an extra


### PR DESCRIPTION
Because `Gesture.Handler`, `Gesture.Type` and `Gesture.Target` needs
to create a functional object (otherwise, we'll end up crashing
later), it was already impossible to create a meaningful
`Gesture`-object from external code.

So let's just make this explicitly clear, and throw some exceptions
on incorrect API-usage.