### PR TITLE
GraphicsView: Make sure App redraws when entering foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.0
 
+## GraphicsView
+- Fixed issue where apps would not redraw when returning to Foreground
+
 ## ScrollView
 - Fixed possible nullref in Scroller that could happen in certain cases while scrolling a ScrollView
 

--- a/Source/Fuse.Controls.Panels/GraphicsView.ux.uno
+++ b/Source/Fuse.Controls.Panels/GraphicsView.ux.uno
@@ -277,6 +277,7 @@ namespace Fuse.Controls
 		bool _inBackground = false;
 		void OnEnteringForeground(Fuse.Platform.ApplicationState s)
 		{
+			rotationHackRedrawCount = 2;
 			_inBackground = false;
 			_frameScheduled = false;
 			ScheduleFrame();


### PR DESCRIPTION
One some Android devices we observe that the app is invisible when it enters forground. I guess we hit the rotation issue, setting rotationHackRedrawCount fixes the issue...

This PR contains:
- [X] Changelog
- [ ] Documentation
- [ ] Tests
