### PR TITLE
Fix: Marshal.TryConvertTo would throw exception instead of fail gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 ## ImageTools
 - Added supported for encoding/decoding images to/from base64 on DotNet platforms, including Windows and Mac OS X.
+## Bugfixes
+- Fixes a bug where the app would crash if a databinding resolved to an incompatible type (e.g. binding a number property to a boolean value). (Marshal.TryConvertTo would throw exception instead of fail gracefully).
 
 ## 1.0
 

--- a/Source/Fuse.Marshal/Marshal.Convert.uno
+++ b/Source/Fuse.Marshal/Marshal.Convert.uno
@@ -18,6 +18,17 @@ namespace Fuse
 			_converters.Add(conv);
 		}
 
+		/** Attempts to convert the given object to the given type. 
+
+			The conversion is performed using optimistic and relaxed conversion rules.
+
+			This method will not throw exceptions if conversion fails, but instead return false. Returns true if conversion succeededs.
+
+			@param t The type to convert to
+			@param o The object to attempt to convert to type `t`.
+			@param res A reference to the variable that will receive the converted value.
+			@param diagnosticSource If not null, a diagnostic UserError will be reported if conversion fails, with this object as the source.
+		*/
 		public static bool TryConvertTo(Type t, object o, out object res, object diagnosticSource = null)
 		{
 			if (o == null) 
@@ -26,29 +37,36 @@ namespace Fuse
 				return true;
 			}
 
-			if (t == typeof(double)) { res = ToDouble(o); return true; }
-			else if (t == typeof(string)) { res = o.ToString(); return true; }
-			else if (t == typeof(Selector)) { res = (Selector)o.ToString(); return true; }
-			else if (t == typeof(float)) { res = ToFloat(o); return true; }
-			else if (t == typeof(int)) { res = ToInt(o); return true; }
-			else if (t == typeof(bool)) { res = ToBool(o); return true; }
-			else if (t == typeof(Size)) { res = ToSize(o); return true; }
-			else if (t == typeof(Size2)) { res = ToSize2(o); return true; }
-			else if (t == typeof(float2)) { res = ToFloat2(o); return true; }
-			else if (t == typeof(float3)) { res = ToFloat3(o); return true; }
-			else if (t == typeof(float4)) { res = ToFloat4(o); return true; }
-			else if (t.IsEnum && o is string) { res = Uno.Enum.Parse(t, (string)o); return true; }
-			else
+			try
 			{
-				for (int i = 0; i < _converters.Count; i++)
+				if (t == typeof(double)) { res = ToDouble(o); return true; }
+				else if (t == typeof(string)) { res = o.ToString(); return true; }
+				else if (t == typeof(Selector)) { res = (Selector)o.ToString(); return true; }
+				else if (t == typeof(float)) { res = ToFloat(o); return true; }
+				else if (t == typeof(int)) { res = ToInt(o); return true; }
+				else if (t == typeof(bool)) { res = ToBool(o); return true; }
+				else if (t == typeof(Size)) { res = ToSize(o); return true; }
+				else if (t == typeof(Size2)) { res = ToSize2(o); return true; }
+				else if (t == typeof(float2)) { res = ToFloat2(o); return true; }
+				else if (t == typeof(float3)) { res = ToFloat3(o); return true; }
+				else if (t == typeof(float4)) { res = ToFloat4(o); return true; }
+				else if (t.IsEnum && o is string) { res = Uno.Enum.Parse(t, (string)o); return true; }
+				else
 				{
-					var c = _converters[i].TryConvert(t, o);
-					if (c != null) 
+					for (int i = 0; i < _converters.Count; i++)
 					{
-						res = c;
-						return true;
+						var c = _converters[i].TryConvert(t, o);
+						if (c != null) 
+						{
+							res = c;
+							return true;
+						}
 					}
 				}
+			}
+			catch (Exception e)
+			{
+				// Do nothing, report diagnostic below if it fails
 			}
 
 			if (diagnosticSource != null)

--- a/Source/Fuse.Marshal/Tests/Fuse.Marshal.Test.unoproj
+++ b/Source/Fuse.Marshal/Tests/Fuse.Marshal.Test.unoproj
@@ -1,6 +1,7 @@
 {
   "Packages": [
     "Fuse.Marshal",
+    "Fuse.Common",
     "Uno.Collections",
     "UnoCore",
     "Uno.Testing",


### PR DESCRIPTION
This fixes and adds tests for cases where Marshal.TryConvertTo would throw exception instead of returning false as expected when an object is attempted converted to an incompatible type.

This caused a crashbug in the FuseCloud app