### PR TITLE
migrated `attract` from premiumlibs into fuselibs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Attract
+- Added the `attract` feature, which was previously only in premiumlibs. This provides a much simpler syntax for animation than the `Attractor` behavior.
+
 ## Gesture
 - The experimental `IGesture` interface has changed. 
   * The `Significance`, `Priority` and `PriotityAdjustment` have been merged into the single `GetPriority` function.

--- a/Source/Fuse.Animations/Attract.uno
+++ b/Source/Fuse.Animations/Attract.uno
@@ -95,7 +95,7 @@ namespace Fuse.Animations
 			{
 				var value = float4(0);
 				int size = 0;
-				if (!TryMarshalToAnimFloat4(oValue, out value, out size))
+				if (!Marshal.TryToZeroFloat4(oValue, out value, out size))
 				{
 					//invalid values can simply discard the simulation (forcing a new one to be created when
 					//a good value arrives)
@@ -186,73 +186,6 @@ namespace Fuse.Animations
 				_attract = null;
 				CleanSimulation();
 			}
-		}
-		
-		/**
-			Converts a value to a float4 suitable for animation, where unspecified values are 0.
-			
-			NOTE: Perhaps this should be made a standard method in Marshal, there must be more places that
-				need this logic. The base logic was just copied from Marshal.ToFloat4 (modified to add 0's) -- Size handling was removed until we can build the special logic needed to support it's animation.
-		*/
-		static bool TryMarshalToAnimFloat4(object o, out float4 value, out int size)
-		{
-			if (o is float4) 
-			{
-				value = (float4)o;
-				size = 4;
-				return true;
-			}
-			
-			if (o is float3)
-			{
-				var f = (float3)o;
-				value =float4(f.X, f.Y, f.Z, 0);
-				size = 3;
-				return true;
-			}
-			
-			if (o is float2)
-			{
-				var f = (float2)o;
-				value = float4(f.X, f.Y, 0, 0);
-				size = 2;
-				return true;
-			}
-			
-			if (o is string)
-			{
-				var s = (string)o;
-				if (s.StartsWith("#"))
-				{
-					value = Uno.Color.FromHex(s);
-					size = 4;
-					return true;
-				}
-			}
-			else if (o is IArray)
-			{
-				var a = (IArray)o;
-				var x = a.Length > 0 ? Marshal.ToFloat(a[0]) : 0.0f;
-				var y = a.Length > 1 ? Marshal.ToFloat(a[1]) : 0.0f;
-				var z = a.Length > 2 ? Marshal.ToFloat(a[2]) : 0.0f;
-				var w = a.Length > 3 ? Marshal.ToFloat(a[3]) : 0.0f;
-				value = float4(x,y,z,w);
-				size = a.Length;
-				return true;
-			}
-
-			double d;
-			if (Marshal.ToDouble(o, out d))
-			{
-				var f = (float)d;
-				value = float4(f,0,0,0);
-				size = 1;
-				return true;
-			}
-
-			value = float4(0);
-			size = 0;
-			return false;
 		}
 	}
 }

