### PR TITLE
Adjust batched element rect padding and some small cleanups/optimizations

### DIFF
--- a/Source/Fuse.Elements/Caching/ElementAtlas.uno
+++ b/Source/Fuse.Elements/Caching/ElementAtlas.uno
@@ -65,7 +65,7 @@ namespace Fuse.Elements
 			if (entry._atlas != null)
 				entry._atlas.RemoveElement(elm);
 			entry._atlas = this;
-			entry._rect = rect;
+			entry.AtlasRect = rect;
 			_elements.Add(elm);
 
 			_invalidElements++;
@@ -80,7 +80,7 @@ namespace Fuse.Elements
 			if (entry._atlas != this)
 				throw new Exception("Removing from wrong atlas");
 
-			_spilledPixels += entry._rect.Area;
+			_spilledPixels += entry.AtlasRect.Area;
 
 			if (!entry.IsValid)
 			{
@@ -108,8 +108,8 @@ namespace Fuse.Elements
 			if (!_rectPacker.TryAdd(cacheRect.Size, out rect))
 				return false;
 
-			_spilledPixels += entry._rect.Area;
-			entry._rect = rect;
+			_spilledPixels += entry.AtlasRect.Area;
+			entry.AtlasRect = rect;
 			if (entry.IsValid)
 			{
 				_invalidElements++;
@@ -180,7 +180,7 @@ namespace Fuse.Elements
 						continue;
 
 					var cachingRect =ElementBatch.GetCachingRect(elm);
-					var offset = (float2)(entry._rect.Minimum - cachingRect.Minimum) / density;
+					var offset = (float2)(entry.AtlasRect.Minimum - cachingRect.Minimum) / density;
 					var translation = Matrix.Translation(offset.X, offset.Y, 0);
 					var cc = new OrthographicFrustum{
 						Origin = float2(0, 0), Size = viewport,
@@ -188,7 +188,7 @@ namespace Fuse.Elements
 
 					dc.PushViewport( new FixedViewport(_rectPacker.Size, density, cc));
 
-					var scissor = entry._rect;
+					var scissor = entry.AtlasRect;
 					if (elm.ClipToBounds)
 						scissor = elm.GetVisibleViewportInvertPixelRect(dc, elm.RenderBoundsWithEffects);
 

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -64,7 +64,7 @@ namespace Fuse.Elements
 		public ElementAtlas _atlas;
 		public ElementBatch _batch;
 		public readonly Element _elm;
-		public Recti _rect;
+		public Recti AtlasRect;
 		public float _opacity;
 		public bool IsValid;
 	}
@@ -297,8 +297,8 @@ namespace Fuse.Elements
 			{
 				var entry = _elements[i];
 
-				float2 texCoordOrigin = (float2)entry._rect.Minimum / _elementAtlas._rectPacker.Size;
-				float2 size = (float2)entry._rect.Size / _elementAtlas._rectPacker.Size;
+				float2 texCoordOrigin = (float2)entry.AtlasRect.Minimum / _elementAtlas._rectPacker.Size;
+				float2 size = (float2)entry.AtlasRect.Size / _elementAtlas._rectPacker.Size;
 				vertexTexCoords.Set((i * 4 + 0) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin);
 				vertexTexCoords.Set((i * 4 + 1) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin + float2(size.X, 0));
 				vertexTexCoords.Set((i * 4 + 2) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin + size);
@@ -323,7 +323,7 @@ namespace Fuse.Elements
 				//this calculation assumes the transform is flat (a precondition to caching the element)
 				float2 localOrigin = (float2)cachingRect.Minimum * densityScale;
 				float2 positionOrigin = transform[3].XY + localOrigin.X * transform[0].XY + localOrigin.Y * transform[1].XY;
-				float2 size = (float2)entry._rect.Size * densityScale;
+				float2 size = (float2)entry.AtlasRect.Size * densityScale;
 				float2 right = transform[0].XY * size.X;
 				float2 up = transform[1].XY * size.Y;
 				vertexPositions.Set((i * 4 + 0) * _positionInfo.BufferStride + _positionInfo.BufferOffset, float3(positionOrigin, opacity));

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -65,6 +65,7 @@ namespace Fuse.Elements
 		public ElementBatch _batch;
 		public readonly Element _elm;
 		public Recti AtlasRect;
+		public int2 DrawingOffset;
 		public float _opacity;
 		public bool IsValid;
 	}
@@ -316,12 +317,11 @@ namespace Fuse.Elements
 			for (int i = 0; i < elementCount; ++i)
 			{
 				var entry = _elements[i];
-				var cachingRect = ElementBatch.GetCachingRect(entry._elm);
 				var opacity = entry._opacity;
 
 				var transform = entry._elm.LocalTransform;
 				//this calculation assumes the transform is flat (a precondition to caching the element)
-				float2 localOrigin = (float2)cachingRect.Minimum * densityScale;
+				float2 localOrigin = (float2)entry.DrawingOffset * densityScale;
 				float2 positionOrigin = transform[3].XY + localOrigin.X * transform[0].XY + localOrigin.Y * transform[1].XY;
 				float2 size = (float2)entry.AtlasRect.Size * densityScale;
 				float2 right = transform[0].XY * size.X;

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -133,9 +133,11 @@ namespace Fuse.Elements
 			var bounds = elm.RenderBoundsWithEffects;
 			if (bounds.IsInfinite || bounds.IsEmpty)
 				throw new Exception( "element has no caching rect" );
+
+			const int CachingRectPadding = 1;
 			
 			return Recti.Inflate(ConservativelySnapToCoveringIntegers(Rect.Scale(bounds.FlatRect,
-				elm.AbsoluteZoom)), 1);
+				elm.AbsoluteZoom)), CachingRectPadding);
 		}
 
 		VisualBounds CalcRenderBounds()

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -296,10 +296,9 @@ namespace Fuse.Elements
 			for (int i = 0; i < elementCount; ++i)
 			{
 				var entry = _elements[i];
-				var cachingRect = ElementBatch.GetCachingRect(entry._elm);
 
 				float2 texCoordOrigin = (float2)entry._rect.Minimum / _elementAtlas._rectPacker.Size;
-				float2 size = (float2)cachingRect.Size / _elementAtlas._rectPacker.Size;
+				float2 size = (float2)entry._rect.Size / _elementAtlas._rectPacker.Size;
 				vertexTexCoords.Set((i * 4 + 0) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin);
 				vertexTexCoords.Set((i * 4 + 1) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin + float2(size.X, 0));
 				vertexTexCoords.Set((i * 4 + 2) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin + size);
@@ -324,7 +323,7 @@ namespace Fuse.Elements
 				//this calculation assumes the transform is flat (a precondition to caching the element)
 				float2 localOrigin = (float2)cachingRect.Minimum * densityScale;
 				float2 positionOrigin = transform[3].XY + localOrigin.X * transform[0].XY + localOrigin.Y * transform[1].XY;
-				float2 size = (float2)cachingRect.Size * densityScale;
+				float2 size = (float2)entry._rect.Size * densityScale;
 				float2 right = transform[0].XY * size.X;
 				float2 up = transform[1].XY * size.Y;
 				vertexPositions.Set((i * 4 + 0) * _positionInfo.BufferStride + _positionInfo.BufferOffset, float3(positionOrigin, opacity));

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -289,6 +289,8 @@ namespace Fuse.Elements
 			_indexBuffer = new IndexBuffer(indices, BufferUsage.Immutable);
 		}
 
