### PR TITLE
Fuse.Share: Fixed iPad crash bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - `Each`, using `TemplateSource`, will no longer respond to template changes after rooting. This was done to simplify the code, and to support alternate sources, and is a minor perf improvement. It's not likely to affect any code since it didn't work correctly, and there's no way in UX to modify templates after rooting.
 - A memory leak was fixed by changing `Instantiator.TemplateSource` to a WeakReference. Only if you assigned this property a tempoary value in Uno would this change impact your code.
 
+## Fuse.Share
+- Fixed issue where using Fuse.Share would crash on iPad. Users must provide a position for spawn origin for the share popover. Check the Fuse.Share docs for more details.
+- Made iOS implementation internal, this was never ment to be public in the first place
+
 ## Optimizations
 - Optimized hit testing calculations. Improves scrolling in large scroll views with deep trees inside, among other things.
 - Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.

--- a/Source/Fuse.Share/Fuse.Share.unoproj
+++ b/Source/Fuse.Share/Fuse.Share.unoproj
@@ -8,7 +8,10 @@
     "Uno.Permissions",
   ],
   "Projects": [
-    "../Fuse.Scripting/Fuse.Scripting.unoproj"
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Elements/Fuse.Elements.unoproj"
   ],
   "Includes": [
     "*"


### PR DESCRIPTION
iOS design guidelines requires a point of reference for use as the popover spawn origin. Added an optional argument to the share api for passing a UX element for use as the spawn origin. If the user does not provide this, emit a UserError and the popover will spawn in a default location

Not to happy about this fix. Makes the share API clunky. I think the Share API should be UX based instead of JS

This PR contains:
- [x] Changelog
- [x] Documentation
- [ ] Tests
