### PR TITLE
Fuse.Controls.Video: do not seek or pause live-streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Bug in Container
 - Fixed bug in Container which caused crash when the container had no subtree nodes. This caused the Fuse.MaterialDesign community package to stop working.
 
+## Fuse.Controls.Video
+- Fixed a bug where we would trigger errors on Android if a live-stream was seeked or paused.
+
+
 ## 1.0
 
 ## Fuse.Elements

--- a/Source/Fuse.Controls.Video/Android/VideoPlayer.uno
+++ b/Source/Fuse.Controls.Video/Android/VideoPlayer.uno
@@ -167,7 +167,11 @@ namespace Fuse.Controls.VideoImpl.Android
 		public double Position
 		{
 			get { return GetCurrentPosition(_handle) / 1000.0; }
-			set { SeekTo(_handle, (int)(value * 1000)); }
+			set
+			{
+				if (GetDuration(_handle) >= 0)
+					SeekTo(_handle, (int)(value * 1000));
+			}
 		}
 
 		public int RotationDegrees
@@ -409,7 +413,11 @@ namespace Fuse.Controls.VideoImpl.Android
 
 
 		public void Play() { Play(_handle); }
-		public void Pause() { Pause(_handle); }
+		public void Pause()
+		{
+			if (GetDuration(_handle) >= 0)
+				Pause(_handle);
+		}
 
 		[Foreign(Language.Java)]
 		static void Play(Java.Object handle)


### PR DESCRIPTION
Live-streams does not support seeking nor pausing, and Android will
get all mad at us and stuff if we try. Luckily, MediaPlayer.getDuration()
will report -1 for live-streams (and possibly other non-seekable nor
pausable video sources), so we can use that information to stay on
Android's good side.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
