### PR TITLE
Feature repair fast track draw with opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Optimized hit testing calculations. Improves scrolling in large scroll views with deep trees inside, among other things.
 - Optimized redundant OpenGL rendertarget operations. Gives speedups on some platforms.
 - To improve rendering speed, Fuse no longer checks for OpenGL errors in release builds in some performance-critical code paths  
+- Fixed a bug which prevented elements like `Image` to use fast-track rendering in trivial cases with opacity (avoids render to texture).
 
 ## Multitouch
 - Fixed issue where during multitouch all input would stop if one finger was lifted.

--- a/Source/Fuse.Controls.Panels/LayoutControl.uno
+++ b/Source/Fuse.Controls.Panels/LayoutControl.uno
@@ -197,10 +197,12 @@ namespace Fuse.Controls
 		protected override bool FastTrackDrawWithOpacity(DrawContext dc)
 		{
 			if (HasChildren) return false;
-			if (Background == null) return true;
 			
-			DrawBackground(dc, Opacity);
-			return base.FastTrackDrawWithOpacity(dc);
+			if (Background != null)
+				DrawBackground(dc, Opacity);
+			
+			// Asserting base class doesn't need to draw anything!
+			return true;
 		}
 	}
 }

--- a/Source/Fuse.Controls.Panels/LayoutControl.uno
+++ b/Source/Fuse.Controls.Panels/LayoutControl.uno
@@ -193,5 +193,14 @@ namespace Fuse.Controls
 				return LayoutDependent.Maybe;
 			}
 		}
+
+		protected override bool FastTrackDrawWithOpacity(DrawContext dc)
+		{
+			if (HasChildren) return false;
+			if (Background == null) return true;
+			
+			DrawBackground(dc, Opacity);
+			return base.FastTrackDrawWithOpacity(dc);
+		}
 	}
 }

--- a/Source/Fuse.Controls.Panels/Panel.Freeze.uno
+++ b/Source/Fuse.Controls.Panels/Panel.Freeze.uno
@@ -181,11 +181,7 @@ namespace Fuse.Controls
 				FreezeDrawable.Singleton.Draw(dc, this, Opacity, Scale, _frozenRenderBounds, _frozenBuffer);
 				return true;
 			}
-			
-			if (HasChildren) return false;
-			if (Background == null) return true;
-			
-			DrawBackground(dc, Opacity);
+
 			return base.FastTrackDrawWithOpacity(dc);
 		}
 

--- a/Source/Fuse.Elements/Element.Effects.uno
+++ b/Source/Fuse.Elements/Element.Effects.uno
@@ -106,7 +106,7 @@ namespace Fuse.Elements
 				return;
 			}
 
-			if (FastTrackDrawWithOpacity(dc))
+			if (!HasActiveEffects && FastTrackDrawWithOpacity(dc))
 			{
 				return;
 			}


### PR DESCRIPTION
When LayoutControl and Panel were split back in the days, it seems the FastTrackDrawWithOpacity was forgotten. The result has been that e.g. images don't use the fast track when they have nontrivial opacity, resulting in a redundant framebuffer allocation and render to texture.

This fixes it.

This PR contains:
- [x] Changelog
