### PR TITLE
Launcher encoding issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 1.1.0
 
+### Fuse.Launchers
+- Fixed bug on iOS where URIs were incorrectly encoded, leading to some input with reserved URI-characters misbehaving.
+
 ### ImageTools
 - Fixed bug in Android implementation that could result in errors due to prematurely recycled bitmaps
 

--- a/Source/Fuse.Launcher.Email/Email/EmailLauncher.uno
+++ b/Source/Fuse.Launcher.Email/Email/EmailLauncher.uno
@@ -48,14 +48,14 @@ namespace Fuse.LauncherImpl
 			{
 				builder.Append("&");
 				builder.Append("subject=");
-				builder.Append(subject.Replace(" ", "%20"));
+				builder.Append(Uri.Encode(subject));
 			}
 
 			if(!String.IsNullOrEmpty(message))
 			{
 				builder.Append("&");
 				builder.Append("body=");
-				builder.Append(message.Replace(" ", "%20"));
+				builder.Append(Uri.Encode(message));
 			}
 			//mailto:foo@example.com?cc=bar@example.com&subject=Greetings%20from%20Cupertino!&body=Wish%20you%20were%20here!
 

--- a/Source/Fuse.Launcher.Maps/Maps/JS.uno
+++ b/Source/Fuse.Launcher.Maps/Maps/JS.uno
@@ -41,7 +41,7 @@ namespace Fuse.Reactive.FuseJS
 			## Example
 
 				var Maps = require("FuseJS/Maps");
-				Maps.searchNear("Fusetools");
+				Maps.searchNearby("Fusetools");
 		*/
 		public static object SearchNearby(Scripting.Context context, object[] args)
 		{
@@ -83,7 +83,7 @@ namespace Fuse.Reactive.FuseJS
 			## Example
 
 				var Maps = require("FuseJS/Maps");
-				Maps.searchNear(59.9117715, 10.7400957);
+				Maps.openAt(59.9117715, 10.7400957);
 		*/
 		public static object OpenAt(Scripting.Context context, object[] args)
 		{

--- a/Source/Fuse.Launcher.Maps/Maps/MapsLauncher.uno
+++ b/Source/Fuse.Launcher.Maps/Maps/MapsLauncher.uno
@@ -38,6 +38,7 @@ namespace Fuse.LauncherImpl
 
 		public static void LaunchMaps(string query)
 		{
+			query = Uri.Encode(query);
 			if defined(Android)
 				LaunchMapsAndroid("geo:0,0?q=" + query);
 			else if defined(iOS)
@@ -49,6 +50,7 @@ namespace Fuse.LauncherImpl
 			if defined(Android || iOS)
 			{
 				var latlon = latitude.ToString() + "," + longitude.ToString();
+				query = Uri.Encode(query);
 
 				if defined(Android)
 					LaunchMapsAndroid("geo:" + latlon + "?q=" + query);

--- a/Tests/ManualTests/ManualTestingApp/MainView.ux
+++ b/Tests/ManualTests/ManualTestingApp/MainView.ux
@@ -138,6 +138,7 @@
 			<HitTestPage/>
 			<DefaultFonts/>
 			<Pages.SurfaceMisc/>
+			<Launchers/>
 			
 			<Android>
 				<WebViewPage/>

--- a/Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj
+++ b/Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj
@@ -8,7 +8,8 @@
     "Fuse.CameraRoll",
     "Fuse.Maps",
     "Fuse.Audio",
-    "Fuse.Share"
+    "Fuse.Share",
+    "Fuse.Launcher"
   ],
   "Projects": [
     "UnoComponents.unoproj",

--- a/Tests/ManualTests/ManualTestingApp/Singles/Launchers.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/Launchers.ux
@@ -1,0 +1,78 @@
+<Page Title="Launchers" ux:Class="Launchers">
+	<InfoStack ux:Key="Info">
+		<p>This part tests various launchers</p>
+		<ul>
+		<li>The "send email"-button should try to send an e-mail to email@example.com, with the subject "test", and message "Hello to email@example.com"</li>
+		<li>The "fusetools.com"-button should open fusetools.com in a browser</li>
+		<li>The "Show fusetools on map" and "Show fusetools on map (JS)"-buttons should open a map-view around the fusetools offices in Oslo/Norway</li>
+		<li>The "Find pizza"-button should search for pizza resturants on the map near the users current position</li>
+		<li>The "Find pizza near Fusetools"-button should search for pizza resturants on the map near the Fusetools offices in Oslo/Norway</li>
+		<li>The "Who you gonna call?"-button should try to call the Ghostbusters (1-800-555-2368)</li>
+		</ul>
+	</InfoStack>
+	<StackPanel Margin="20">
+		<JavaScript>
+			var Maps = require("FuseJS/Maps");
+
+			function showFusetools() {
+				Maps.openAt(59.9117715, 10.7400957);
+			}
+
+			function findPizza() {
+				Maps.searchNearby("pizza resturant");
+			}
+
+			function findPizzaNearFusetools() {
+				Maps.searchNear(59.9117715, 10.7400957, "pizza resturant");
+			}
+
+			module.exports = {
+				showFusetools: showFusetools,
+				findPizza: findPizza,
+				findPizzaNearFusetools: findPizzaNearFusetools
+			};
+		</JavaScript>
+
+		<StdButton Text="Send email">
+			<Clicked>
+				<LaunchEmail To="email@example.com" Subject="Test" CarbonCopy="" BlindCarbonCopy="" Message="Hello to email@example.com" />
+			</Clicked>
+		</StdButton>
+
+		<StdButton Text="fusetools.com">
+			<Clicked>
+				<LaunchUri Uri="https://www.fusetools.com/" />
+			</Clicked>
+		</StdButton>
+
+		<StdButton Text="Show fusetools on map">
+			<Clicked>
+				<LaunchMaps Latitude="59.9117715" Longitude="10.7400957"  />
+			</Clicked>
+		</StdButton>
+
+		<StdButton Text="Show fusetools on map (JS)">
+			<Clicked>
+				<Callback Handler="{showFusetools}" />
+			</Clicked>
+		</StdButton>
+
+		<StdButton Text="Find pizza">
+			<Clicked>
+				<Callback Handler="{findPizza}" />
+			</Clicked>
+		</StdButton>
+
+		<StdButton Text="Find pizza near Fusetools">
+			<Clicked>
+				<Callback Handler="{findPizzaNearFusetools}" />
+			</Clicked>
+		</StdButton>
+
+		<StdButton Text="Who you gonna call?">
+			<Clicked>
+				<Call Number="1-800-555-2368" />
+			</Clicked>
+		</StdButton>
+	</StackPanel>
+</Page>


### PR DESCRIPTION
The launchers doesn't always encode URIs correctly, which cause issues on iOS. See #126 for more details.

Unfortunately, I don't have an iOS-device at hand now, but I've verified that things still works as it should on Android. So if someone else could test this on iOS, that would be great.

This also fixes fusetools/fuse-docs#790

This PR contains:
- [x] Changelog
- [x] Tests
