### PR TITLE
Optimized how WorldTransform is invalidated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 - Optimized invalidation strategy for transforms, to avoid subtree traversion. This improves performance generally when animating large subtrees (e.g. scrollviews).
 - Backwards incompatible optimization change: The `protected virtual void Visual.OnInvalidateWorldTransform()` method was removed. The contract of this method was very expensive to implement as it had to be called on all nodes, just in case it was overridden somewhere. If you have custom Uno code relying on this method (unlikely), then please rewrite to explicitly subscribe to the `Visual.WorldTransformInvalidated` event instead, like so: Override `OnRooted` and do `WorldTransformInvalidated += OnInvalidateWorldTransform;`, Override `OnUnrooted` and to `WorldTransformInvalidated -= OnInvalidateWorldTransform;`, then rewrite `protected override void OnInvalidateWorldTransform()` to `void OnInvalidateWorldTransform(object sender, EventArgs args)`
 
-
-
 ## Attract
 - Added the `attract` feature, which was previously only in premiumlibs. This provides a much simpler syntax for animation than the `Attractor` behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Optimizaitons
 - Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.
+- Optimized invalidation strategy for transforms, to avoid subtree traversion. This improves performance generally when animating large subtrees (e.g. scrollviews).
 
 ## Attract
 - Added the `attract` feature, which was previously only in premiumlibs. This provides a much simpler syntax for animation than the `Attractor` behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Optimizaitons
 - Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.
 - Optimized invalidation strategy for transforms, to avoid subtree traversion. This improves performance generally when animating large subtrees (e.g. scrollviews).
+- Backwards incompatible optimization change: The `protected virtual void Visual.OnInvalidateWorldTransform()` method was removed. The contract of this method was very expensive to implement as it had to be called on all nodes, just in case it was overridden somewhere. If you have custom Uno code relying on this method (unlikely), then please rewrite to explicitly subscribe to the `Visual.WorldTransformInvalidated` event instead, like so: Override `OnRooted` and do `WorldTransformInvalidated += OnInvalidateWorldTransform;`, Override `OnUnrooted` and to `WorldTransformInvalidated -= OnInvalidateWorldTransform;`, then rewrite `protected override void OnInvalidateWorldTransform()` to `void OnInvalidateWorldTransform(object sender, EventArgs args)`
+
+
 
 ## Attract
 - Added the `attract` feature, which was previously only in premiumlibs. This provides a much simpler syntax for animation than the `Attractor` behavior.

