### PR TITLE
ElementAtlas: Don't set rendertarget redundantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Optimizaitons
+- Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.
+
 ## Attract
 - Added the `attract` feature, which was previously only in premiumlibs. This provides a much simpler syntax for animation than the `Attractor` behavior.
 

--- a/Source/Fuse.Elements/Caching/ElementAtlas.uno
+++ b/Source/Fuse.Elements/Caching/ElementAtlas.uno
@@ -147,18 +147,10 @@ namespace Fuse.Elements
 			if (_invalidElements > 0)
 			{
 				Rect scissorRectInClipSpace = GetScissorRectInClipSpace(dc);
-				dc.PushRenderTarget(fb);
-
 				bool drawAll = _invalidElements == _elements.Count;
-				if (drawAll)
-				{
-					dc.Clear(float4(0), 1);
-					FillFramebuffer(dc, true, scissorRectInClipSpace);
-				} else
-					FillFramebuffer(dc, false, scissorRectInClipSpace);
-
-				dc.PopRenderTarget();
+				FillFramebuffer(dc, fb, drawAll, scissorRectInClipSpace);
 			}
+
 			return fb;
 		}
 
@@ -167,8 +159,12 @@ namespace Fuse.Elements
 			_framebuffer.Unpin();
 		}
 
-		void FillFramebuffer(DrawContext dc, bool drawAll, Rect scissorRectInClipSpace)
+		void FillFramebuffer(DrawContext dc, framebuffer fb, bool drawAll, Rect scissorRectInClipSpace)
 		{
+			// Changing the framebuffer is expensive. This loop actually doesn't draw anything in
+			// common case. Don't push the render target unless we actually have to render something.
+			var framebufferPushed = false;
+
 			var density = dc.ViewportPixelsPerPoint;
 			var viewport = (float2)_rectPacker.Size / density;
 			foreach (var elm in _elements)
@@ -186,6 +182,13 @@ namespace Fuse.Elements
 					var cc = new OrthographicFrustum{
 						Origin = float2(0, 0), Size = viewport,
 						LocalFromWorld = Matrix.Mul(elm.WorldTransformInverse, translation) };
+
+					if (!framebufferPushed)
+					{
+						dc.PushRenderTarget(fb);
+						if (drawAll) dc.Clear(float4(0), 1);
+						framebufferPushed = true;
+					}
 
 					dc.PushViewport( new FixedViewport(_rectPacker.Size, density, cc));
 
@@ -208,6 +211,9 @@ namespace Fuse.Elements
 					entry.IsValid = true;
 				}
 			}
+
+			if (framebufferPushed)
+				dc.PopRenderTarget();
 		}
 	}
 }

--- a/Source/Fuse.Elements/Caching/ElementAtlas.uno
+++ b/Source/Fuse.Elements/Caching/ElementAtlas.uno
@@ -163,6 +163,10 @@ namespace Fuse.Elements
 		{
 			// Changing the framebuffer is expensive. This loop actually doesn't draw anything in
 			// common case. Don't push the render target unless we actually have to render something.
+			// Note: _invalidElements may also be >0 after FillFramebuffer is called
+			// because we only repaint elements that are visible in the scissor rectangle
+			// This means that (_invalidElements > 0) doesn't imply that any painting is actually 
+			// going to happen this frame
 			var framebufferPushed = false;
 
 			var density = dc.ViewportPixelsPerPoint;


### PR DESCRIPTION
PinAndValidate sets rendertarget and calls FillFramebuffer, but often nothing is actually drawn. This postpones setting the rendertarget until actually needed.

Causes significant speedups on some platofrms.

This PR contains:
- [x] Changelog

