### PR TITLE
DotNet support for base64 operations in ImageTools 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 ## MemoryPolicy
 - Added `QuickUnload` memory policy to keep data in memory for as short as possible.
 
+## ImageTools
+- Added supported for encoding/decoding images to/from base64 on DotNet platforms, including Windows and Mac OS X.
 
 ## 1.0
 
@@ -81,7 +83,6 @@
 ## ImageTools
 - Changed the algorithm for creating new file names for temporary images. Previously this used a date format that caused problems when several images were created in sub-second intervals, breaking custom map marker icons, for instance.
 - Fixed a memory leak that occured when resizing multiple images one after another.
-- Added supported for encoding/decoding images to/from base64 on DotNet platforms, including Windows and Mac OS X.
 
 ## Vector drawing
 A new vector drawing system has been added to Fuse. This allows drawing of curves, shapes, and simple vector images.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 ## ImageTools
 - Changed the algorithm for creating new file names for temporary images. Previously this used a date format that caused problems when several images were created in sub-second intervals, breaking custom map marker icons, for instance.
 - Fixed a memory leak that occured when resizing multiple images one after another.
+- Added supported for encoding/decoding images to/from base64 on DotNet platforms, including Windows and Mac OS X.
 
 ## Vector drawing
 A new vector drawing system has been added to Fuse. This allows drawing of curves, shapes, and simple vector images.

--- a/Source/Fuse.ImageTools/DotNet.uxl
+++ b/Source/Fuse.ImageTools/DotNet.uxl
@@ -1,0 +1,3 @@
+<Extensions Backend="CIL">
+    <Require AssemblyReference="System.Drawing" />
+</Extensions>

--- a/Source/Fuse.ImageTools/DotNetImageUtils.uno
+++ b/Source/Fuse.ImageTools/DotNetImageUtils.uno
@@ -1,0 +1,77 @@
+using Uno.Threading;
+using Uno;
+using Uno.IO;
+using Uno.Compiler.ExportTargetInterop;
+using System;
+
+namespace Fuse.ImageTools
+{
+	using DotNetNative;
+
+	extern (DOTNET) internal class DotNetImageUtils
+	{
+		public static void GetImageFromBase64(string b64, Action<string> onSuccess, Action<string> onFail)
+		{
+			var asBytes = Convert.FromBase64String(b64);
+			var stream = new MemoryStream(asBytes);
+			DotNetImage outImage = DotNetImage.FromStream(stream);
+			
+			var path = TemporaryPath("jpg");
+			outImage.Save(path);
+			onSuccess(path);
+		}
+
+		public static void GetBase64FromImage(string path, Action<string> onSuccess, Action<string> onFail)
+		{
+			var image = DotNetImage.FromFile(path);
+
+			using (MemoryStream ms = new MemoryStream())
+			{
+				image.Save(ms, ImageFormat.Jpeg);
+				byte[] imageBytes = ms.GetBuffer();
+				onSuccess(Convert.ToBase64String(imageBytes));
+			}
+		}
+		
+		static string TemporaryPath(string extension)
+		{
+			var dir = DotNetNative.Path.GetTempPath ();
+			var path = DotNetNative.Path.ChangeExtension(dir + DotNetNative.Path.GetRandomFileName(), extension);
+			return path;
+		}
+	}
+
+	namespace DotNetNative
+	{
+		[Require("Assembly", "System.Drawing.dll")]
+		[DotNetType("System.Drawing.Image")]
+		extern(DOTNET) internal class DotNetImage
+		{
+			public extern static DotNetImage FromFile(string path);
+			public extern static DotNetImage FromStream(Stream stream);
+			public extern void Save(string filename);
+			public extern void Save(Stream stream, ImageFormat format);
+		}
+
+		[DotNetType("System.Convert")]
+		extern(DOTNET) internal class Convert
+		{
+			public extern static byte[] FromBase64String(string s);
+			public extern static string ToBase64String(byte[] inArray);
+		}
+
+		[DotNetType("System.Drawing.Imaging.ImageFormat")]
+		extern(DOTNET) internal class ImageFormat
+		{
+			public extern static ImageFormat Jpeg { get; }
+		}
+
+		[DotNetType("System.IO.Path")]
+		extern(DOTNET) internal class Path
+		{
+			public extern static string GetTempPath();
+			public extern static string GetRandomFileName();
+			public extern static string ChangeExtension(string path, string extension);
+		}
+	}
+}

--- a/Source/Fuse.ImageTools/Fuse.ImageTools.unoproj
+++ b/Source/Fuse.ImageTools/Fuse.ImageTools.unoproj
@@ -9,7 +9,10 @@
   },
   "InternalsVisibleTo":[
     "Fuse.Camera",
-    "Fuse.CameraRoll"
+    "Fuse.CameraRoll",
+    "FuseTest",
+    "Fuse.Testing",
+    "Fuse.ImageTools.Test"
   ],
   "Packages": [
     "Uno.Threading",
@@ -32,5 +35,8 @@
     "iOS/ImagePicker.m:CSource:iOS",
     "iOS/ImageHelper.h:CHeader:iOS",
     "iOS/ImageHelper.m:CSource:iOS"
+  ],
+  "Excludes": [
+    "Tests/",
   ]
 }

