### PR TITLE
travis builtin-ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ os: osx
 
 language: cpp
 
-cache:
-  directories:
-    - $HOME/.ccache
+cache: ccache
 
 install:
   - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 os: osx
 
+language: cpp
+
 cache:
   directories:
     - $HOME/.ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ os: osx
 
 language: cpp
 
+compiler: clang
+
 cache: ccache
 
 install:


### PR DESCRIPTION
This seems to make travis-builds quite a bit faster:

|            | cold cache    | warm cache    |
|-----------:|:--------------|:--------------|
| **before** | 33 min 54 sec | 19 min 58 sec |
| **after**  | 43 min 58 sec | 14 min 59 sec |

Unfortunately, the numbers above are quite unreliable, as variations in builders and builder-load seems to fluctuate wildly. Especially the cold cache numbers seems questionable.