### PR TITLE
Revert "GraphicsView: Let iOS decide when to call display"

### DIFF
--- a/Source/Fuse.Controls.Native/iOS/GraphicsView.uno
+++ b/Source/Fuse.Controls.Native/iOS/GraphicsView.uno
@@ -108,7 +108,7 @@ namespace Fuse.Controls.Native.iOS
 		static void EndDraw(ObjC.Object handle)
 		@{
 			GLKView* glkView = (GLKView*)handle;
-			[glkView setNeedsDisplay];
+			[glkView display];
 		@}
 
 		public override void Dispose()


### PR DESCRIPTION
This reverts commit 727dc9b9fd621efe6241c0372ca88cd6f91fce04.

I have two cases where this breaks down, at app startup and on device rotation.

1. If the app is very simple (I guess something does not cause invalidations after the first frame), the app will not draw.
2. On device rotation the app will not draw until next invalidation

I read the docs and tried figure out whats causing this, but could not find any easy fix. Lets revert until I can find out whats going on
