### PR TITLE
Experimental.TextureLoader: downsample large bitmaps

### DIFF
--- a/Source/Experimental.TextureLoader/TextureLoaderImpl.cpp.uxl
+++ b/Source/Experimental.TextureLoader/TextureLoaderImpl.cpp.uxl
@@ -18,12 +18,22 @@
                     uBase::Auto<uBase::BufferPtr> bp = new uBase::BufferPtr(U_BUFFER_PTR($0), U_BUFFER_SIZE($0), false);
                     uBase::Auto<uBase::BufferStream> bs = new uBase::BufferStream(bp, true, false);
                     uBase::Auto<uImage::ImageReader> ir = uImage::Jpeg::CreateReader(bs);
-                    uBase::Auto<uImage::Bitmap> bmp = ir->ReadBitmap();
+                    uBase::Auto<uImage ::Bitmap> bmp = ir->ReadBitmap();
+                    int originalWidth = bmp->GetWidth(), originalHeight = bmp->GetHeight();
+
+                    int maxTextureSize;
+                    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
+                    while (bmp->GetWidth() > maxTextureSize ||
+                           bmp->GetHeight() > maxTextureSize)
+                    {
+                        bmp = bmp->DownSample2x2();
+                    }
+
                     uBase::Auto<uImage::Texture> tex = uImage::Texture::Create(bmp);
                     uGLTextureInfo info;
                     GLuint handle = uCreateGLTexture(tex, false, &info);
 
-                    @{Experimental.TextureLoader.Callback.Execute(Uno.Graphics.Texture2D):Call($1, @{Uno.Graphics.Texture2D(OpenGL.GLTextureHandle,int2,int,Uno.Graphics.Format):New(handle, @{int2(int,int):New(info.Width, info.Height)}, info.MipCount, @{Uno.Graphics.Format.Unknown})})};
+                    @{Experimental.TextureLoader.Callback.Execute(Uno.Graphics.Texture2D):Call($1, @{Uno.Graphics.Texture2D(OpenGL.GLTextureHandle,int2,int,Uno.Graphics.Format):New(handle, @{int2(int,int):New(originalWidth, originalHeight)}, info.MipCount, @{Uno.Graphics.Format.Unknown})})};
                 }
                 catch (const uBase::Exception &e)
                 {
@@ -40,11 +50,21 @@
                     uBase::Auto<uBase::BufferStream> bs = new uBase::BufferStream(bp, true, false);
                     uBase::Auto<uImage::ImageReader> ir = uImage::Png::CreateReader(bs);
                     uBase::Auto<uImage::Bitmap> bmp = ir->ReadBitmap();
+                    int originalWidth = bmp->GetWidth(), originalHeight = bmp->GetHeight();
+
+                    int maxTextureSize;
+                    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
+                    while (bmp->GetWidth() > maxTextureSize ||
+                           bmp->GetHeight() > maxTextureSize)
+                    {
+                        bmp = bmp->DownSample2x2();
+                    }
+
                     uBase::Auto<uImage::Texture> tex = uImage::Texture::Create(bmp);
                     uGLTextureInfo info;
                     GLuint handle = uCreateGLTexture(tex, false, &info);
 
-                    @{Experimental.TextureLoader.Callback.Execute(Uno.Graphics.Texture2D):Call($1, @{Uno.Graphics.Texture2D(OpenGL.GLTextureHandle,int2,int,Uno.Graphics.Format):New(handle, @{int2(int,int):New(info.Width, info.Height)}, info.MipCount, @{Uno.Graphics.Format.Unknown})})};
+                    @{Experimental.TextureLoader.Callback.Execute(Uno.Graphics.Texture2D):Call($1, @{Uno.Graphics.Texture2D(OpenGL.GLTextureHandle,int2,int,Uno.Graphics.Format):New(handle, @{int2(int,int):New(originalWidth, originalHeight)}, info.MipCount, @{Uno.Graphics.Format.Unknown})})};
                 }
                 catch (const uBase::Exception &e)
                 {


### PR DESCRIPTION
Bitmaps that are larger than the maximum supported texture-size of
the GPU currently fails to load, producing an OpenGL error, and a
seemingly black texture.

To at least get something related to the image on-screen, let's
down-sample such images until they fit in a texture. We still lie
to the rest of the system about the texture-size later, so layout
etc will use the real size rather than the down-sampled size.

This is only implemented for C++-targets. That might be acceptable
for now, as all our mobile targets, which are the ones that are
likely to have low max-texture sizes. Modern desktop GPUs can do
16k x 16k textures, many mobile phones only support 4096 x 4096.

This is a forward-port from an identical change in the unolibs-repository.