### PR TITLE
Remove unnecessary render bounds inflation in FuseTextRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Optimized invalidation strategy for transforms, to avoid subtree traversion. This improves performance generally when animating large subtrees (e.g. scrollviews).
 - Backwards incompatible optimization change: The `protected virtual void Visual.OnInvalidateWorldTransform()` method was removed. The contract of this method was very expensive to implement as it had to be called on all nodes, just in case it was overridden somewhere. If you have custom Uno code relying on this method (unlikely), then please rewrite to explicitly subscribe to the `Visual.WorldTransformInvalidated` event instead, like so: Override `OnRooted` and do `WorldTransformInvalidated += OnInvalidateWorldTransform;`, Override `OnUnrooted` and to `WorldTransformInvalidated -= OnInvalidateWorldTransform;`, then rewrite `protected override void OnInvalidateWorldTransform()` to `void OnInvalidateWorldTransform(object sender, EventArgs args)`
 - To improve rendering speed, Fuse no longer checks for OpenGL errors in release builds in some performance-critical code paths  
+- Tightened up render bounds for text rendered with harfbuzz. Reduces overdraw significantly.
 
 ## Multitouch
 - Fixed issue where during multitouch all input would stop if one finger was lifted.

--- a/Source/Fuse.Controls.Primitives/TextControls/FuseTextRenderer/FuseTextRenderer.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/FuseTextRenderer/FuseTextRenderer.uno
@@ -213,7 +213,7 @@ namespace Fuse.Controls.FuseTextRenderer
 			_cacheState = _cacheState.GetBounds(CreateTextControlData(), out bounds);
 
 			return Rect.Scale(
-				Rect.Inflate(bounds, 2 * Font.Value.LineHeight),
+				bounds,
 				1 / _control.Viewport.PixelsPerPoint);
 		}
 


### PR DESCRIPTION
Currently, `FuseTextRenderer` is [inflating its renderbounds significantly](https://github.com/fusetools/fuselibs-public/blob/fddc657cde5c877b0add26283885358a57623e68/Source/Fuse.Controls.Primitives/TextControls/FuseTextRenderer/FuseTextRenderer.uno#L216). From what I can tell there's no good reason for this; the text measuring is already conservative wrt glyph sizes and appears to be producing very sensible bounds already. My guess is this was left over from some testing when the renderer was first introduced just to be safe, but now it just seems excessive.

Fixes #176.

This PR contains:
- [x] Changelog
