### PR TITLE
GraphicsView: Let iOS decide when to call display

### DIFF
--- a/Source/Fuse.Controls.Native/iOS/GraphicsView.uno
+++ b/Source/Fuse.Controls.Native/iOS/GraphicsView.uno
@@ -108,7 +108,7 @@ namespace Fuse.Controls.Native.iOS
 		static void EndDraw(ObjC.Object handle)
 		@{
 			GLKView* glkView = (GLKView*)handle;
-			[glkView display];
+			[glkView setNeedsDisplay];
 		@}
 
 		public override void Dispose()


### PR DESCRIPTION
Calling display on a GLKView will make it immediately draw. Calling setNeedsDisplay will make iOS call display when it decied its the right time (typically when iOS redraws native UI). This also showed up during profiling, maybe this just results in the same time being spent somewhere else. Atleast this cooperates better with iOS