### PR TITLE
Feature toggle for implicit GraphicsView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Native
+- Added feature toggle for implicit `GraphicsView`. If you are making an app using only Native UI disabling the implicit `GraphicsView` can increase performance. Disable the `GraphicsView` by defining `DISABLE_IMPLICIT_GRAPHICSVIEW` when building. For example `uno build -t=ios -DDISABLE_IMPLICIT_GRAPHICSVIEW`
+
 ## Gestures
 - Fuse.Input.Gesture now only has an internal constructor. This means that external code can't instantiate it. But before, they already couldn't do so in a *meaningful* way, so this shouldn't really affect any applications.
 

--- a/Source/Fuse.Android/AndroidApp.uno
+++ b/Source/Fuse.Android/AndroidApp.uno
@@ -20,7 +20,20 @@ namespace Fuse
 		}
 
 		TreeRendererPanel _renderPanel;
-		GraphicsView _graphicsView;
+
+		extern(!DISABLE_IMPLICIT_GRAPHICSVIEW)
+		GraphicsView _graphicsView = new RootGraphicsView();
+
+		Visual RootVisual
+		{
+			get
+			{
+				if defined(!DISABLE_IMPLICIT_GRAPHICSVIEW)
+					return _graphicsView;
+				else
+					return _renderPanel;
+			}
+		}
 
 		public App()
 		{
@@ -31,12 +44,13 @@ namespace Fuse
 			Fuse.Controls.TextControl.TextRendererFactory = Fuse.Android.TextRenderer.Create;
 
 			_renderPanel = new TreeRendererPanel(new RootViewHost());
-			_graphicsView = new RootGraphicsView();
-			_renderPanel.Children.Add(_graphicsView);
+
+			if defined(!DISABLE_IMPLICIT_GRAPHICSVIEW)
+				_renderPanel.Children.Add(_graphicsView);
 
 			MobileBootstrapping.Init();
 
-			RootViewport = new NativeRootViewport(new ViewHandle(AppRoot.Handle));
+			RootViewport = new NativeRootViewport(AppRoot.ViewHandle);
 			RootViewport.Children.Add(_renderPanel);
 
 			Uno.Platform.Displays.MainDisplay.Tick += OnTick;
@@ -44,12 +58,12 @@ namespace Fuse
 
 		public sealed override IList<Node> Children
 		{
-			get { return _graphicsView.Children; }
+			get { return RootVisual.Children; }
 		}
 
 		public sealed override Visual ChildrenVisual
 		{
-			get { return _graphicsView; }
+			get { return RootVisual; }
 		}
 
 		void OnTick(object sender, Uno.Platform.TimerEventArgs args)
@@ -78,7 +92,10 @@ namespace Fuse
 
 		void PropagateBackground()
 		{
-			_graphicsView.Color = Background;
+			if defined(!DISABLE_IMPLICIT_GRAPHICSVIEW)
+				_graphicsView.Color = Background;
+			else
+				AppRoot.ViewHandle.SetBackgroundColor((int)Uno.Color.ToArgb(Background));
 		}
 	}
 }

--- a/Source/Fuse.Android/AppRoot.uno
+++ b/Source/Fuse.Android/AppRoot.uno
@@ -11,16 +11,23 @@ namespace Fuse.Android
 	extern(Android && !Library) internal static class AppRoot
 	{
 
+		public static ViewHandle ViewHandle
+		{
+			get { return _viewHandle; }
+		}
+
 		public static Java.Object Handle
 		{
 			get { return _rootContainer; }
 		}
 
 		static readonly Java.Object _rootContainer;
+		static readonly ViewHandle _viewHandle;
 
 		static AppRoot()
 		{
 			_rootContainer = CreateRootView();
+			_viewHandle = new ViewHandle(_rootContainer);
 			SetAppRoot(_rootContainer);
 		}
 

--- a/Source/Fuse.iOS/iOSApp.uno
+++ b/Source/Fuse.iOS/iOSApp.uno
@@ -19,7 +19,21 @@ namespace Fuse
 		}
 
 		TreeRendererPanel _renderPanel;
-		Fuse.Controls.GraphicsView _graphicsView;
+
+		extern(!DISABLE_IMPLICIT_GRAPHICSVIEW)
+		Fuse.Controls.GraphicsView _graphicsView = new Fuse.Controls.GraphicsView();
+
+		Visual RootVisual
+		{
+			get
+			{
+				if defined(!DISABLE_IMPLICIT_GRAPHICSVIEW)
+					return _graphicsView;
+				else
+					return _renderPanel;
+			}
+		}
+
 
 		public App()
 		{
@@ -35,8 +49,9 @@ namespace Fuse
 			Uno.Platform.Displays.MainDisplay.Tick += OnTick;
 
 			_renderPanel = new TreeRendererPanel(new RootViewHost());
-			_graphicsView = new Fuse.Controls.GraphicsView();
-			_renderPanel.Children.Add(_graphicsView);
+
+			if defined(!DISABLE_IMPLICIT_GRAPHICSVIEW)
+				_renderPanel.Children.Add(_graphicsView);
 
 			InputDispatch.AddListener(_renderPanel, AppRoot.Handle);
 
@@ -45,12 +60,12 @@ namespace Fuse
 
 		public sealed override IList<Node> Children
 		{
-			get { return _graphicsView.Children; }
+			get { return RootVisual.Children; }
 		}
 		
 		public sealed override Visual ChildrenVisual
 		{
-			get { return _graphicsView; }
+			get { return RootVisual; }
 		}
 
 		void OnTick(object sender, Uno.Platform.TimerEventArgs args)
@@ -126,7 +141,8 @@ namespace Fuse
  			if (_prevStatusBarOrientation != o)
  			{
  				_prevStatusBarOrientation = o;
-				UpdateManager.PerformNextFrame(_graphicsView.InvalidateVisual);
+				if defined(!DISABLE_IMPLICIT_GRAPHICSVIEW)
+					UpdateManager.PerformNextFrame(_graphicsView.InvalidateVisual);
  			}
  		}
 


### PR DESCRIPTION
While profiling apps using `NativeViewHost` in the root I observed that a significant amount of cpu time was spent in [`EndDraw`](https://github.com/fusetools/fuselibs-public/blob/master/Source/Fuse.Controls.Native/iOS/GraphicsView.uno#L108-L112). I guess we are stuck waiting for swap buffers.

Disabling the implicit `GraphicsView` yielded visible performance improvements on both iOS and Android.

This feature is in our backlog and will at some point be an option in `unoproj`