### PR TITLE
Fuse.Elements: restore state when CompositEffects fail

### DIFF
--- a/Source/Fuse.Elements/Caching/Cache.uno
+++ b/Source/Fuse.Elements/Caching/Cache.uno
@@ -177,15 +177,20 @@ namespace Fuse.Elements
 
 			// Push
 			dc.PushRenderTargetFrustum(tile._framebuffer.Framebuffer, cc);
-			dc.Clear(float4(0), 1);
 
-			// Render
-			_element.CompositEffects(dc);
+			try
+			{
+				dc.Clear(float4(0), 1);
 
-			// Pop
-			dc.PopRenderTargetFrustum();
-
-			dc.IsCaching = oldIsCaching;
+				// Render
+				_element.CompositEffects(dc);
+			}
+			finally
+			{
+				// Pop
+				dc.PopRenderTargetFrustum();
+				dc.IsCaching = oldIsCaching;
+			}
 		}
 
 		static CacheHelper cacheHelper = new CacheHelper();


### PR DESCRIPTION
A small detail from the stack-trace in fusetools/fuselibs#4211 is
that we seem to fail extra badly here, because of exception-unsafe
code.

Let's fix that part, as we can easily use try-finally for this.

There's no real changelog or docs needed here, as this just cleans
up the error-reporting when there's already something else gone
wrong; users shouldn't usually see this.