--- a/Source/Fuse.Animations/Attract.uno
+++ b/Source/Fuse.Animations/Attract.uno
@@ -1,0 +1,258 @@
+using Uno;
+using Uno.UX;
+
+using Fuse;
+using Fuse.Motion;
+using Fuse.Motion.Simulation;
+using Fuse.Reactive;
+
+namespace Fuse.Animations
+{
+	/** 
+		A configuration for use with the `attract` expression or to an `Attractor` property.
+
+		A single `AttractorConfig` can be used for multiple `attract` expressions.
+		
+		@see @Attract
+		@experimental
+	*/
+	public class AttractorConfig : DestinationMotionConfig
+	{
+	}
+	
+	[UXFunction("attract")]
+	/**
+		Animates the change in a value.
+		
+		The syntax is `attract( value, config )`
+		
+		This requires an @AttractorConfig that defines the style of the animation.
+		
+		# Example
+		
+			<AttractorConfig Unit="Points" Easing="SinusoidalInOut" Duration="0.3" ux:Global="asPoints"/>
+			
+			<Panel>
+				<Translation X="attract({xOffset}, asPoints)"/>
+			</Panel>
+			
+		Where `xOffset` is a context variable.
+	*/
+	public sealed class Attract : Fuse.Reactive.Expression
+	{
+		Fuse.Reactive.Expression _sourceValue;
+		AttractorConfig _config;
+		
+		[UXConstructor]
+		public Attract([UXParameter("Value")] Fuse.Reactive.Expression value, 
+			[UXParameter("Config")] AttractorConfig config )
+		{
+			_config = config;
+			_sourceValue = value;
+		}
+		
+		public override IDisposable Subscribe(IContext context, IListener listener)
+		{
+			return new Subscription(this, context, listener);
+		}
+		
+		class Subscription : IListener, IDisposable
+		{
+			IListener _target;
+			Attract _attract;
+			IDisposable _sourceSub;
+			
+			//we need to support these four possibilties to avoid having special `attract/2/3/4` functions per type
+			//TODO: Perhaps this can be simplified if the adapters for simulation (angular) just dealt with
+			//non-scale types (we could just use float4 again for everything)
+			DestinationBehavior<float4> _simulation4;
+			DestinationBehavior<float3> _simulation3;
+			DestinationBehavior<float2> _simulation2;
+			DestinationBehavior<float> _simulation1;
+			int _simSize;
+			
+			public Subscription(Attract attract, IContext context, IListener target)
+			{
+				_target = target;
+				_attract = attract;
+				_simulation4 = new DestinationBehavior<float4>();
+				_simulation4.Motion = attract._config;
+				_sourceSub = attract._sourceValue.Subscribe(context, this);
+			}
+			
+			void OnValueUpdate<T>(T value)
+			{
+				if (_target == null) //safety
+					return;
+				_target.OnNewData(_attract, value);
+			}
+			void OnValueUpdate4(float4 value) { OnValueUpdate(value); }
+			void OnValueUpdate3(float3 value) { OnValueUpdate(value); }
+			void OnValueUpdate2(float2 value) { OnValueUpdate(value); }
+			void OnValueUpdate1(float value) { OnValueUpdate(value); }
+			
+			void IListener.OnNewData( IExpression source, object oValue )
+			{
+				var value = float4(0);
+				int size = 0;
+				if (!TryMarshalToAnimFloat4(oValue, out value, out size))
+				{
+					//invalid values can simply discard the simulation (forcing a new one to be created when
+					//a good value arrives)
+					CleanSimulation();
+					return;
+				}
+
+				NeedSim(size);
+				
+				if (_simulation1 != null)
+					_simulation1.SetValue( value.X, OnValueUpdate1 );
+				if (_simulation2 != null)
+					_simulation2.SetValue( value.XY, OnValueUpdate2 );
+				if (_simulation3 != null)
+					_simulation3.SetValue( value.XYZ, OnValueUpdate3 );
+				if (_simulation4 != null)
+					_simulation4.SetValue( value, OnValueUpdate4 );
+			}
+			
+			void NeedSim(int size)
+			{
+				if (size != _simSize)
+				{
+					CleanSimulation();
+					_simSize = size;
+				}
+				
+				if (size < 0 || size > 4)
+				{
+					Fuse.Diagnostics.InternalError( "Unexpected size for attract: " + size, this );
+					return;
+				}
+					
+				if (size == 1 && _simulation1 == null)
+				{
+					_simulation1 = new DestinationBehavior<float>();
+					_simulation1.Motion = _attract._config;
+				}
+				else if (size == 2 && _simulation2 == null)
+				{
+					_simulation2 =new DestinationBehavior<float2>();
+					_simulation2.Motion = _attract._config;
+				}
+				else if (size == 3 && _simulation3 == null)
+				{
+					_simulation3 =new DestinationBehavior<float3>();
+					_simulation3.Motion = _attract._config;
+				}
+				else if (size == 4 && _simulation4 == null)
+				{
+					_simulation4 =new DestinationBehavior<float4>();
+					_simulation4.Motion = _attract._config;
+				}
+			}
+			
+			void CleanSimulation()
+			{
+				if (_simulation4 != null)
+				{
+					_simulation4.Unroot();
+					_simulation4 = null;
+				}
+				if (_simulation3 != null)
+				{
+					_simulation3.Unroot();
+					_simulation3 = null;
+				}
+				if (_simulation2 != null)
+				{
+					_simulation2.Unroot();
+					_simulation2 = null;
+				}
+				if (_simulation1 != null)
+				{
+					_simulation1.Unroot();
+					_simulation1 = null;
+				}
+			}
+			
+			public void Dispose()
+			{
+				if (_sourceSub != null)
+				{
+					_sourceSub.Dispose();
+					_sourceSub = null;
+				}
+				_target = null;
+				_attract = null;
+				CleanSimulation();
+			}
+		}
+		
+		/**
+			Converts a value to a float4 suitable for animation, where unspecified values are 0.
+			
+			NOTE: Perhaps this should be made a standard method in Marshal, there must be more places that
+				need this logic. The base logic was just copied from Marshal.ToFloat4 (modified to add 0's) -- Size handling was removed until we can build the special logic needed to support it's animation.
+		*/
+		static bool TryMarshalToAnimFloat4(object o, out float4 value, out int size)
+		{
+			if (o is float4) 
+			{
+				value = (float4)o;
+				size = 4;
+				return true;
+			}
+			
+			if (o is float3)
+			{
+				var f = (float3)o;
+				value =float4(f.X, f.Y, f.Z, 0);
+				size = 3;
+				return true;
+			}
+			
+			if (o is float2)
+			{
+				var f = (float2)o;
+				value = float4(f.X, f.Y, 0, 0);
+				size = 2;
+				return true;
+			}
+			
+			if (o is string)
+			{
+				var s = (string)o;
+				if (s.StartsWith("#"))
+				{
+					value = Uno.Color.FromHex(s);
+					size = 4;
+					return true;
+				}
+			}
+			else if (o is IArray)
+			{
+				var a = (IArray)o;
+				var x = a.Length > 0 ? Marshal.ToFloat(a[0]) : 0.0f;
+				var y = a.Length > 1 ? Marshal.ToFloat(a[1]) : 0.0f;
+				var z = a.Length > 2 ? Marshal.ToFloat(a[2]) : 0.0f;
+				var w = a.Length > 3 ? Marshal.ToFloat(a[3]) : 0.0f;
+				value = float4(x,y,z,w);
+				size = a.Length;
+				return true;
+			}
+
+			double d;
+			if (Marshal.ToDouble(o, out d))
+			{
+				var f = (float)d;
+				value = float4(f,0,0,0);
+				size = 1;
+				return true;
+			}
+
+			value = float4(0);
+			size = 0;
+			return false;
+		}
+	}
+}

