### PR TITLE
NativeViewHost: listen to WorldTransform after base.OnRooted

### DIFF
--- a/Source/Fuse.Controls.Panels/NativeViewHost.uno
+++ b/Source/Fuse.Controls.Panels/NativeViewHost.uno
@@ -310,8 +310,6 @@ namespace Fuse.Controls
 		extern(Android || iOS)
 		protected override void OnRooted()
 		{
-			WorldTransformInvalidated += OnInvalidateWorldTransform;
-
 			if (IsInGraphicsContext)
 			{
 				_glRenderer = new NativeViewRenderer();
@@ -332,6 +330,7 @@ namespace Fuse.Controls
 					Fuse.Diagnostics.InternalError(this + " does not have an IProxyHost and will malfunction");
 			}
 			base.OnRooted();
+			WorldTransformInvalidated += OnInvalidateWorldTransform;
 		}
 
 		extern(Android || iOS)


### PR DESCRIPTION
WorldTransformInvalidated can only be listened to after base.OnRooted is done

Fixes https://github.com/fusetools/fuselibs-public/issues/154

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
