### PR TITLE
Optimization: Repairs the broken FastTrackDrawWithOpacity feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Optimized hit testing calculations. Improves scrolling in large scroll views with deep trees inside, among other things.
 - Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.
 - To improve rendering speed, Fuse no longer checks for OpenGL errors in release builds in some performance-critical code paths  
+- Fixed a bug which prevented elements like `Image` to use fast-track rendering in trivial cases with opacity (avoids render to texture).
 
 ## Attract
 - Added the `attract` feature, which was previously only in premiumlibs. This provides a much simpler syntax for animation than the `Attractor` behavior.

--- a/Source/Fuse.Controls.Panels/LayoutControl.uno
+++ b/Source/Fuse.Controls.Panels/LayoutControl.uno
@@ -193,5 +193,14 @@ namespace Fuse.Controls
 				return LayoutDependent.Maybe;
 			}
 		}
+
+		protected override bool FastTrackDrawWithOpacity(DrawContext dc)
+		{
+			if (HasChildren) return false;
+			if (Background == null) return true;
+			
+			DrawBackground(dc, Opacity);
+			return base.FastTrackDrawWithOpacity(dc);
+		}
 	}
 }

--- a/Source/Fuse.Controls.Panels/Panel.Freeze.uno
+++ b/Source/Fuse.Controls.Panels/Panel.Freeze.uno
@@ -181,11 +181,7 @@ namespace Fuse.Controls
 				FreezeDrawable.Singleton.Draw(dc, this, Opacity, Scale, _frozenRenderBounds, _frozenBuffer);
 				return true;
 			}
-			
-			if (HasChildren) return false;
-			if (Background == null) return true;
-			
-			DrawBackground(dc, Opacity);
+
 			return base.FastTrackDrawWithOpacity(dc);
 		}
 


### PR DESCRIPTION
When LayoutControl and Panel were split back in the days, it seems the FastTrackDrawWithOpacity was forgotten. The result has been that e.g. images don't use the fast track when they have nontrivial opacity, resulting in a redundant framebuffer allocation and render to texture.

This fixes it.

This PR contains:
- [x] Changelog