--- a/Source/Fuse.Animations/Fuse.Animations.unoproj
+++ b/Source/Fuse.Animations/Fuse.Animations.unoproj
@@ -18,10 +18,13 @@
   "Projects": [
     "../Fuse.Motion/Fuse.Motion.unoproj",
     "../Fuse.Nodes/Fuse.Nodes.unoproj",
-    "../Fuse.Common/Fuse.Common.unoproj"
+    "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Reactive/Fuse.Reactive.unoproj",
+    "../Fuse.Reactive.Expressions/Fuse.Reactive.Expressions.unoproj",
   ],
   "Includes": [
     "Animator.uno:Source",
+    "Attract.uno:Source",
     "Attractor.uno:Source",
     "AverageMixer.uno:Source",
     "Change.uno:Source",

--- a/Source/Fuse.Animations/Tests/Attract.Test.uno
+++ b/Source/Fuse.Animations/Tests/Attract.Test.uno
@@ -1,0 +1,27 @@
+using Uno;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Animations.Test
+{
+	public class AttractTest: TestBase
+	{
+		[Test]
+		public void Basic()
+		{	
+			var p =  new UX.Attract.Basic();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(50, p.T.X);
+				
+				p.slider.Value = 100;
+				root.StepFrame(1f);
+				Assert.AreEqual(75, p.T.X);
+				
+				root.StepFrame(1f);
+				Assert.AreEqual(100,p.T.X);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Animations/Tests/Fuse.Animations.Test.unoproj
+++ b/Source/Fuse.Animations/Tests/Fuse.Animations.Test.unoproj
@@ -1,15 +1,7 @@
 {
   "Packages": [
-    "Fuse.Animations",
-    "Fuse.Controls",
-    "Fuse.Controls.Panels",
-    "Fuse.Controls.Primitives",
-    "Fuse.Drawing",
-    "Fuse.Elements",
-    "Fuse.Gestures",
-    "Fuse.Triggers",
-    "Fuse.Common",
-    "Fuse.Nodes",
+    "Fuse",
+    "FuseJS",
     "Uno.Testing"
   ],
   "Projects": [

--- a/Source/Fuse.Animations/Tests/UX/Attract.Test.ux
+++ b/Source/Fuse.Animations/Tests/UX/Attract.Test.ux
@@ -1,0 +1,6 @@
+<Panel ux:Class="UX.Attract.Basic">
+	<AttractorConfig Unit="Points" Easing="Linear" 
+		Duration="1" DurationExp="1" Distance="25" ux:Global="lit"/>
+	<Slider Minimum="0" Maximum="100" Value="50" ux:Name="slider"/>
+	<Translation X="attract({Property slider.Value}, lit)" ux:Name="T"/>
+</Panel>

--- a/Source/Fuse.Motion/DestinationBehavior.uno
+++ b/Source/Fuse.Motion/DestinationBehavior.uno
@@ -5,8 +5,6 @@ using Fuse.Motion;
 using Fuse.Reactive;
 using Fuse.Motion.Simulation;
 
-//NOTE: This is likely destined to be a fuselibs package. It resides in premiumlibs since it's necessary
-//for animation of charts desired for release-1.0
 namespace Fuse.Animations
 {
 	/**

--- a/Source/Fuse.Motion/DestinationBehavior.uno
+++ b/Source/Fuse.Motion/DestinationBehavior.uno
@@ -1,0 +1,87 @@
+using Uno;
+using Uno.UX;
+
+using Fuse.Motion;
+using Fuse.Reactive;
+using Fuse.Motion.Simulation;
+
+//NOTE: This is likely destined to be a fuselibs package. It resides in premiumlibs since it's necessary
+//for animation of charts desired for release-1.0
+namespace Fuse.Animations
+{
+	/**
+		A mixin-like class to provide common attractor behavior for variables inside Uno.
+	*/
+	class DestinationBehavior<T>
+	{
+		public DestinationMotionConfig Motion;
+		
+		public delegate void ValueHandler( T value );
+		
+		ValueHandler _handler;
+		DestinationSimulation<T> _simulation;
+
+		void OnUpdate()
+		{
+			if (_simulation == null) //safety
+			{
+				StopListenUpdate();
+				return;
+			}
+				
+			_simulation.Update( Time.FrameInterval );
+			if (_handler != null)
+				_handler( _simulation.Position );
+			
+			if (_simulation.IsStatic)
+				StopListenUpdate();
+		}
+		
+		bool _listenUpdate;
+		void StopListenUpdate()
+		{
+			if (_listenUpdate)
+			{
+				UpdateManager.RemoveAction( OnUpdate );
+				_listenUpdate = false;
+			}
+		}
+		
+		public void Unroot()
+		{
+			StopListenUpdate();
+			_simulation = null;
+			_handler = null;
+		}
+		
+		public void SetValue( T value, ValueHandler handler )
+		{
+			if (Motion == null)
+			{
+				handler( value );
+				return;
+			}
+			
+			_handler = handler;
+			if (_simulation == null)
+			{
+				_simulation = Motion.Create<T>();
+				_simulation.Reset( value );
+				//force in first frame to avoid unset initial values being rendered
+				if (_handler != null)
+					_handler( _simulation.Position );
+			}
+			else
+			{
+				_simulation.Destination = value;
+				_simulation.Start();
+			}
+				
+			if (!_listenUpdate)
+			{
+				UpdateManager.AddAction( OnUpdate );
+				_listenUpdate = true;
+			}
+		}
+	}
+}

--- a/Source/Fuse.Motion/DestinationMotion.uno
+++ b/Source/Fuse.Motion/DestinationMotion.uno
@@ -10,9 +10,9 @@ namespace Fuse.Motion
 	*/
 	/**
 		This class defines the animation of a value as it moves towards another values. It is typically used as
-		a composite object of other types, such as @MotionConfig and @Attractor.
+		a composite object of other types, such as @MotionConfig, @Attract and @Attractor.
 	*/
-	public class DestinationMotion<T>
+	public class DestinationMotionConfig
 	{
 		internal MotionDestinationType _type = MotionDestinationType.Elastic;
 		bool _explicitType;
@@ -120,7 +120,7 @@ namespace Fuse.Motion
 			}
 		}
 		
-		internal DestinationSimulation<T> Create()
+		internal DestinationSimulation<T> Create<T>()
 		{
 			var effectiveUnit = Unit;
 			var multiplier = 1f;
@@ -182,4 +182,13 @@ namespace Fuse.Motion
 			return dest;
 		}
 	}
+	
+	public class DestinationMotion<T> : DestinationMotionConfig
+	{
+		new internal DestinationSimulation<T> Create()
+		{
+			return base.Create<T>();
+		}
+	}
+	
 }

--- a/Source/Fuse.Motion/Fuse.Motion.unoproj
+++ b/Source/Fuse.Motion/Fuse.Motion.unoproj
@@ -22,6 +22,7 @@
   ],
   "Includes": [
     "MotionConfig.uno:Source",
+    "DestinationBehavior.uno:Source",
     "DestinationMotion.uno:Source",
     "SpringFunction.uno:Source",
     "DelayFunction.uno:Source",


### PR DESCRIPTION
`attract` was always meant for fuselibs but due to release timing ended up in premiumlibs. This moves it to the correct place now.

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
