### PR TITLE
make sure IncreaseFrameIndex happens right after draw

### DIFF
--- a/Source/Fuse.Desktop/DesktopApp.uno
+++ b/Source/Fuse.Desktop/DesktopApp.uno
@@ -66,6 +66,8 @@ namespace Fuse
 
 			if defined(FUSELIBS_PROFILING)
 				Profiling.EndDraw();
+
+			UpdateManager.IncreaseFrameIndex();
 		}
 
 		public override bool NeedsRedraw 

--- a/Source/Fuse.Nodes/AppBase.uno
+++ b/Source/Fuse.Nodes/AppBase.uno
@@ -281,12 +281,13 @@ namespace Fuse
 			be overridden in user code. Use @UpdateManager instead. */
 		protected virtual void OnUpdate()
 		{
-			UpdateManager.IncreaseFrameIndex();
-
 			if defined(FUSELIBS_PROFILING)
 				Profiling.BeginUpdate();
 
 			UpdateManager.Update();
+
+			if defined(MOBILE)
+				UpdateManager.IncreaseFrameIndex();
 
 			if defined(FUSELIBS_PROFILING)
 				Profiling.EndUpdate();


### PR DESCRIPTION
Doing things like InvalidateVisual in response to input requires that
the UpdateManager.FrameIndex was increased right after drawing, because
otherwise the frame index will be the same when the input happens,
causing elements that were validated the same frame to not be
invalidated.

This problem was introduced in 81eae3e, where another similar issue
was worked around. This should fix both cases.

Fixes issue #182

Unfortunately, this doesn't seem to be possible to write a test-case for,
because the logic happens in AppBase, and we don't have an instance
of that during `uno test`.