### PR TITLE
Fuse.Elements: set scissor-box if ClipToBounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## ScrollView
 - Fixed possible nullref in Scroller that could happen in certain cases while scrolling a ScrollView
 
+## Fuse.Elements
+- Fixed an issue where the rendering of one element could bleed into the rendering of another element under some very specific circumstances.
+
 
 ### 1.0.3
 

--- a/Source/Fuse.Elements/Caching/ElementAtlas.uno
+++ b/Source/Fuse.Elements/Caching/ElementAtlas.uno
@@ -188,7 +188,11 @@ namespace Fuse.Elements
 
 					dc.PushViewport( new FixedViewport(_rectPacker.Size, density, cc));
 
-					dc.PushScissor(entry._rect);
+					var scissor = entry._rect;
+					if (elm.ClipToBounds)
+						scissor = elm.GetVisibleViewportInvertPixelRect(dc, elm.RenderBoundsWithEffects);
+
+					dc.PushScissor(scissor);
 
 					if (!drawAll)
 						dc.Clear(float4(0), 1);

--- a/Source/Fuse.Elements/Tests/Caching.Test.uno
+++ b/Source/Fuse.Elements/Tests/Caching.Test.uno
@@ -48,5 +48,29 @@ namespace Fuse.Test
 			Assert.AreEqual(float4(0, 0.375f, 0, 0.375f), root.ReadDrawPixel(int2(50, 98)), eps);
 			Assert.AreEqual(float4(0.375f, 0, 0, 0.375f), root.ReadDrawPixel(int2(50, 198)), eps);
 		}
+
+		[Test]
+		public void BorderIssue()
+		{
+			var p = new UX.Caching.BorderIssue();
+			var root = TestRootPanel.CreateWithChild(p, int2(32, 32));
+			root.CaptureDraw();
+
+			for (int y = -15; y < 16; ++y)
+			{
+				for (int x = -15; x < 16; ++x)
+				{
+					int manhattanDistance = Math.Max(Math.Abs(x), Math.Abs(y));
+
+					// check red rectangle
+					if (manhattanDistance < 4)
+						Assert.AreEqual(float4(1.0f, 0, 0, 1.0f), root.ReadDrawPixel(int2(16 + x, 16 + y)));
+
+					// check outside red and green rectangle
+					if (manhattanDistance > 6)
+						Assert.AreEqual(float4(0.0f, 0.0f, 0.0f, 0.0f), root.ReadDrawPixel(int2(16 + x, 16 + y)));
+				}
+			}
+		}
 	}
 }

--- a/Source/Fuse.Elements/Tests/UX/Caching.BorderIssue.ux
+++ b/Source/Fuse.Elements/Tests/UX/Caching.BorderIssue.ux
@@ -1,0 +1,16 @@
+<Panel ux:Class="UX.Caching.BorderIssue" Width="32px" Height="32px">
+	<Panel Width="8px" Height="8px" ClipToBounds="true">
+		<Translation X="1" />
+		<Panel Color="#F00">
+			<Translation X="-1" />
+		</Panel>
+	</Panel>
+
+	<Panel Width="4px" Height="4px" Color="#0F0">
+		<Scaling Factor="2" />
+	</Panel>
+
+	<Each Count="10">
+		<Panel Width="1px" Height="1px" Color="#00F" />
+	</Each>
+</Panel>


### PR DESCRIPTION
If a batched element has ClipToBounds=True, but contents that overflow
it, we didn't set up the scissor-box. This lead to rendering outside the
allocated part of the element-atlas, and could corrupt the rendering of
other elements.

Add a test-case to make sure this doesn't regress in the future.

This PR contains:
- [x] Changelog
- [x] Tests
