### PR TITLE
Feature android camera buffer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # 1.1
 
+### Fuse.ImageTools
+- Fixed bug preventing handling of KEEP_ASPECT resize mode on Android when using ImageTools.resize 
+
 ## 1.1.0
 
 ### Fuse.Launchers

--- a/Source/Fuse.ImageTools/Android/ImageUtils.java
+++ b/Source/Fuse.ImageTools/Android/ImageUtils.java
@@ -166,7 +166,7 @@ public class ImageUtils {
 				scaledBitmap.recycle();
 			}
 
-			if (!resultBitmap.isRecycled())
+			if (resultBitmap != null && !resultBitmap.isRecycled())
 				resultBitmap.recycle();
 		}
 	}

--- a/Source/Fuse.ImageTools/Android/ImageUtils.java
+++ b/Source/Fuse.ImageTools/Android/ImageUtils.java
@@ -135,7 +135,25 @@ public class ImageUtils {
 						Math.min(desiredHeight, (int)height));
 
 				break;
-			case IGNORE_ASPECT:
+			case KEEP_ASPECT:
+				if (width > desiredWidth) {
+					ratio = desiredWidth / width;
+					width *= ratio;
+					height *= ratio;
+				}
+				if (height > desiredHeight) {
+					ratio = desiredHeight / height;
+					width *= ratio;
+					height *= ratio;
+				}
+
+				resultBitmap = Bitmap.createScaledBitmap(
+						sourceBitmap,
+						(int)width,
+						(int)height,
+						true);
+				break;
+			default:
 				//Use width/height as given
 				resultBitmap = Bitmap.createScaledBitmap(
 						sourceBitmap,


### PR DESCRIPTION
This PR reimplements handling for the KEEP_ASPECT resize mode in ImageUtils that I apparently overlooked at some point when trying to fix OOM crashes. Fixes https://github.com/fusetools/ManualTestApp/issues/358

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
