### PR TITLE
pack.sh: add a dev-prefix to unknown branches

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -34,7 +34,7 @@ master)
     SUFFIX="--suffix=master-$REVISION"
     ;;
 *)
-    SUFFIX="--suffix=$REVISION"
+    SUFFIX="--suffix=dev-$REVISION"
     ;;
 esac
 


### PR DESCRIPTION
Suffixes that starts with a digit are invalid, and when unlucky, we
can easily get a SHA-1 that does this. So let's add a dev-prefix to
show clearly that this is a development-version of the package.