### PR TITLE
Implemented array lookup in UX expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## UX Expression improvements
+- UX expressions now support arbitrary array lookups, e.g. `{someArray[index+3]}`. The same syntax can also be used with string keys, e.g `{someObject[someKey]}`. The lookup is fully reactive - both the collection and the key/index can change.
+
 ## Native
 - Added feature toggle for implicit `GraphicsView`. If you are making an app using only Native UI disabling the implicit `GraphicsView` can increase performance. Disable the `GraphicsView` by defining `DISABLE_IMPLICIT_GRAPHICSVIEW` when building. For example `uno build -t=ios -DDISABLE_IMPLICIT_GRAPHICSVIEW`
 

--- a/Source/Fuse.Reactive.Expressions/LookUp.uno
+++ b/Source/Fuse.Reactive.Expressions/LookUp.uno
@@ -1,0 +1,213 @@
+using Uno;
+using Uno.UX;
+using Uno.Collections;
+
+namespace Fuse.Reactive
+{
+	/** Represents a reactive object-index look-up operation, with a computed index.
+		
+		Index can be either a number (for IArray lookups) or a string (for IObject lookups).
+	 */
+	public sealed class LookUp: Expression
+	{
+		public Expression Collection { get; private set; }
+		public Expression Index { get; private set; }
+
+		[UXConstructor]
+		public LookUp([UXParameter("Collection")] Expression collection, [UXParameter("Index")] Expression index)
+		{
+			Collection = collection;
+			Index = index;
+		}
+
+		public override IDisposable Subscribe(IContext context, IListener listener)
+		{
+			return new LookUpSubscription(this, context, listener);
+		}
+
+		sealed class LookUpSubscription: IDisposable, IObserver, IListener, ValueForwarder.IValueListener
+		{
+			IListener _listener;
+			LookUp _lu;
+
+			IDisposable _colSub;
+			IDisposable _indexSub;
+
+			public LookUpSubscription(LookUp lu, IContext context, IListener listener)
+			{
+				_listener = listener;
+				_lu = lu;
+				_colSub = _lu.Index.Subscribe(context, this);
+				_indexSub = _lu.Collection.Subscribe(context, this);
+			}
+
+			bool _hasCollection;
+			object _collection;
+			bool _hasIndex;
+			object _index;
+
+			public void OnNewData(IExpression source, object value)
+			{
+				if (_lu == null) return;
+				if (source == _lu.Index) NewIndex(value);
+				if (source == _lu.Collection) NewCollection(value);
+			}
+
+			IDisposable _indexForwarder;
+			void NewIndex(object ind)
+			{
+				DisposeIndexSub();
+
+				var obs = ind as IObservable;
+				if (obs != null)
+				{
+					_indexForwarder = new ValueForwarder(obs, this);
+				}
+				else
+				{
+					_index = ind;
+					_hasIndex = true;
+					ResultChanged();
+				}
+			}
+
+			IDisposable _diag;
+
+			public void SetDiagnostic(string message, IExpression source)
+			{
+				ClearDiagnostic();
+				_diag = Diagnostics.ReportTemporalUserWarning(message, source);
+			}
+
+			public void ClearDiagnostic()
+			{
+				if (_diag != null)
+				{
+					_diag.Dispose();
+					_diag = null;
+				}
+			}
+
+			void ValueForwarder.IValueListener.NewValue(object value)
+			{
+				_index = value;
+				_hasIndex = true;
+				ResultChanged();
+			}
+
+			void DisposeIndexSub()
+			{
+				if (_indexForwarder != null)
+				{
+					_indexForwarder.Dispose();
+					_indexForwarder = null;
+				}
+			}
+
+			IDisposable _colObservableSub;
+			void NewCollection(object col)
+			{
+				_collection = col;
+				_hasCollection = true;
+
+				DisposeCollectionObservableSub();
+
+				var obs = col as IObservable;
+				if (obs != null) 
+					_colObservableSub = obs.Subscribe(this);
+
+				ResultChanged();
+			}
+
+			void DisposeCollectionObservableSub()
+			{
+				if (_colObservableSub != null)
+				{
+					_colObservableSub.Dispose();
+					_colObservableSub = null;
+				}
+			}
+
+			void ResultChanged()
+			{
+				if (_listener == null) return;
+				ClearDiagnostic();
+
+				if (!_hasIndex) return;
+				if (!_hasCollection) return;
+				if (_index == null || _collection == null) PushNewData(null);
+
+				var arr = _collection as IArray;
+				if (arr != null)
+				{
+					int index = 0;
+					try
+					{
+						index = Marshal.ToInt(_index);
+					}
+					catch (MarshalException me)
+					{
+						SetDiagnostic("Index must be a number: " + me.Message, _lu.Index);
+						return;
+					}
+
+					if (index >= 0 && index < arr.Length)
+					{
+						PushNewData(arr[index]);
+					}
+					else
+					{
+						SetDiagnostic("Index was outside the bounds of the array", _lu.Index);
+					}
+					return;
+				}
+
+				var obj = _collection as IObject;
+				if (obj != null)
+				{
+					var key = _index.ToString();
+					if (obj.ContainsKey(key))
+					{
+						PushNewData(obj[key]);
+					}
+					else
+					{
+						SetDiagnostic("Object does not contain the given key '" + key + "'", _lu.Index);
+					}
+					return;
+				}
+
+				SetDiagnostic("Unsupported collection type: " + _collection, _lu.Collection);
+			}
+
+			void PushNewData(object value)
+			{
+				_listener.OnNewData(_lu, value);
+			}
+
+			public void Dispose()
+			{
+				ClearDiagnostic();
+				DisposeCollectionObservableSub();
+				DisposeIndexSub();
+				_colSub.Dispose();
+				_indexSub.Dispose();
+				_colSub = null;
+				_indexSub = null;
+				_collection = null;
+				_listener = null;
+				_index = null;
+				_lu = null;
+			}
+
+			void IObserver.OnClear(){ ResultChanged(); }
+			void IObserver.OnSet(object newValue){ ResultChanged(); }
+			void IObserver.OnAdd(object addedValue){ ResultChanged(); }
+			void IObserver.OnNewAt(int index, object value){ ResultChanged(); }
+			void IObserver.OnFailed(string message){ ResultChanged(); }
+			void IObserver.OnNewAll(IArray values){ ResultChanged(); }
+			void IObserver.OnRemoveAt(int index){ ResultChanged(); }
+			void IObserver.OnInsertAt(int index, object value){ ResultChanged(); }		
+		}
+	}
+}

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/Expressions.ArrayLookup.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/Expressions.ArrayLookup.ux
@@ -1,0 +1,24 @@
+<Panel ux:Class="UX.ArrayLookup">
+	<JavaScript>
+		var Observable = require("FuseJS/Observable");
+		var obs = Observable("foo", "bar", "moo");
+		var arr = ["FOO", "BAR", "MOO"];
+
+		var obj = Observable( { col: { foo: "THIS IS FOO", bar: "THIS IS BAR" } });
+		var bar = Observable("bar");
+
+		var index = Observable(0);
+
+		function inc() { index.value = index.value+1; }
+		function dec() { index.value = index.value-1; }
+		function changeObj() { obj.value = { col : { foo: "FOO HAS CHANGED", bar : "BAR HAS CHANGED" }}}
+
+		module.exports = { obs, arr, index, inc, dec, obj, bar, changeObj };
+	</JavaScript>
+	<Text ux:Name="t1" Value="Hello {obs[index/2]} : {arr[(index+1)/2]}!" />
+	<Text ux:Name="t2" Value="{obj.col['foo']}" />
+	<Text ux:Name="t3" Value="{obj.col[bar]}" />
+	<FuseTest.Invoke Handler="{inc}" ux:Name="CallInc"/>
+	<FuseTest.Invoke Handler="{dec}" ux:Name="CallDec"/>
+	<FuseTest.Invoke Handler="{changeObj}" ux:Name="CallChangeObj"/>
+</Panel>

