### PR TITLE
README: add section on how to integrate with fuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ the UI framework used in [Fuse](https://www.fusetools.com/) apps.
 * `build.sh` runs stuff (which downloads uno if needed), and builds all packages.
 * `test.sh` runs all tests.
 
+
+### Fuse
+
+If you want to use a self-built fuselibs installation with an installed
+Fuse, you can do this through a `.unoconfig`-file, something like this:
+
+```
+Packages.SourcePaths += <path-to-fuselibs>/Source
+```
+
+You'll need to replace `<path-to-fuselibs>` above with the actual path to
+your fuselibs checkout.
+
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ the UI framework used in [Fuse](https://www.fusetools.com/) apps.
 
 ### Fuse
 
-If you want to use a self-built fuselibs installation with an installed
-Fuse, you can do this through a `.unoconfig`-file, something like this:
+You may use a locally built copy of fuselibs with an installed copy of
+Fuse. This is done by creating a file named `.unoconfig` in either a Fuse
+project directory (applies to that project only), or in your home
+directory (applies to all projects). It should contain something like the
+following:
 
 ```
 Packages.SourcePaths += <path-to-fuselibs>/Source


### PR DESCRIPTION
This adds a short section about how to configure fuse/uno to always pick up the checked-out fuselibs.

I'm not in love with this, but we need this information in some form. Some feedback would be greatly appreciated.

One of the big lacks, is that this doesn't really mention where to put the unoconfig-file, might be confusing to people who aren't used to dealing with unoconfig-files (which is probably most users). But I don't really know what the best advice would be.

We used to have something like this at the root of the repo, which made things work when using `Stuff/uno` from inside the fuselibs-repo. But that was removed by @mortend when the package-manager was introduced. We could consider adding it back...