### PR TITLE
ScrollingAnimation: Update animation if From or To changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added `reload` and `retry` JavaScript functions on `Image` to allow reloading failed images.
 - Fixed infinite recursion bug that could happen if a MemoryPolicy is set on a MultiDensityImageSource
 
+## ScrollingAnimation
+- Fixed issue where the animation could become out of sync if the properties on ScrollingAnimation were updated.
+
 ## macOS SIGILL problems
 - Updated the bundled Freetype library on macOS to now (again) include both 32-bit and 64-bit symbols, which fixes an issue where .NET and preview builds would crash with a SIGILL at startup when running on older Mac models.
 - Updated the bundled libjpeg, libpng, Freetype, and SDL2 libaries for macOS to not use AVX instructions, since they are incompatible with the CPUs in some older Mac models. This fixes an issue with SIGILLs in native builds.

--- a/Source/Fuse.Controls.ScrollView/Tests/ScrollingAnimation.Test.uno
+++ b/Source/Fuse.Controls.ScrollView/Tests/ScrollingAnimation.Test.uno
@@ -77,5 +77,30 @@ namespace Fuse.Controls.ScrollViewTest
 				Assert.AreEqual(0.25f,TriggerProgress(sv.S1));
 			}
 		}
+
+		/**
+			Ensure that the ScrollingAnimation's progress is updated if From or To
+			changes at runtime
+		*/
+		[Test]
+		public void ScrollingAnimationFromTo()
+		{
+			var sv = new UX.ScrollingAnimation.FromTo();
+			using (var root = TestRootPanel.CreateWithChild(sv, int2(100,50)))
+			{
+				Assert.AreEqual(0.0f, TriggerProgress(sv.S1));
+
+				sv.ScrollPosition = float2(0,200);
+				root.StepFrame(5);
+				Assert.AreEqual(1.0f, TriggerProgress(sv.S1));
+
+				sv.S1.From = 100.0f;
+				sv.S1.To = 300.0f;
+				Assert.AreEqual(0.5f, TriggerProgress(sv.S1));
+
+				sv.S1.From = 200.0f;
+				Assert.AreEqual(0.0f, TriggerProgress(sv.S1));
+			}
+		}
 	}
 }

--- a/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollingAnimation.FromTo.ux
+++ b/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollingAnimation.FromTo.ux
@@ -1,0 +1,5 @@
+<ScrollView ux:Class="UX.ScrollingAnimation.FromTo">
+	<Rectangle Height="2000" Y="0" ux:Name="TheRect"/>
+
+	<ScrollingAnimation ux:Name="S1" From="0" To="200" />
+</ScrollView>

--- a/Source/Fuse.Controls.ScrollView/Triggers/ScrollingAnimation.uno
+++ b/Source/Fuse.Controls.ScrollView/Triggers/ScrollingAnimation.uno
@@ -93,6 +93,9 @@ namespace Fuse.Triggers
 				_hasFrom = true;
 				if (!_hasRange)
 					_range = ScrollingAnimationRange.Explicit;
+
+				if (_scrollable != null)
+					BypassSeek(OffsetScrollProgress);
 			}
 		}
 
@@ -105,6 +108,9 @@ namespace Fuse.Triggers
 				_hasTo = true;
 				if (!_hasRange)
 					_range = ScrollingAnimationRange.Explicit;
+
+				if (_scrollable != null)
+					BypassSeek(OffsetScrollProgress);
 			}
 		}
 		


### PR DESCRIPTION
We have to update the animation state if From or To changes, if not the animation can get out of sync since it only updates when the scrollview is scrolls.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [x] Tests
