### PR TITLE
Handle iOS status bar changes properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 ## MemoryPolicy
 - Added `QuickUnload` memory policy to keep data in memory for as short as possible.
 
+## iOS
+- Fixed an issue where the statusbar would incorrectly push the app down without triggering a resize.
+
 ## 1.0
 
 ## Instance/Each/Deferred

--- a/Source/Fuse.Controls.Panels/Backgrounds/TopFrameBackground.uno
+++ b/Source/Fuse.Controls.Panels/Backgrounds/TopFrameBackground.uno
@@ -49,7 +49,13 @@ namespace Fuse.Controls
 
 		protected override float2 GetContentSize(LayoutParams lp)
 		{
-			if defined(iOS || Android)
+			if defined(iOS) {
+				// on iOS, we always treat the bar as though it's 40 points
+				var height = 40 / AppBase.Current.PixelsPerPoint;
+				var x = SystemUI.TopFrame.Size.X / AppBase.Current.PixelsPerPoint;
+				return float2(x, height);
+			}
+			else if defined(Android)
 			{
 				var x = SystemUI.TopFrame.Size / AppBase.Current.PixelsPerPoint;
 				return x;

--- a/Source/Fuse.Platform/iOS/AppDelegateStatusBar.mm
+++ b/Source/Fuse.Platform/iOS/AppDelegateStatusBar.mm
@@ -12,7 +12,7 @@
 
 // On iOS 8 this is only called when Status Bar changes in response to external
 // events
-- (void)application:(UIApplication *)application willChangeStatusBarFrame:(CGRect)frame
+- (void)application:(UIApplication *)application didChangeStatusBarFrame:(CGRect)frame
 {
 	uAutoReleasePool pool;
 	@{Fuse.Platform.SystemUI._statusBarWillChangeFrame(Uno.Platform.iOS.uCGRect, double):Call(frame, 0)};

--- a/Source/Fuse.Platform/iOS/SystemUI.uno
+++ b/Source/Fuse.Platform/iOS/SystemUI.uno
@@ -184,6 +184,7 @@ namespace Fuse.Platform
 				density);
 		}
 
+		static private float _modifier = 0;
 		static void _statusBarWillChangeFrame(Uno.Platform.iOS.uCGRect _endFrame, double animationDuration)
 		{
 			if (Lifecycle.State == ApplicationState.Uninitialized)
@@ -210,6 +211,23 @@ namespace Fuse.Platform
 				reason = Fuse.Platform.SystemUIResizeReason.WillChangeFrame;
 
 			var args = new SystemUIWillResizeEventArgs(SystemUIID.TopFrame, reason, endFrame, startFrame, animationDuration, 1);
+
+			Rect newFrameRect;
+			// when the endFrame size is > 40, we are streching to fill the space
+			if (endFrame.Size.Y > 40) 
+			{
+				newFrameRect = new Rect(float2(Frame.Left, Frame.Top), float2(Frame.Size.X, Frame.Size.Y - _modifier));
+			} 
+			else 
+			{
+				_modifier = -40;
+				newFrameRect = new Rect(float2(Frame.Left, Frame.Top), float2(Frame.Size.X, Frame.Size.Y + _modifier));
+			}
+
+			Frame = newFrameRect;
+			var frameHandler = FrameChanged;
+			if (frameHandler != null)
+				frameHandler(null, EventArgs.Empty);
 
 			OnWillResize(args);
 		}

--- a/Source/Fuse.iOS/AppRoot.uno
+++ b/Source/Fuse.iOS/AppRoot.uno
@@ -31,7 +31,7 @@ namespace Fuse
 			[[root layer] setAnchorPoint: { 0.0f, 0.0f }];
 			@{Fuse.Platform.SystemUI.RootView:Set(root)};
 			[root sizeToFit];
-			root.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+			root.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
 			return root;
 		@}
 

--- a/Tests/ManualTests/ManualTestingApp/MainView.ux
+++ b/Tests/ManualTests/ManualTestingApp/MainView.ux
@@ -97,6 +97,7 @@
 
 			<DeviceInfo ux:Name="FirstPage"/>
 			<ScrollViewPage/>
+			<StatusBar/>
 			<MoveAndScale/>
 			<HttpXmlView/>
 			<HttpsView/>

--- a/Tests/ManualTests/ManualTestingApp/Singles/StatusBar.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/StatusBar.ux
@@ -1,5 +1,7 @@
 <Page Title="Status bar" ux:Class="StatusBar">
-
+	<InfoStack ux:Key="Info">
+		<p>This page is intended to test the status bar handling when a phone call is recieved with the app open.</p>
+	</InfoStack>
 	<StackPanel Margin="10">
 		<Panel>
 			<Text Margin="5"> Recieve a call

--- a/Tests/ManualTests/ManualTestingApp/Singles/StatusBar.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/StatusBar.ux
@@ -1,0 +1,27 @@
+<Page Title="Status bar" ux:Class="StatusBar">
+
+	<StackPanel Margin="10">
+		<Panel>
+			<Text Margin="5"> Recieve a call
+				A green bar should show up
+				All content should fit on the page 
+			</Text>
+		</Panel>
+		
+		<Panel>
+			<Text Margin="5"> Leave the app and come back while still in the call
+				The green bar should still be there 
+				All content should fit on the page 
+			</Text>
+		</Panel>
+
+		<Panel>
+			<Text Margin="5">End the call
+				The green bar should be gone
+				All content should fit on the page
+			</Text>
+		</Panel>
+	</StackPanel>
+	
+	<FpsMeter/>
+</Page>


### PR DESCRIPTION
This fixes an issue where the "in call" statusbar would not correctly resize the window. It only resolves the issue if the user uses a `ClientPanel` - normal panels or raw elements do not scale accordingly, as they lack the TopFrame handlers.

## Test

There are two cases for testing, both only apply to iOS apps that have `ClientPanel`

- Start an application with a `ClientPanel` without being in-call
- toggle in-call on and off

- Start an application with `ClientPanel` with being in-call
- toggle in-call on and off



This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
