### PR TITLE
Scroller: Fix possible nullref when capture is lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## ScrollView
 - Fixed possible nullref in Scroller that could happen in certain cases while scrolling a ScrollView
+- Fixed nullref in Scroll that could happen if there are any pending LostCapture callbacks after the Scroller is Unrooted
 
 ## Fuse.Elements
 - Fixed an issue where the rendering of one element could bleed into the rendering of another element under some very specific circumstances.

--- a/Source/Fuse.Controls.ScrollView/Scroller.uno
+++ b/Source/Fuse.Controls.ScrollView/Scroller.uno
@@ -227,7 +227,7 @@ namespace Fuse.Gestures
 		void IGesture.OnLostCapture( bool forced ) 
 		{ 
 			_significance = 0;
-			if (_region.IsUser)
+			if (_region != null && _region.IsUser)
 				_region.EndUser();
 			CheckNeedUpdated();
 		}


### PR DESCRIPTION
This PR contains:
- [X] Changelog
- [ ] Documentation
- [ ] Tests