--- a/Source/Fuse.Controls.Panels/NativeViewHost.uno
+++ b/Source/Fuse.Controls.Panels/NativeViewHost.uno
@@ -310,6 +310,8 @@ namespace Fuse.Controls
 		extern(Android || iOS)
 		protected override void OnRooted()
 		{
+			WorldTransformInvalidated += OnInvalidateWorldTransform;
+
 			if (IsInGraphicsContext)
 			{
 				_glRenderer = new NativeViewRenderer();
@@ -392,6 +394,8 @@ namespace Fuse.Controls
 		extern(Android || iOS)
 		protected override void OnUnrooted()
 		{
+			WorldTransformInvalidated -= OnInvalidateWorldTransform;
+
 			if (IsInGraphicsContext && _proxyHost != null && !_offscreenEnabled)
 				_proxyHost.Remove(_root);
 
@@ -410,9 +414,8 @@ namespace Fuse.Controls
 			that responds to all local transform changes.
 		*/
 		extern(Android || iOS)
-		protected override void OnInvalidateWorldTransform()
+		void OnInvalidateWorldTransform(object sender, EventArgs args)
 		{
-			base.OnInvalidateWorldTransform();
 			if (RenderToTexture || !IsInGraphicsContext)
 				return;
 			PostUpdateTransform();

--- a/Source/Fuse.Controls.Panels/SingleViewHost.uno
+++ b/Source/Fuse.Controls.Panels/SingleViewHost.uno
@@ -106,10 +106,14 @@ namespace Fuse.Controls
 			_proxyHost = this.FindProxyHost();
 			if (RenderToTexture == RenderState.Disabled)
 				SetOnscreen();
+
+			WorldTransformInvalidated += OnInvalidateWorldTransform;
 		}
 
 		protected override void OnUnrooted()
 		{
+			WorldTransformInvalidated -= OnInvalidateWorldTransform;
+
 			base.OnUnrooted();
 			SetOffscreen();
 			_proxyHost = null;
@@ -135,9 +139,8 @@ namespace Fuse.Controls
 		}
 
 		bool _updateTransform = false;
-		protected override void OnInvalidateWorldTransform()
+		void OnInvalidateWorldTransform(object sender, EventArgs args)
 		{
-			base.OnInvalidateWorldTransform();
 			if (!_updateTransform)
 			{
 				UpdateManager.AddDeferredAction(UpdateHostViewTransform, UpdateStage.Layout, LayoutPriority.Post);

--- a/Source/Fuse.Nodes/Visual.Transform.uno
+++ b/Source/Fuse.Nodes/Visual.Transform.uno
@@ -60,19 +60,6 @@ namespace Fuse
 			InvalidateWorldTransform();
 		}
 
-		void InvalidateWorldTransform()
-		{
-			if (_worldTransform == null && _worldTransformInverse == null)
-				return;
-			_worldTransform = null;
-			_worldTransformInverse = null;
-			_worldTransformVersion++;
-
-			// Raises WorldTransformInvalidated for this and subtree 
-			// event implemented using special algorithm for performance reasons
-			RaiseWTI(); 
-		}
-
 		FastMatrix _worldTransformInverse;
 		public float4x4 WorldTransformInverse
 		{

--- a/Source/Fuse.Nodes/Visual.Transform.uno
+++ b/Source/Fuse.Nodes/Visual.Transform.uno
@@ -68,7 +68,7 @@ namespace Fuse
 			_worldTransformInverse = null;
 			_worldTransformVersion++;
 
-			// Raises WorldTransformInvalidated for subtree 
+			// Raises WorldTransformInvalidated for this and subtree 
 			// event implemented using special algorithm for performance reasons
 			RaiseWTI(); 
 		}

--- a/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
+++ b/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
@@ -65,6 +65,8 @@ namespace Fuse
 
 		void WTIRooted()
 		{
+			if (_wtiListeners != 0) throw new Exception(); // should never happen
+			
 			if (_worldTransformInvalidated != null)
 				IncrementWTIListener();
 		}
@@ -73,6 +75,8 @@ namespace Fuse
 		{
 			if (_worldTransformInvalidated != null)
 				DecrementWTIListener();
+
+			if (_wtiListeners != 0) throw new Exception(); // should never happen
 		}
 		
 		protected virtual void OnInvalidateWorldTransform() 

--- a/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
+++ b/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
@@ -67,7 +67,7 @@ namespace Fuse
 			{ 
 				_worldTransformInvalidated -= value;
 
-				if (_worldTransformInvalidated == null && IsRootingStarted)
+				if (_worldTransformInvalidated == null && Parent != null)
 					DecrementWTIListener();
 			}
 		}

--- a/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
+++ b/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
@@ -1,0 +1,85 @@
+using Uno;
+using Uno.Collections;
+using Uno.UX;
+using Uno.Matrix;
+
+namespace Fuse
+{
+	/*
+		This file implements the WorldTransformInvalidated event and calls the OnInvalidateWorldTransform method, 
+		which due to optimizations can not be generated the intuitive way anymore. 
+
+		The implementation is based on counting how many listeners there are in the subtree, at rooting time.
+		This allows us to traverse the precise path down to the listeners instead of traversing the entire
+		subtree, as well as early-out immedtiately if there are no listeners in the subtree.
+	*/
+
+	public partial class Visual
+	{
+		int _wtiListeners;
+		void IncrementWTIListener()
+		{
+			_wtiListeners++;
+			if (Parent != null) Parent.IncrementWTIListener();
+		}
+
+		void DecrementWTIListener()
+		{
+			_wtiListeners--;
+			if (Parent != null) Parent.DecrementWTIListener();
+		}
+
+		void RaiseWTI()
+		{
+			if (_wtiListeners == 0) return;
+
+			OnInvalidateWorldTransform();
+
+			for (var i = 0; i < Children.Count; i++)
+			{
+				var v = Children[i] as Visual;
+				if (v != null) v.RaiseWTI();
+			}
+		}
+
+		event EventHandler _worldTransformInvalidated;
+		/** @advanced
+		*/
+		public event EventHandler WorldTransformInvalidated
+		{
+			add 
+			{ 
+				if (_worldTransformInvalidated == null && IsRootingStarted)
+					IncrementWTIListener();
+
+				_worldTransformInvalidated += value;
+			}
+			remove 
+			{ 
+				_worldTransformInvalidated -= value;
+
+				if (_worldTransformInvalidated == null && IsRootingStarted)
+					DecrementWTIListener();
+			}
+		}
+
+		void WTIRooted()
+		{
+			if (_worldTransformInvalidated != null)
+				IncrementWTIListener();
+		}
+
+		void WTIUnrooted()
+		{
+			if (_worldTransformInvalidated != null)
+				DecrementWTIListener();
+		}
+		
+		protected virtual void OnInvalidateWorldTransform() 
+		{ 
+			if (_worldTransformInvalidated != null)
+				_worldTransformInvalidated(this, EventArgs.Empty);
+		}
+
+	}
+}

--- a/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
+++ b/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
@@ -29,16 +29,25 @@ namespace Fuse
 			if (Parent != null) Parent.DecrementWTIListener();
 		}
 
-		void RaiseWTI()
+		void InvalidateWorldTransform()
 		{
-			if (_wtiListeners == 0) return;
-
-			OnInvalidateWorldTransform();
-
-			for (var i = 0; i < Children.Count; i++)
+			_worldTransformVersion++;
+			if (_worldTransform != null || _worldTransformInverse != null)
 			{
-				var v = Children[i] as Visual;
-				if (v != null) v.RaiseWTI();
+				_worldTransform = null;
+				_worldTransformInverse = null;
+			}
+			
+			if (_worldTransformInvalidated != null)
+				_worldTransformInvalidated(this, EventArgs.Empty);
+
+			if (_wtiListeners > 0) 
+			{
+				for (var i = 0; i < Children.Count; i++)
+				{
+					var v = Children[i] as Visual;
+					if (v != null) v.InvalidateWorldTransform();
+				}
 			}
 		}
 
@@ -78,12 +87,5 @@ namespace Fuse
 
 			if (_wtiListeners != 0) throw new Exception(); // should never happen
 		}
-		
-		protected virtual void OnInvalidateWorldTransform() 
-		{ 
-			if (_worldTransformInvalidated != null)
-				_worldTransformInvalidated(this, EventArgs.Empty);
-		}
-
 	}
 }

