### PR TITLE
Fix for Atlas issue

### DIFF
--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -321,7 +321,9 @@ namespace Fuse.Elements
 				var opacity = entry._opacity;
 
 				var transform = entry._elm.LocalTransform;
-				float2 positionOrigin = transform[3].XY + (float2)cachingRect.Minimum * densityScale;
+				//this calculation assumes the transform is flat (a precondition to caching the element)
+				float2 localOrigin = (float2)cachingRect.Minimum * densityScale;
+				float2 positionOrigin = transform[3].XY + localOrigin.X * transform[0].XY + localOrigin.Y * transform[1].XY;
 				float2 size = (float2)cachingRect.Size * densityScale;
 				float2 right = transform[0].XY * size.X;
 				float2 up = transform[1].XY * size.Y;


### PR DESCRIPTION
fixes https://github.com/fusetools/fuselibs/issues/4176

All I did was use the full transform to translate the points of the atlas item. This seems like the right thing to do, but it seems unlikely this was forgotten previously -- am I missing something?  I'm also uncertain how the previous items managed to be rotated at all without this transform multiplication.

This will also break if there are non-flat transforms, but I think the caching excludes those anyway (though it doesn't really have to, since the element's visuals are still flat). Note, this would be broken before as well, so no further problem here.