### PR TITLE
appveyor: drop bogus Source-argument

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
   - ps: Expand-Archive mesa.zip mesa
 
 build_script:
-  - Stuff\uno --trace doctor Source
+  - Stuff\uno --trace doctor
 
 before_test:
   - ps: |


### PR DESCRIPTION
This argument is bogus, and leads to a couple of warnings like this:

> WARNING: Package 'Source' was not found

So let's drop it. We're not using this arument on Travis CI either.
