### PR TITLE
Fuse.Controls.Video: fix video-size for HLS-streams on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ## Fuse.Controls.Video
 - Fixed a bug where we would trigger errors on Android if a live-stream was seeked or paused.
+- Fixed a bug where HLS streams would become zero-sized on iOS.
 
 
 ## 1.0


### PR DESCRIPTION
We currently fail hard on HLS-streams on iOS, where we get a video
size of zero instead of the actual size.

As a half-measure, let's wait for the first resize-event until we
report the video as loaded. This allows us to correctly render HLS
streams that never change the resolution, which is better than
nothing.

This PR contains:
- [x] Changelog
