### PR TITLE
fixing the example for working with Selection API

### DIFF
--- a/Source/Fuse.Selection/Docs/example.md
+++ b/Source/Fuse.Selection/Docs/example.md
@@ -1,20 +1,20 @@
 The following example uses @Selection to create a simple list of options. Tap the items to toggle their selection. `Values` is bound to a JavaScript `Observable` in order to track the currently selected items.
 
 	<Panel ux:Class="MyItem" Color="#aaa">
-		<string ux:Property="Label"/>
-		<string ux:Property="Value"/>
-		
-		<Selectable Value="{ReadProperty this.Value}"/>
-		<Text Value="{ReadProperty this.Label}"/>
-		
+		<string ux:Property="Label" />
+		<string ux:Property="Value" />
+
+		<Selectable Value="{ReadProperty this.Value}" />
+		<Text Value="{ReadProperty this.Label}" />
+
 		<WhileSelected>
-			<Change this.Color="#ffc"/>
+			<Change this.Color="#ffc" />
 		</WhileSelected>
 		<Tapped>
-			<ToggleSelection/>
+			<ToggleSelection />
 		</Tapped>
 	</Panel>
-
+	
 	<JavaScript>
 		var Observable = require("FuseJS/Observable")
 		exports.values = Observable()
@@ -24,15 +24,16 @@ The following example uses @Selection to create a simple list of options. Tap th
 			exports.list.value = exports.values.toArray().join(",")
 		})
 	</JavaScript>
-	<StackPanel>
-		<Selection Values="{values}"/>
 	
-		<MyItem Label="Big Red One" Value="sku-01"/>
-		<MyItem Label="Small Green Two" Value="sku-02"/>
-		<MyItem Label="Third Last One" Value="sku-03"/>
-		<MyItem Label="Four Fore For" Value="sku-04"/>
-		<MyItem Label="Point Oh-Five" Value="sku-05"/>
+	<StackPanel>
+		<Selection Values="{values}" />
 
-		<Text Value="Selected:" Margin="0,10,0,0"/>
-		<Text Value="{list}"/>
+		<MyItem Label="Big Red One" Value="sku-01" />
+		<MyItem Label="Small Green Two" Value="sku-02" />
+		<MyItem Label="Third Last One" Value="sku-03" />
+		<MyItem Label="Four Fore For" Value="sku-04" />
+		<MyItem Label="Point Oh-Five" Value="sku-05" />
+
+		<Text Value="Selected:" Margin="0,10,0,0" />
+		<Text Value="{list}" />
 	</StackPanel>

--- a/Source/Fuse.Selection/Docs/example.md
+++ b/Source/Fuse.Selection/Docs/example.md
@@ -16,13 +16,17 @@ The following example uses @Selection to create a simple list of options. Tap th
 	</Panel>
 	
 	<JavaScript>
-		var Observable = require("FuseJS/Observable")
-		exports.values = Observable()
-		
-		exports.list = Observable("")
-		exports.values.onValueChanged( module, function() {
-			exports.list.value = exports.values.toArray().join(",")
-		})
+		var Observable = require("FuseJS/Observable");
+
+		var values = Observable();
+		var list = Observable(function() {
+			return values.toArray().join(",");
+		});
+
+		module.exports = {
+			values: values,
+			list: list
+		};
 	</JavaScript>
 	
 	<StackPanel>


### PR DESCRIPTION
Here: https://www.fusetools.com/docs/fuse/selection/selection#section-examples

The example treats list Observable as a single-value Observable, and that's wrong.
It also relies on the Selection API replacing the first value every time the selection changes, which might currently be true, but probably isn't correct either.

This PR contains:
- [ ] Changelog
- [x] Documentation
- [ ] Tests
