### PR TITLE
(restored) Optimized invalidation strategy for transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Optimizations
 - Optimized hit testing calculations. Improves scrolling in large scroll views with deep trees inside, among other things.
 - Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.
+- Optimized invalidation strategy for transforms, to avoid subtree traversion. This improves performance generally when animating large subtrees (e.g. scrollviews).
+- Backwards incompatible optimization change: The `protected virtual void Visual.OnInvalidateWorldTransform()` method was removed. The contract of this method was very expensive to implement as it had to be called on all nodes, just in case it was overridden somewhere. If you have custom Uno code relying on this method (unlikely), then please rewrite to explicitly subscribe to the `Visual.WorldTransformInvalidated` event instead, like so: Override `OnRooted` and do `WorldTransformInvalidated += OnInvalidateWorldTransform;`, Override `OnUnrooted` and to `WorldTransformInvalidated -= OnInvalidateWorldTransform;`, then rewrite `protected override void OnInvalidateWorldTransform()` to `void OnInvalidateWorldTransform(object sender, EventArgs args)`
 - To improve rendering speed, Fuse no longer checks for OpenGL errors in release builds in some performance-critical code paths  
 
 ## Attract

--- a/Source/Fuse.Controls.Panels/NativeViewHost.uno
+++ b/Source/Fuse.Controls.Panels/NativeViewHost.uno
@@ -310,6 +310,8 @@ namespace Fuse.Controls
 		extern(Android || iOS)
 		protected override void OnRooted()
 		{
+			WorldTransformInvalidated += OnInvalidateWorldTransform;
+
 			if (IsInGraphicsContext)
 			{
 				_glRenderer = new NativeViewRenderer();
@@ -392,6 +394,8 @@ namespace Fuse.Controls
 		extern(Android || iOS)
 		protected override void OnUnrooted()
 		{
+			WorldTransformInvalidated -= OnInvalidateWorldTransform;
+
 			if (IsInGraphicsContext && _proxyHost != null && !_offscreenEnabled)
 				_proxyHost.Remove(_root);
 
@@ -410,9 +414,8 @@ namespace Fuse.Controls
 			that responds to all local transform changes.
 		*/
 		extern(Android || iOS)
-		protected override void OnInvalidateWorldTransform()
+		void OnInvalidateWorldTransform(object sender, EventArgs args)
 		{
-			base.OnInvalidateWorldTransform();
 			if (RenderToTexture || !IsInGraphicsContext)
 				return;
 			PostUpdateTransform();

--- a/Source/Fuse.Controls.Panels/SingleViewHost.uno
+++ b/Source/Fuse.Controls.Panels/SingleViewHost.uno
@@ -106,10 +106,14 @@ namespace Fuse.Controls
 			_proxyHost = this.FindProxyHost();
 			if (RenderToTexture == RenderState.Disabled)
 				SetOnscreen();
+
+			WorldTransformInvalidated += OnInvalidateWorldTransform;
 		}
 
 		protected override void OnUnrooted()
 		{
+			WorldTransformInvalidated -= OnInvalidateWorldTransform;
+
 			base.OnUnrooted();
 			SetOffscreen();
 			_proxyHost = null;
@@ -135,9 +139,8 @@ namespace Fuse.Controls
 		}
 
 		bool _updateTransform = false;
-		protected override void OnInvalidateWorldTransform()
+		void OnInvalidateWorldTransform(object sender, EventArgs args)
 		{
-			base.OnInvalidateWorldTransform();
 			if (!_updateTransform)
 			{
 				UpdateManager.AddDeferredAction(UpdateHostViewTransform, UpdateStage.Layout, LayoutPriority.Post);

--- a/Source/Fuse.Nodes/Visual.Transform.uno
+++ b/Source/Fuse.Nodes/Visual.Transform.uno
@@ -60,37 +60,14 @@ namespace Fuse
 			InvalidateWorldTransform();
 		}
 
-		void InvalidateWorldTransform()
-		{
-			if (_worldTransform == null && _worldTransformInverse == null)
-				return;
-			_worldTransform = null;
-			_worldTransformInverse = null;
-			for (int i=0; i < ZOrderChildCount; i++)
-				GetZOrderChild(i).InvalidateWorldTransform();
-				
-			OnInvalidateWorldTransform();
-		}
-		
-		static PropertyHandle _worldTransformInvalidatedHandle = Fuse.Properties.CreateHandle();
-		/** @advanced
-		*/
-		public event EventHandler WorldTransformInvalidated
-		{
-			add { AddEventHandler(_worldTransformInvalidatedHandle, VisualBits.WorldTransformInvalidated, value); }
-			remove { RemoveEventHandler(_worldTransformInvalidatedHandle, VisualBits.WorldTransformInvalidated, value); }
-		}
-		
-		protected virtual void OnInvalidateWorldTransform() 
-		{ 
-			RaiseEvent(_worldTransformInvalidatedHandle, VisualBits.WorldTransformInvalidated);
-		}
-
 		FastMatrix _worldTransformInverse;
 		public float4x4 WorldTransformInverse
 		{
 			get
 			{
+				if (_worldTransformInverse != null)
+					CheckWorldTransformVersion();
+
 				if (_worldTransformInverse == null)
 				{
 					_worldTransformInverse = WorldTransformInternal.Copy();
@@ -118,11 +95,34 @@ namespace Fuse
 			get { return new Box(float3(0), float3(0)); }
 		}
 
+		int _worldTransformVersion;
+		int _parentWorldTransformVersion;
+
+		void CheckWorldTransformVersion()
+		{
+			if (_worldTransform != null || _worldTransformInverse != null)
+				if (Parent != null)
+				{
+					Parent.CheckWorldTransformVersion();
+				
+					if (_parentWorldTransformVersion != Parent._worldTransformVersion)
+					{
+						_parentWorldTransformVersion = Parent._worldTransformVersion;
+						_worldTransform = null;
+						_worldTransformInverse = null;
+						_worldTransformVersion++;
+					}
+				}
+		}
+
 		FastMatrix _worldTransform;
 		FastMatrix WorldTransformInternal
 		{
 			get
 			{
+				if (_worldTransform != null)
+					CheckWorldTransformVersion();
+				
 				if (_worldTransform == null)
 					_worldTransform = CalcWorldTransform();
 				return _worldTransform;

--- a/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
+++ b/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
@@ -58,7 +58,7 @@ namespace Fuse
 		{
 			add 
 			{ 
-				if (_worldTransformInvalidated == null && IsRootingCompleted)
+				if (_worldTransformInvalidated == null && _wtiRooted)
 					IncrementWTIListener();
 
 				_worldTransformInvalidated += value;
@@ -67,14 +67,18 @@ namespace Fuse
 			{ 
 				_worldTransformInvalidated -= value;
 
-				if (_worldTransformInvalidated == null && Parent != null)
+				if (_worldTransformInvalidated == null && _wtiRooted)
 					DecrementWTIListener();
 			}
 		}
 
+		bool _wtiRooted;
+
 		void WTIRooted()
 		{
-			if (_wtiListeners != 0) throw new Exception(); // should never happen
+			_wtiRooted = true;
+			if (_wtiListeners != 0)
+				throw new Exception(); // should never happen
 			
 			if (_worldTransformInvalidated != null)
 				IncrementWTIListener();
@@ -82,10 +86,13 @@ namespace Fuse
 
 		void WTIUnrooted()
 		{
+			_wtiRooted = false;
+
 			if (_worldTransformInvalidated != null)
 				DecrementWTIListener();
 
-			if (_wtiListeners != 0) throw new Exception(); // should never happen
+			if (_wtiListeners != 0)
+				throw new Exception(); // should never happen
 		}
 	}
 }

--- a/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
+++ b/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
@@ -1,0 +1,91 @@
+using Uno;
+using Uno.Collections;
+using Uno.UX;
+using Uno.Matrix;
+
+namespace Fuse
+{
+	/*
+		This file implements the WorldTransformInvalidated event and calls the OnInvalidateWorldTransform method, 
+		which due to optimizations can not be generated the intuitive way anymore. 
+
+		The implementation is based on counting how many listeners there are in the subtree, at rooting time.
+		This allows us to traverse the precise path down to the listeners instead of traversing the entire
+		subtree, as well as early-out immedtiately if there are no listeners in the subtree.
+	*/
+
+	public partial class Visual
+	{
+		int _wtiListeners;
+		void IncrementWTIListener()
+		{
+			_wtiListeners++;
+			if (Parent != null) Parent.IncrementWTIListener();
+		}
+
+		void DecrementWTIListener()
+		{
+			_wtiListeners--;
+			if (Parent != null) Parent.DecrementWTIListener();
+		}
+
+		void InvalidateWorldTransform()
+		{
+			_worldTransformVersion++;
+			if (_worldTransform != null || _worldTransformInverse != null)
+			{
+				_worldTransform = null;
+				_worldTransformInverse = null;
+			}
+			
+			if (_worldTransformInvalidated != null)
+				_worldTransformInvalidated(this, EventArgs.Empty);
+
+			if (_wtiListeners > 0) 
+			{
+				for (var i = 0; i < Children.Count; i++)
+				{
+					var v = Children[i] as Visual;
+					if (v != null) v.InvalidateWorldTransform();
+				}
+			}
+		}
+
+		event EventHandler _worldTransformInvalidated;
+		/** @advanced
+		*/
+		public event EventHandler WorldTransformInvalidated
+		{
+			add 
+			{ 
+				if (_worldTransformInvalidated == null && IsRootingCompleted)
+					IncrementWTIListener();
+
+				_worldTransformInvalidated += value;
+			}
+			remove 
+			{ 
+				_worldTransformInvalidated -= value;
+
+				if (_worldTransformInvalidated == null && Parent != null)
+					DecrementWTIListener();
+			}
+		}
+
+		void WTIRooted()
+		{
+			if (_wtiListeners != 0) throw new Exception(); // should never happen
+			
+			if (_worldTransformInvalidated != null)
+				IncrementWTIListener();
+		}
+
+		void WTIUnrooted()
+		{
+			if (_worldTransformInvalidated != null)
+				DecrementWTIListener();
+
+			if (_wtiListeners != 0) throw new Exception(); // should never happen
+		}
+	}
+}

--- a/Source/Fuse.Nodes/Visual.uno
+++ b/Source/Fuse.Nodes/Visual.uno
@@ -94,6 +94,7 @@ namespace Fuse
 			UpdateIsContextEnabledCache();
 			UpdateIsVisibleCache();
 			UpdateContextSnapToPixelsCache();
+			WTIRooted();
 
 			OnRootedPreChildren();
 
@@ -146,6 +147,8 @@ namespace Fuse
 						iter.Current.UnrootInternal();
 				}
 			}
+
+			WTIUnrooted();
 
 			ConcludePendingRemove();
 		}


### PR DESCRIPTION
Avoids subtree traversion on world transform invalidation. This improves performance generally when animating large subtrees (e.g. scrollviews).

This is a restoration of what was reverted in https://github.com/fusetools/fuselibs-public/commit/da640d44aa6633c51ea8578a09ae92a1404dc4f5

Fixes https://github.com/fusetools/fuselibs-public/issues/154

This PR contains:
- [x] Changelog