### PR TITLE
Reload failed images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Unreleased
 
+## Image
+- A failed to load Image with a Url will now try again when the Url is used again in a new Image
+- Added `reload` and `retry` JavaScript functions on `Image` to allow reloading failed images.
+
 ## macOS SIGILL problems
 - Updated the bundled Freetype library on macOS to now (again) include both 32-bit and 64-bit symbols, which fixes an issue where .NET and preview builds would crash with a SIGILL at startup when running on older Mac models.
 - Updated the bundled libjpeg, libpng, Freetype, and SDL2 libaries for macOS to not use AVX instructions, since they are incompatible with the CPUs in some older Mac models. This fixes an issue with SIGILLs in native builds.
-## Image
-- A failed to load Image with a Url will now try again when the Url is used again in a new Image
 
 ## Native
 - Added feature toggle for implicit `GraphicsView`. If you are making an app using only Native UI disabling the implicit `GraphicsView` can increase performance. Disable the `GraphicsView` by defining `DISABLE_IMPLICIT_GRAPHICSVIEW` when building. For example `uno build -t=ios -DDISABLE_IMPLICIT_GRAPHICSVIEW`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## macOS SIGILL problems
 - Updated the bundled Freetype library on macOS to now (again) include both 32-bit and 64-bit symbols, which fixes an issue where .NET and preview builds would crash with a SIGILL at startup when running on older Mac models.
 - Updated the bundled libjpeg, libpng, Freetype, and SDL2 libaries for macOS to not use AVX instructions, since they are incompatible with the CPUs in some older Mac models. This fixes an issue with SIGILLs in native builds.
+## Image
+- A failed to load Image with a Url will now try again when the Url is used again in a new Image
 
 ## Native
 - Added feature toggle for implicit `GraphicsView`. If you are making an app using only Native UI disabling the implicit `GraphicsView` can increase performance. Disable the `GraphicsView` by defining `DISABLE_IMPLICIT_GRAPHICSVIEW` when building. For example `uno build -t=ios -DDISABLE_IMPLICIT_GRAPHICSVIEW`

--- a/Source/Fuse.Common/Tests/FuseTest/TestImageSource.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestImageSource.uno
@@ -46,5 +46,12 @@ namespace FuseTest
 			_state = ImageSourceState.Failed;
 			OnError( message );
 		}
+
+		int _reloadCount;
+		public int ReloadCount { get { return _reloadCount; } }
+		public override void Reload()
+		{
+			_reloadCount++;
+		}
 	}
 }

--- a/Source/Fuse.Controls.Primitives/Image.ScriptClass.uno
+++ b/Source/Fuse.Controls.Primitives/Image.ScriptClass.uno
@@ -1,0 +1,53 @@
+using Uno;
+using Uno.UX;
+
+using Fuse.Scripting;
+
+namespace Fuse.Controls
+{
+	public partial class Image
+	{
+		static Image()
+		{
+			ScriptClass.Register(typeof(Image),
+				new ScriptMethod<Image>("reload", reload, ExecutionThread.MainThread),
+				new ScriptMethod<Image>("retry", retry, ExecutionThread.MainThread));
+		}
+		
+		/**
+			Reload the image source.
+			
+			@scriptmethod reload( )
+		*/
+		static void reload(Context c, Image img, object[] args)
+		{
+			if (args.Length != 0)
+			{
+				Fuse.Diagnostics.UserError( "reload takes no parameters", img );
+				return;
+			}
+
+			var src = img.Source;
+			if (src != null)
+				src.Reload();
+		}
+
+		/**
+			Reload the image source if it is in a failed state.
+			
+			@scriptmethod retry( )
+		*/
+		static void retry(Context c, Image img, object[] args)
+		{
+			if (args.Length != 0)
+			{
+				Fuse.Diagnostics.UserError( "retry takes no parameters", img );
+				return;
+			}
+
+			var src = img.Source;
+			if (src != null && src.State == Fuse.Resources.ImageSourceState.Failed)
+				src.Reload();
+		}
+	}
+}

--- a/Source/Fuse.Controls.Primitives/Tests/Image.Test.uno
+++ b/Source/Fuse.Controls.Primitives/Tests/Image.Test.uno
@@ -47,5 +47,31 @@ namespace Fuse.Controls.Primitives.Test
 				Assert.Contains("nope", diagnostics[0].Message);
 			}
 		}
+
+		[Test]
+		public void RetryReload()
+		{
+			var p = new UX.Image.RetryReload();
+			using (var dg = new RecordDiagnosticGuard())
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				p.src.Fail( "Not there" );
+
+				p.CallRetry.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual(1, p.src.ReloadCount);
+
+				p.src.MarkReady();
+				p.CallRetry.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual(1, p.src.ReloadCount);
+
+				p.CallReload.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual(2, p.src.ReloadCount);
+
+				var d = dg.DequeueAll();
+			}
+		}
 	}
 }

--- a/Source/Fuse.Controls.Primitives/Tests/UX/Image.RetryReload.ux
+++ b/Source/Fuse.Controls.Primitives/Tests/UX/Image.RetryReload.ux
@@ -1,0 +1,17 @@
+<Panel ux:Class="UX.Image.RetryReload">
+	<JavaScript>
+		exports.reload = function() { 
+			image.reload()
+		}
+
+		exports.retry = function() {
+			image.retry()
+		}
+	</JavaScript>
+
+	<Image ux:Name="image">
+		<FuseTest.TestImageSource ux:Name="src"/>
+	</Image>
+	<FuseTest.Invoke Handler="{reload}" ux:Name="CallReload"/>
+	<FuseTest.Invoke Handler="{retry}" ux:Name="CallRetry"/>
+</Panel>

--- a/Source/Fuse.Elements/Resources/HttpImageSource.uno
+++ b/Source/Fuse.Elements/Resources/HttpImageSource.uno
@@ -77,7 +77,11 @@ namespace Fuse.Resources
 			{
 				HttpImageSourceImpl his;
 				if( value.TryGetTarget( out his ) )
+				{
+					if (his.State == ImageSourceState.Failed)
+						his.Reload();
 					return his;
+				}
 				_cache.Remove( url );
 			}
 


### PR DESCRIPTION
Fixes https://github.com/fusetools/fuselibs/issues/4227
Adds Image.reload/retry functions

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests - except 4227 as there is no easy way to test that in an automated fashion
