### PR TITLE
Optimization: Don't check for GL errors all the time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.
 - Optimized invalidation strategy for transforms, to avoid subtree traversion. This improves performance generally when animating large subtrees (e.g. scrollviews).
 - Backwards incompatible optimization change: The `protected virtual void Visual.OnInvalidateWorldTransform()` method was removed. The contract of this method was very expensive to implement as it had to be called on all nodes, just in case it was overridden somewhere. If you have custom Uno code relying on this method (unlikely), then please rewrite to explicitly subscribe to the `Visual.WorldTransformInvalidated` event instead, like so: Override `OnRooted` and do `WorldTransformInvalidated += OnInvalidateWorldTransform;`, Override `OnUnrooted` and to `WorldTransformInvalidated -= OnInvalidateWorldTransform;`, then rewrite `protected override void OnInvalidateWorldTransform()` to `void OnInvalidateWorldTransform(object sender, EventArgs args)`
+## OpenGL Optimizations
+- To improve rendering speed, Fuse no longer checks for OpenGL errors in release builds in some performance-critical code paths  
 
 ## Attract
 - Added the `attract` feature, which was previously only in premiumlibs. This provides a much simpler syntax for animation than the `Attractor` behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.
 - Optimized invalidation strategy for transforms, to avoid subtree traversion. This improves performance generally when animating large subtrees (e.g. scrollviews).
 - Backwards incompatible optimization change: The `protected virtual void Visual.OnInvalidateWorldTransform()` method was removed. The contract of this method was very expensive to implement as it had to be called on all nodes, just in case it was overridden somewhere. If you have custom Uno code relying on this method (unlikely), then please rewrite to explicitly subscribe to the `Visual.WorldTransformInvalidated` event instead, like so: Override `OnRooted` and do `WorldTransformInvalidated += OnInvalidateWorldTransform;`, Override `OnUnrooted` and to `WorldTransformInvalidated -= OnInvalidateWorldTransform;`, then rewrite `protected override void OnInvalidateWorldTransform()` to `void OnInvalidateWorldTransform(object sender, EventArgs args)`
-## OpenGL Optimizations
 - To improve rendering speed, Fuse no longer checks for OpenGL errors in release builds in some performance-critical code paths  
 
 ## Attract

--- a/Source/Fuse.Nodes/DrawContext.uno
+++ b/Source/Fuse.Nodes/DrawContext.uno
@@ -83,7 +83,7 @@ namespace Fuse
 			if defined(OPENGL)
 			{
 				GL.Enable(GLEnableCap.ScissorTest);
-				CheckGLError();
+				if defined(DEBUG) CheckGLError();
 
 				_glScissor = GL.GetInteger(GLInteger4Name.ScissorBox);
 				_glViewport = GL.GetInteger(GLInteger4Name.Viewport);
@@ -149,7 +149,7 @@ namespace Fuse
 			{
 				_glFramebuffer = value;
 				GL.BindFramebuffer(GLFramebufferTarget.Framebuffer, value);
-				CheckGLError();
+				if defined(DEBUG) CheckGLError();
 			}
 		}
 
@@ -178,7 +178,7 @@ namespace Fuse
 			if defined(OPENGL)
 			{
 				GLFramebuffer = rt.GLFramebufferHandle;
-				CheckGLError();
+				if defined(DEBUG) CheckGLError();
 			}
 			_renderTarget = rt;
 			GLViewportPixelSize = viewportPixelSize;
@@ -199,7 +199,7 @@ namespace Fuse
 			if defined(OPENGL)
 			{
 				GLFramebuffer = old.GLFramebuffer;
-				CheckGLError();
+				if defined(DEBUG) CheckGLError();
 			}
 			GLViewportPixelSize = old.GLViewportPixelSize;
 			GLScissor = old.GLScissor;
@@ -237,7 +237,7 @@ namespace Fuse
 				OpenGL.GL.ClearColor(color.X, color.Y, color.Z, color.W);
 				OpenGL.GL.Clear(GLClearBufferMask.ColorBufferBit | GLClearBufferMask.DepthBufferBit |
 				GLClearBufferMask.StencilBufferBit);
-				CheckGLError();
+				if defined(DEBUG) CheckGLError();
 			}
 		}
 
@@ -278,7 +278,7 @@ namespace Fuse
 				if defined(OpenGL)
 				{
 					OpenGL.GL.Scissor(value[0],value[1],value[2],value[3]);
-					CheckGLError();
+					if defined(DEBUG) CheckGLError();
 				}
 			}
 		}
@@ -322,7 +322,7 @@ namespace Fuse
 				if defined(OPENGL)
 				{
 					OpenGL.GL.Viewport(0, 0, value.X, value.Y);
-					CheckGLError();
+					if defined(DEBUG) CheckGLError();
 				}
 			}
 		}


### PR DESCRIPTION
These GL errors should never trigger (indicates bugs in fuselibs, or custom user GL code messing up things). Introduced `-DDEBUG_GL` if the user wants the old behavior or to enable debugging in the future.

Achieves a 0.5-1.0ms speedup on my android phone per frame in the test case (a big app), and ~5ms speedup on my desktop (!!)

This PR contains:
- [x] Changelog