+		const float CachingRectPaddingAdjustment = 0.5f;
+
 		void FillVertexTexCoordBuffer()
 		{
 			var elementCount = _elements.Count;
@@ -298,8 +300,8 @@ namespace Fuse.Elements
 			{
 				var entry = _elements[i];
 
-				float2 texCoordOrigin = (float2)entry.AtlasRect.Minimum / _elementAtlas._rectPacker.Size;
-				float2 size = (float2)entry.AtlasRect.Size / _elementAtlas._rectPacker.Size;
+				float2 texCoordOrigin = ((float2)entry.AtlasRect.Minimum + CachingRectPaddingAdjustment) / _elementAtlas._rectPacker.Size;
+				float2 size = ((float2)entry.AtlasRect.Size - CachingRectPaddingAdjustment * 2) / _elementAtlas._rectPacker.Size;
 				vertexTexCoords.Set((i * 4 + 0) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin);
 				vertexTexCoords.Set((i * 4 + 1) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin + float2(size.X, 0));
 				vertexTexCoords.Set((i * 4 + 2) * _texCoordInfo.BufferStride + _texCoordInfo.BufferOffset, texCoordOrigin + size);
@@ -321,9 +323,9 @@ namespace Fuse.Elements
 
 				var transform = entry._elm.LocalTransform;
 				//this calculation assumes the transform is flat (a precondition to caching the element)
-				float2 localOrigin = (float2)entry.DrawingOffset * densityScale;
+				float2 localOrigin = ((float2)entry.DrawingOffset + CachingRectPaddingAdjustment) * densityScale;
 				float2 positionOrigin = transform[3].XY + localOrigin.X * transform[0].XY + localOrigin.Y * transform[1].XY;
-				float2 size = (float2)entry.AtlasRect.Size * densityScale;
+				float2 size = ((float2)entry.AtlasRect.Size - CachingRectPaddingAdjustment * 2) * densityScale;
 				float2 right = transform[0].XY * size.X;
 				float2 up = transform[1].XY * size.Y;
 				vertexPositions.Set((i * 4 + 0) * _positionInfo.BufferStride + _positionInfo.BufferOffset, float3(positionOrigin, opacity));

--- a/Source/Fuse.Elements/Caching/ElementBatcher.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatcher.uno
@@ -312,8 +312,8 @@ namespace Fuse.Elements
 
 				Recti cachingRect;
 				if (!Cache.GetCachingRect(elm, out cachingRect) ||
-					cachingRect.Size.X > e._rect.Size.X ||
-				    cachingRect.Size.Y > e._rect.Size.Y)
+					cachingRect.Size.X > e.AtlasRect.Size.X ||
+				    cachingRect.Size.Y > e.AtlasRect.Size.Y)
 				{
 					// re-insert element
 					if (!atlas.ReinsertElement(elm))


### PR DESCRIPTION
While working to fix https://github.com/fusetools/fuselibs/issues/4213 (fixed proper in https://github.com/fusetools/fuselibs/issues/4213), @kusma and I found a bunch of code that could use some clarification/small optimizations.

Particularly we renamed a `_rect` to `AtlasRect` on `Fuse.Elements.ElementBatchEntry` for clarity, introduced the `DrawingOffset` field, and moved some duplicated calculation out of `ElementBatch`, as we already had done these calculations when placing elements inside their atlases, and could just pass the data along with these fields.

We also realized that we had an extra half-pixel more padding around all of the batched elements than we needed, so I went ahead and choked up on that. This is both a minor speed optimization and an additional safety net in case we run into issues of elements drawing outside of their allocated area in the batch atlas in the future.
