### PR TITLE
Move IncreaseFrameIndex to prior to Update to make it consistent across platforms

### DIFF
--- a/Source/Fuse.Nodes/AppBase.uno
+++ b/Source/Fuse.Nodes/AppBase.uno
@@ -281,11 +281,12 @@ namespace Fuse
 			be overridden in user code. Use @UpdateManager instead. */
 		protected virtual void OnUpdate()
 		{
+			UpdateManager.IncreaseFrameIndex();
+
 			if defined(FUSELIBS_PROFILING)
 				Profiling.BeginUpdate();
 
 			UpdateManager.Update();
-			UpdateManager.IncreaseFrameIndex();
 
 			if defined(FUSELIBS_PROFILING)
 				Profiling.EndUpdate();


### PR DESCRIPTION
Because rendering happens independently of Update on desktop, desktop would get inconsistent FrameIndex where you would update with frame N, and render with frame N+1. This messes up cache heuristics etc. and causes slow and jittery rendering on desktop.