--- a/Source/Fuse.Nodes/Visual.uno
+++ b/Source/Fuse.Nodes/Visual.uno
@@ -128,7 +128,6 @@ namespace Fuse
 
 			UnrootResources();
 			UnrootTemplates();
-			WTIUnrooted();
 			_viewport = null;
 
 			ResetParameterListeners();
@@ -148,6 +147,8 @@ namespace Fuse
 						iter.Current.UnrootInternal();
 				}
 			}
+
+			WTIUnrooted();
 
 			ConcludePendingRemove();
 		}

--- a/Source/Fuse.Nodes/Visual.uno
+++ b/Source/Fuse.Nodes/Visual.uno
@@ -94,6 +94,7 @@ namespace Fuse
 			UpdateIsContextEnabledCache();
 			UpdateIsVisibleCache();
 			UpdateContextSnapToPixelsCache();
+			WTIRooted();
 
 			OnRootedPreChildren();
 
@@ -127,6 +128,7 @@ namespace Fuse
 
 			UnrootResources();
 			UnrootTemplates();
+			WTIUnrooted();
 			_viewport = null;
 
 			ResetParameterListeners();


### PR DESCRIPTION
Optimized invalidation strategy for transforms, to avoid subtree traversion. This improves performance generally when animating large subtrees (e.g. scrollviews).

This required a new implementation strategy for emitting the WorldTransformInvalidated event, as we are no longer traversing the subtree eagerly to generate these events.

This PR contains:
- [x] Changelog

@mortoray - please evaluate carefully whether we have enough test coverage to safely make this optimization. If not, any help to extend the test coverage is highly appreciated.