### PR TITLE
Made ValueForwarder.IValueListener internal

### DIFF
--- a/Source/Fuse.Reactive/ValueObserver.uno
+++ b/Source/Fuse.Reactive/ValueObserver.uno
@@ -76,7 +76,7 @@ namespace Fuse.Reactive
 
 	class ValueForwarder: ValueObserver
 	{
-		public interface IValueListener { void NewValue(object value); }
+		internal interface IValueListener { void NewValue(object value); }
 
 		IValueListener _listener;
 		public ValueForwarder(IObservable obs, IValueListener listener)


### PR DESCRIPTION
The docs generator tried to create links to this interface because it is
implemented by some public classes (like `With`, although they are
explicitly implemented). I guess this should be considered a bug in the
docs generator, but if this is an OK change anyway, its an easier fix
for now.