### PR TITLE
iOS: Fix crashes caused by ObjC reference loop

### DIFF
--- a/Source/Fuse.Controls.Video/iOS/VideoImpl.mm
+++ b/Source/Fuse.Controls.Video/iOS/VideoImpl.mm
@@ -95,6 +95,11 @@ namespace FuseVideoImpl
 
 		if (vs->Player)
 		{
+			if (vs->_presentationSizeObserver)
+			{
+				[vs->Player removeObserver:vs->_presentationSizeObserver forKeyPath:@"currentItem.presentationSize"];
+				vs->_presentationSizeObserver = NULL;
+			}
 			[vs->Player pause];
 			vs->Player = NULL;
 		}


### PR DESCRIPTION
This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
