### PR TITLE
Revert android update caret position feature

### DIFF
--- a/Source/Fuse.Controls.Native/Android/TextEdit.uno
+++ b/Source/Fuse.Controls.Native/Android/TextEdit.uno
@@ -1,12 +1,12 @@
+
 using Uno;
 using Uno.Compiler.ExportTargetInterop;
-using Fuse.Input;
 
 namespace Fuse.Controls.Native.Android
 {
 	extern(Android) public class TextEdit : TextInput
 	{
-		public TextEdit(ITextEditHost host, Visual visual, bool isMultiline) : base(host, visual, isMultiline)
+		public TextEdit(ITextEditHost host, bool isMultiline) : base(host, isMultiline)
 		{
 			MakeItPlain(Handle);
 		}
@@ -27,18 +27,14 @@ namespace Fuse.Controls.Native.Android
 	extern(Android) public class TextInput : TextView, ITextEdit
 	{
 		ITextEditHost _host;
-		Visual _visual;
 
-		public TextInput(ITextEditHost host, Visual visual, bool isMultiline) : base(Create())
+		public TextInput(ITextEditHost host, bool isMultiline) : base(Create())
 		{
 			_host = host;
-			_visual = visual;
 			IsMultiline = isMultiline;
 			AddEditorActionListener(Handle);
 			_focusEvent = FocusChangedListener.AddHandler(Handle, OnNativeFocusChanged);
 			AddTextChangedListener(Handle);
-
-			Pointer.AddHandlers(_visual, OnPointerPressed, OnPointerMoved, OnPointerReleased);
 		}
 
 		void OnNativeFocusChanged(Java.Object view, bool hasFocus)
@@ -68,63 +64,15 @@ namespace Fuse.Controls.Native.Android
 
 		public override void Dispose()
 		{
-			Pointer.RemoveHandlers(_visual, OnPointerPressed, OnPointerMoved, OnPointerReleased);
-			_visual = null;
 			_host = null;
 			_focusEvent.Dispose();
 			_focusEvent = null;
 			base.Dispose();
 		}
 
-		int _inputFrame = -1;
-		float2 _pointerPosition = float2(0.0f);
-		/* This code is reconstructing the case where the pointer input would cause,
-		 * our textinput being focused. Due to lack of information in the Focus event,
-		 * what I really want is to get some metadata on the FocusedArgs telling me
-		 * how the TextEdit was focused (for example by providing the PointerEventArgs).
-		 *
-		 * Dont forget to deal with this :)
-		 */
-		void UpdatePointer(PointerEventArgs args)
-		{
-			if (args.IsPrimary)
-			{
-				_pointerPosition = args.WindowPoint;
-				_inputFrame = UpdateManager.FrameIndex;
-			}
-		}
-
-		/* I am feeling so bad for having to do stuff like this, but android's TextView
-		 * is so full of state that looks out of sync with itself until the View has been
-		 * onscreen... yuck!
-		 */
-		bool _warmedUp = false;
-		void UpdateCaretPosition()
-		{
-			if (_inputFrame == UpdateManager.FrameIndex)
-			{
-				if (!_warmedUp)
-				{
-					_warmedUp = true;
-					return;
-				}
-				var p = _visual.WindowToLocal(_pointerPosition) * _visual.Viewport.PixelsPerPoint;
-				var offset = GetOffsetForPosition(Handle, p.X, p.Y);
-				if (offset != -1)
-					SetCaretPosition(Handle, offset);
-			}
-		}
-
-		void OnPointerPressed(object sender, PointerPressedArgs args) { UpdatePointer(args); }
-
-		void OnPointerMoved(object sender, PointerMovedArgs args) { UpdatePointer(args); }
-
-		void OnPointerReleased(object sender, PointerReleasedArgs args) { UpdatePointer(args); }
-
 		void ITextEdit.FocusGained()
 		{
 			RequestFocus(Handle);
-			UpdateCaretPosition();
 		}
 
 		void ITextEdit.FocusLost()
@@ -329,12 +277,6 @@ namespace Fuse.Controls.Native.Android
 		}
 
 		[Foreign(Language.Java)]
-		static void SetCaretPosition(Java.Object handle, int offset)
-		@{
-			((android.widget.EditText)handle).setSelection(offset);
-		@}
-
-		[Foreign(Language.Java)]
 		static void SetPlaceholderColor(Java.Object handle, int value)
 		@{
 			((android.widget.TextView)handle).setHintTextColor(value);
@@ -344,12 +286,6 @@ namespace Fuse.Controls.Native.Android
 		static void SetPlaceholderText(Java.Object handle, string value)
 		@{
 			((android.widget.TextView)handle).setHint(value);
-		@}
-
-		[Foreign(Language.Java)]
-		static int GetOffsetForPosition(Java.Object handle, float x, float y)
-		@{
-			return ((android.widget.TextView)handle).getOffsetForPosition(x, y);
 		@}
 
 		int ReturnKeyType

--- a/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
@@ -184,7 +184,7 @@ namespace Fuse.Controls
 			extern(Android)
 			public override object New()
 			{
-				return new Fuse.Controls.Native.Android.TextEdit(_parent, _parent, _parent._isMultiline);
+				return new Fuse.Controls.Native.Android.TextEdit(_parent, _parent._isMultiline);
 			}
 
 			extern(!Android)

--- a/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
@@ -258,10 +258,12 @@ namespace Fuse.Controls
 		static readonly TextEditRenderer Instance = new TextEditRenderer();
 
 		ViewHandle _renderView;
+		ViewHandle _container;
 
 		TextEditRenderer()
 		{
 			_renderView = new ViewHandle(CreateTextEdit());
+			_container = new ViewHandle(CreateContainer());
 		}
 
 		void Draw(
@@ -272,25 +274,39 @@ namespace Fuse.Controls
 			float2 size,
 			float density)
 		{
-			CopyState(viewHandle.NativeHandle, _renderView.NativeHandle);
+			CopyState(_container.NativeHandle, viewHandle.NativeHandle, _renderView.NativeHandle);
 			renderer.Draw(_renderView, localToClipTransform, position, size, density);
 		}
 
 		[Foreign(Language.Java)]
-		static void CopyState(Java.Object sourceHandle, Java.Object targetHandle)
+		static void CopyState(Java.Object container, Java.Object sourceHandle, Java.Object targetHandle)
 		@{
+			android.widget.GridLayout gridLayout = (android.widget.GridLayout)container;
 			android.widget.TextView source = (android.widget.TextView)sourceHandle;
 			android.widget.TextView target = (android.widget.TextView)targetHandle;
+
+			if (target.getParent() == gridLayout)
+			{
+				gridLayout.removeView(target);
+			}
 
 			java.lang.String text = source.getText().toString();
 			java.lang.CharSequence hint = text.length() == 0 ? source.getHint() : "";
 			target.setText(text);
 			target.setHint(hint);
-			target.setBackgroundResource(0);
 			target.setTextColor(source.getCurrentTextColor());
 			target.setHintTextColor(source.getCurrentHintTextColor());
+			target.setImeOptions(source.getImeOptions());
 			target.setIncludeFontPadding(source.getIncludeFontPadding());
 			target.setTransformationMethod(source.getTransformationMethod());
+
+			// Setting the inputtype causes bugs when rendering RTL text,
+			// it triggers the same symptoms as the TextAlignment bug below.
+			// Assuming not copying this state is safe since it does not affect
+			// the rendering. No idea why this happens...
+
+			// target.setInputType(source.getInputType());
+
 			target.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, source.getTextSize());
 			target.setTypeface(source.getTypeface());
 			target.setLineSpacing(source.getLineSpacingExtra(), source.getLineSpacingMultiplier());
@@ -299,13 +315,32 @@ namespace Fuse.Controls
 				source.getPaddingTop(),
 				source.getPaddingRight(),
 				source.getPaddingBottom());
+			target.setTextScaleX(source.getTextScaleX());
 
-			if (android.os.Build.VERSION.SDK_INT >= 17)
-				target.setTextAlignment(source.getTextAlignment());
-
-			target.setGravity(source.getGravity());
-			target.setHorizontallyScrolling(source.getScrollX() > 0);
-			target.setScrollX(source.getScrollX());
+			/*
+				Nasty workaround to avoid Android rendering bug when textalignment is set to center,
+				doing it the normal way makes all the characters render on top of eachother...
+			*/
+			android.widget.GridLayout.LayoutParams lp = new android.widget.GridLayout.LayoutParams();
+			lp.rowSpec = android.widget.GridLayout.spec(0, android.widget.GridLayout.FILL);
+			int gravity = source.getGravity();
+			if ((gravity & android.view.Gravity.LEFT) == android.view.Gravity.LEFT)
+			{
+				lp.setGravity(android.view.Gravity.LEFT);
+				lp.columnSpec = android.widget.GridLayout.spec(0, android.widget.GridLayout.LEFT);
+			}
+			else if ((gravity & android.view.Gravity.RIGHT) == android.view.Gravity.RIGHT)
+			{
+				lp.setGravity(android.view.Gravity.RIGHT);
+				lp.columnSpec = android.widget.GridLayout.spec(0, android.widget.GridLayout.RIGHT);
+			}
+			else if ((gravity & android.view.Gravity.CENTER_HORIZONTAL) == android.view.Gravity.CENTER_HORIZONTAL)
+			{
+				lp.setGravity(android.view.Gravity.CENTER_HORIZONTAL);
+				lp.columnSpec = android.widget.GridLayout.spec(0, android.widget.GridLayout.CENTER);
+			}
+			target.setLayoutParams(lp);
+			gridLayout.addView(target);
 		@}
 
 		[Foreign(Language.Java)]
@@ -313,11 +348,18 @@ namespace Fuse.Controls
 		@{
 			android.widget.TextView tv = new android.widget.TextView(com.fuse.Activity.getRootActivity());
 			tv.setBackgroundResource(0);
-			tv.setLayoutParams(
-				new android.widget.FrameLayout.LayoutParams(
+			return tv;
+		@}
+
+		[Foreign(Language.Java)]
+		static Java.Object CreateContainer()
+		@{
+			android.widget.GridLayout gridLayout = new android.widget.GridLayout(com.fuse.Activity.getRootActivity());
+			gridLayout.setLayoutParams(
+				new android.widget.RelativeLayout.LayoutParams(
 					android.view.ViewGroup.LayoutParams.MATCH_PARENT,
 					android.view.ViewGroup.LayoutParams.MATCH_PARENT));
-			return tv;
+			return gridLayout;
 		@}
 
 	}


### PR DESCRIPTION
Revert the android implementation of https://github.com/fusetools/fuselibs-public/pull/14. As discussed in that PR this feature was sketchy on Android.

Resulting in regressions:
https://github.com/fusetools/ManualTestApp/issues/354
https://github.com/fusetools/ManualTestApp/issues/356

Reverting this feature since there are no easy fix for these issues 