### PR TITLE
Optimize WindowToLocal by using FastMatrix to transform vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Optimization
+- Optimized hit testing calculations. Improves scrolling in large scroll views with deep trees inside, among other things.
+
 ## Attract
 - Added the `attract` feature, which was previously only in premiumlibs. This provides a much simpler syntax for animation than the `Attractor` behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-## Optimization
+## Optimizations
 - Optimized hit testing calculations. Improves scrolling in large scroll views with deep trees inside, among other things.
 - Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.
 

--- a/Source/Fuse.Common/FastMatrix.uno
+++ b/Source/Fuse.Common/FastMatrix.uno
@@ -7,6 +7,8 @@ namespace Fuse
 		float4x4 _matrix;
 		public float4x4 Matrix { get { return _matrix; } }
 
+		float3 Translation { get { return _matrix.M41M42M43; } }
+
 		bool _hasNonTranslation;
 		public bool HasNonTranslation { get { return _hasNonTranslation; } }
 		
@@ -209,6 +211,18 @@ namespace Fuse
 				_matrix.M41 += fm._matrix.M41;
 				_matrix.M42 += fm._matrix.M42;
 				_matrix.M43 += fm._matrix.M43;
+			}
+		}
+
+		public float3 TransformVector(float3 v)
+		{
+			if (_hasNonTranslation)
+			{
+				return Vector.TransformCoordinate(v, Matrix);
+			}
+			else
+			{
+				return v + Translation;
 			}
 		}
 	}

--- a/Source/Fuse.Nodes/Visual.Transform.uno
+++ b/Source/Fuse.Nodes/Visual.Transform.uno
@@ -256,8 +256,7 @@ namespace Fuse
 			if (HitTestTransform == HitTestTransformMode.LocalPoint)
 			{
 				var parentCoord = (Parent == null) ? windowCoord : Parent.WindowToLocal(windowCoord);
-
-				return Vector.TransformCoordinate(parentCoord, LocalTransformInverse);
+				return LocalTransformInverseInternal.TransformVector(float3(parentCoord,0)).XY;
 			}
 			else
 			{


### PR DESCRIPTION
The WindowToLocal function is called frequently while processing pointer events for hit testing. The old implementation did a full float4x4 vector transform for each node in the view heirarchy. This optimization delegates to FastMatrix to transform the vector, taking a fast path in the common case of translation-only.

This PR contains:
- [x] Changelog