--- a/Source/Fuse.ImageTools/Fuse.ImageTools.unoproj
+++ b/Source/Fuse.ImageTools/Fuse.ImageTools.unoproj
@@ -10,8 +10,6 @@
   "InternalsVisibleTo":[
     "Fuse.Camera",
     "Fuse.CameraRoll",
-    "FuseTest",
-    "Fuse.Testing",
     "Fuse.ImageTools.Test"
   ],
   "Packages": [

--- a/Source/Fuse.ImageTools/ImageTools.uno
+++ b/Source/Fuse.ImageTools/ImageTools.uno
@@ -384,6 +384,8 @@ namespace Fuse.ImageTools
 				new GetBase64Command(img.Path,closure.Resolve, closure.Reject).Execute();
 			else if defined(iOS)
 				iOSImageUtils.GetBase64FromImage(img.Path, closure.Resolve, closure.Reject);
+			else if defined(dotnet)
+				DotNetImageUtils.GetBase64FromImage(img.Path, closure.Resolve, closure.Reject);
 			else
 				closure.Reject("Unsupported platform");
 			return p;
@@ -418,6 +420,8 @@ namespace Fuse.ImageTools
 				new ImageFromBase64Command(b64, closure.Resolve, closure.Reject).Execute();
 			else if defined(iOS)
 				iOSImageUtils.GetImageFromBase64(b64, closure.Resolve, closure.Reject);
+			else if defined(dotnet)
+				DotNetImageUtils.GetImageFromBase64(b64, closure.Resolve, closure.Reject);
 			else
 				closure.Reject("Unsupported platform");
 			return p;

--- a/Source/Fuse.ImageTools/Tests/Fuse.ImageTools.Test.unoproj
+++ b/Source/Fuse.ImageTools/Tests/Fuse.ImageTools.Test.unoproj
@@ -1,0 +1,14 @@
+{
+  "Packages": [
+    "Fuse",
+    "FuseJS",
+    "Uno.Testing",
+    "Fuse.ImageTools"
+  ],
+  "Projects": [
+    "../../Fuse.Common/Tests/FuseTest/FuseTest.unoproj"
+  ],
+  "Includes": [
+    "*",
+  ]
+}

--- a/Source/Fuse.ImageTools/Tests/ImageTools.Test.uno
+++ b/Source/Fuse.ImageTools/Tests/ImageTools.Test.uno
@@ -1,0 +1,68 @@
+using Uno;
+using Uno.Collections;
+using Uno.Testing;
+using Fuse;
+using FuseTest;
+
+namespace Fuse.ImageTools.Test
+{
+	public class ImageToolsTest : TestBase
+	{
+		private Object _image = null;
+
+
+		[Test]
+		public void CreatingAnImageSucceeds()
+		{
+			if defined(!DOTNET) return;
+
+			Fuse.ImageTools.ImageTools image = new Fuse.ImageTools.ImageTools();
+			using (var root = new TestRootPanel()){
+				var future = ImageTools.ImageFromBase64("iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAABlBMVEX9//wAAQATpOzaAAAAH0l" + "EQVQI12MAAoMHIFLAAYSEwIiJgYGZASrI38AAAwBamgM5VF7xgwAAAABJRU5ErkJggg==");
+				future.Then(Print, Fail);
+				root.StepFrame();
+				root.StepFrame();
+				root.StepFrame();
+				root.StepFrame();
+
+				Assert.IsFalse(_image == null);
+			}
+			_image = null;
+		}
+
+		[Test]
+		public void CreatingAnImageFails()
+		{
+			if defined(!DOTNET) return;
+			
+			Fuse.ImageTools.ImageTools image = new Fuse.ImageTools.ImageTools();
+			using (var root = new TestRootPanel()){
+				try 
+				{
+					var future = ImageTools.ImageFromBase64("iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAABlBMVEX9//wAAQATpOzaAAAAH0l");
+					future.Then(Print, Fail);
+				} catch (FormatException e)
+				{
+					// expected error case
+				}
+				root.StepFrame();
+				root.StepFrame();
+				root.StepFrame();
+				root.StepFrame();
+
+				Assert.IsTrue(_image == null);
+			}
+			_image = null;
+		}
+
+		private void Fail(Exception e)
+		{
+			_image = null;
+		}
+
+		private void Print(Object image)
+		{
+			_image = image;
+		}
+	}
+}

--- a/Source/Fuse.ImageTools/Tests/ImageTools.Test.uno
+++ b/Source/Fuse.ImageTools/Tests/ImageTools.Test.uno
@@ -10,49 +10,31 @@ namespace Fuse.ImageTools.Test
 	{
 		private Object _image = null;
 
-
 		[Test]
+		[Ignore("Only supported on dotnet", "!DOTNET")]
 		public void CreatingAnImageSucceeds()
 		{
-			if defined(!DOTNET) return;
-
 			Fuse.ImageTools.ImageTools image = new Fuse.ImageTools.ImageTools();
 			using (var root = new TestRootPanel()){
 				var future = ImageTools.ImageFromBase64("iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAABlBMVEX9//wAAQATpOzaAAAAH0l" + "EQVQI12MAAoMHIFLAAYSEwIiJgYGZASrI38AAAwBamgM5VF7xgwAAAABJRU5ErkJggg==");
 				future.Then(Print, Fail);
-				root.StepFrame();
-				root.StepFrame();
-				root.StepFrame();
-				root.StepFrame();
-
 				Assert.IsFalse(_image == null);
 			}
 			_image = null;
 		}
 
+		void MakeInvalidImage()
+		{
+			Fuse.ImageTools.ImageTools image = new Fuse.ImageTools.ImageTools();
+			var future = ImageTools.ImageFromBase64("iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAABlBMVEX9//wAAQATpOzaAAAAH0l");
+			future.Then(Print, Fail);
+		}
+
 		[Test]
+		[Ignore("Only supported on dotnet", "!DOTNET")]
 		public void CreatingAnImageFails()
 		{
-			if defined(!DOTNET) return;
-			
-			Fuse.ImageTools.ImageTools image = new Fuse.ImageTools.ImageTools();
-			using (var root = new TestRootPanel()){
-				try 
-				{
-					var future = ImageTools.ImageFromBase64("iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAABlBMVEX9//wAAQATpOzaAAAAH0l");
-					future.Then(Print, Fail);
-				} catch (FormatException e)
-				{
-					// expected error case
-				}
-				root.StepFrame();
-				root.StepFrame();
-				root.StepFrame();
-				root.StepFrame();
-
-				Assert.IsTrue(_image == null);
-			}
-			_image = null;
+			Assert.Throws<FormatException>(MakeInvalidImage);
 		}
 
 		private void Fail(Exception e)

--- a/Source/Fuse.ImageTools/Tests/ImageTools.Test.uno
+++ b/Source/Fuse.ImageTools/Tests/ImageTools.Test.uno
@@ -11,13 +11,12 @@ namespace Fuse.ImageTools.Test
 		private Object _image = null;
 
 		[Test]
-		[Ignore("Only supported on dotnet", "!DOTNET")]
+		[Ignore("Only supported on dotnet, Android or iOS", "native")]
 		public void CreatingAnImageSucceeds()
 		{
-			Fuse.ImageTools.ImageTools image = new Fuse.ImageTools.ImageTools();
 			using (var root = new TestRootPanel()){
 				var future = ImageTools.ImageFromBase64("iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAABlBMVEX9//wAAQATpOzaAAAAH0l" + "EQVQI12MAAoMHIFLAAYSEwIiJgYGZASrI38AAAwBamgM5VF7xgwAAAABJRU5ErkJggg==");
-				future.Then(Print, Fail);
+				future.Then(SaveImage, Fail);
 				Assert.IsFalse(_image == null);
 			}
 			_image = null;
@@ -25,13 +24,12 @@ namespace Fuse.ImageTools.Test
 
 		void MakeInvalidImage()
 		{
-			Fuse.ImageTools.ImageTools image = new Fuse.ImageTools.ImageTools();
 			var future = ImageTools.ImageFromBase64("iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAABlBMVEX9//wAAQATpOzaAAAAH0l");
-			future.Then(Print, Fail);
+			future.Then(SaveImage, Fail);
 		}
 
 		[Test]
-		[Ignore("Only supported on dotnet", "!DOTNET")]
+		[Ignore("Only supported on dotnet, Android or iOS", "native")]
 		public void CreatingAnImageFails()
 		{
 			Assert.Throws<FormatException>(MakeInvalidImage);
@@ -42,7 +40,7 @@ namespace Fuse.ImageTools.Test
 			_image = null;
 		}
 
-		private void Print(Object image)
+		private void SaveImage(Object image)
 		{
 			_image = image;
 		}


### PR DESCRIPTION
Now this will work on DotNet platforms: 

```
<App>
	<JavaScript>
		var ImageTools = require("FuseJS/ImageTools");
		var Observable = require("FuseJS/Observable");

		var imagePath = Observable();
		var base64Image =	"iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPAQMAAAABGAcJAAAABlBMVEX9//wAAQATpOzaAAAAH0l" +
							"EQVQI12MAAoMHIFLAAYSEwIiJgYGZASrI38AAAwBamgM5VF7xgwAAAABJRU5ErkJggg==";
		ImageTools.getImageFromBase64(base64Image)
		.then(function(image) {
			imagePath.value = image.path;
			ImageTools.getBase64FromImage(image).then(function(b64){
				console.log(b64);
			});
		});

		module.exports = { test: new Date().toString(), image: imagePath };
	</JavaScript>
	<Image File="{image}" />
</App>
```

Previously this was unsupported. This is a first PR to add full DotNet compatibility for image tools