### PR TITLE
Fuse.Camera iOS 10.1+ crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # 1.1
 
+### Fuse.Camera
+- iOS: Fixed crash when using Fuse.Camera alongside `<iOS.StatusBarConfig IsVisible="false" />`
+
 ## 1.1.0
 
 ### Fuse.Launchers

--- a/Source/Fuse.ImageTools/iOS/ImagePicker.m
+++ b/Source/Fuse.ImageTools/iOS/ImagePicker.m
@@ -19,7 +19,9 @@
 		_imagePicker = [[UIImagePickerController alloc] init];
 		_imagePicker.sourceType = type;
 		[_imagePicker setDelegate:self];
-		[[self VC] presentViewController:_imagePicker animated:YES completion:^{ }];
+		[[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+			[[self VC] presentViewController:_imagePicker animated:YES completion:^{ }];
+		}];
 		return YES;
 	}else{
 		return NO;
@@ -36,9 +38,11 @@
 -(void)closePickerThen:(Action)a
 {
 	__block Action postAction = a;
-	[[self VC] dismissViewControllerAnimated:YES completion:^{
-		postAction();
-		[self cleanUp];
+	[[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+		[[self VC] dismissViewControllerAnimated:YES completion:^{
+			postAction();
+			[self cleanUp];
+		}];
 	}];
 }
 


### PR DESCRIPTION
This PR fixes a crash introduced with iOS 10.1 where modal view controller invoke and dismiss *must* happen on UI thread. Fixes #128 

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
