### PR TITLE
Revert "Move IncreaseFrameIndex to prior to Update to make it consist…

### DIFF
--- a/Source/Fuse.Nodes/AppBase.uno
+++ b/Source/Fuse.Nodes/AppBase.uno
@@ -281,12 +281,11 @@ namespace Fuse
 			be overridden in user code. Use @UpdateManager instead. */
 		protected virtual void OnUpdate()
 		{
-			UpdateManager.IncreaseFrameIndex();
-
 			if defined(FUSELIBS_PROFILING)
 				Profiling.BeginUpdate();
 
 			UpdateManager.Update();
+			UpdateManager.IncreaseFrameIndex();
 
 			if defined(FUSELIBS_PROFILING)
 				Profiling.EndUpdate();


### PR DESCRIPTION
…ent across platforms"

This reverts commit 81eae3e47960ee0624de073d5d702005b0de9e0e.

This commit causes inconsistent frame index for input events, causing
issue #182 and likely some other problems we haven't caught yet.