--- a/Source/Fuse.Reactive.JavaScript/Tests/UXExpressionsTest.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UXExpressionsTest.uno
@@ -38,6 +38,89 @@ namespace Fuse.Reactive.Test
 		}
 
 		[Test]
+		public void ArrayLookup()
+		{
+			var e = new UX.ArrayLookup();
+			var root = TestRootPanel.CreateWithChild(e);
+
+			root.StepFrameJS();
+			root.StepFrameJS();
+
+			Assert.AreEqual("THIS IS FOO", e.t2.Value);
+			Assert.AreEqual("THIS IS BAR", e.t3.Value);
+
+			e.CallChangeObj.Perform();
+			root.StepFrameJS();
+
+			Assert.AreEqual("FOO HAS CHANGED", e.t2.Value);
+			Assert.AreEqual("BAR HAS CHANGED", e.t3.Value);
+
+			Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
+
+			e.CallInc.Perform();
+			root.StepFrameJS();
+			root.StepFrameJS();
+
+			Assert.AreEqual("Hello foo : BAR!", e.t1.Value);
+
+			e.CallInc.Perform();
+			root.StepFrameJS();
+
+			Assert.AreEqual("Hello bar : BAR!", e.t1.Value);
+
+			e.CallDec.Perform();
+			root.StepFrameJS();
+
+			Assert.AreEqual("Hello foo : BAR!", e.t1.Value);
+
+			e.CallDec.Perform();
+			root.StepFrameJS();
+
+			Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
+
+			e.CallDec.Perform(); // index = -1 now, but that's fine since its /2 so = 0
+			root.StepFrameJS();
+
+			Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
+
+			if defined (FUSELIBS_NO_TOASTS)
+			{
+				Diagnostics.DiagnosticReported += OnDiagnosticReported;
+				Diagnostics.DiagnosticDismissed += OnDiagnosticDismissed;
+
+				Assert.AreEqual(0, _currentDiagnostics.Count);
+
+				e.CallDec.Perform(); // index = -2 now, so that's = -1 and should give errro
+				root.StepFrameJS();
+
+				Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
+
+				Assert.AreEqual(1, _currentDiagnostics.Count);
+				Assert.IsTrue(_currentDiagnostics[0].Message.Contains("Index was outside the bounds of the array"));
+
+				e.CallInc.Perform();
+				root.StepFrameJS();
+
+				Assert.AreEqual(0, _currentDiagnostics.Count);
+
+				Diagnostics.DiagnosticReported -= OnDiagnosticReported;
+				Diagnostics.DiagnosticDismissed -= OnDiagnosticDismissed;
+			}
+		}
+
+		List<Diagnostic> _currentDiagnostics = new List<Diagnostic>();
+
+		void OnDiagnosticReported(Diagnostic d)
+		{
+			_currentDiagnostics.Add(d);
+		}
+
+		void OnDiagnosticDismissed(Diagnostic d)
+		{
+			_currentDiagnostics.Remove(d);
+		}
+
+		[Test]
 		public void StringAttribute()
 		{
 			var e = new UX.Expressions2();


### PR DESCRIPTION
UX expressions now support arbitrary array lookups, e.g. `{someArray[index+3]}`. The same syntax can also be used with string keys, e.g `{someObject[someKey]}`. The lookup is fully reactive - both the collection and the key/index can change.


This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
