### PR TITLE
Scroller: Fix nullref in OnPointerMoved

### DIFF
--- a/Source/Fuse.Controls.ScrollView/Scroller.uno
+++ b/Source/Fuse.Controls.ScrollView/Scroller.uno
@@ -245,6 +245,9 @@ namespace Fuse.Gestures
 
 		GestureRequest IGesture.OnPointerMoved(PointerMovedArgs args)
 		{
+			if (_gesture == null)
+				return GestureRequest.Ignore;
+
 			if (!_gesture.IsHardCapture)
 			{
 				_softCaptureCurrent = args.WindowPoint;


### PR DESCRIPTION
If there is no gesture present, I assume that the GestureRequest should be Ignore

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
