### PR TITLE
Prevents JavaScript from crashing when dependencies have reserved ES5.1 names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## JavaScript
+- Fixed a bug where if any injected dependencies to a JavaScript (e.g. `ux:Name`, `ux:Dependency`, `dep:`) have names that correspond to EcmaScript 5.1 reserved words, these dependencies will now be available with a dollar sign `$` prefix (e.g. `$undefined`) instead of causing a script compile error.
+
 ## Templates
 - Triggers may now use templates which will be instantiated and added to the parent when active (like a node child).
 	<WhileActive>

--- a/Source/Fuse.Reactive.JavaScript/JavaScript.ReservedWords.uno
+++ b/Source/Fuse.Reactive.JavaScript/JavaScript.ReservedWords.uno
@@ -1,0 +1,31 @@
+using Uno.Collections;
+
+namespace Fuse.Reactive
+{
+	partial class JavaScript
+	{
+		// Taken from the ECMAScript 5.1 Standard
+		// https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262%205th%20edition%20December%202009.pdf
+		static HashSet<string> _reservedKeywords = new HashSet<string>()
+		{
+			"break", "do", "instanceof", "typeof",
+			"case", "else", "new", "var",
+			"catch", "finally", "return", "void",
+			"continue", "for", "switch", "while",
+			"debugger", "function", "this", "with",
+			"default", "if", "throw",
+			"delete", "in", "try", 
+			"undefined" // not actually a reserved word in the spec, but most linters etc treat it as such
+		};
+
+		internal static bool IsReservedKeyword(string s)
+		{
+			return _reservedKeywords.Contains(s);
+		}
+
+		internal static string ToValidName(string name)
+		{
+			return IsReservedKeyword(name) ? "$" + name : name;
+		}
+	}
+}

--- a/Source/Fuse.Reactive.JavaScript/ObservableProperty.uno
+++ b/Source/Fuse.Reactive.JavaScript/ObservableProperty.uno
@@ -8,7 +8,7 @@ namespace Fuse.Reactive
 	{
 		public LazyObservableProperty(ThreadWorker w, Scripting.Object obj, Property p): base(w, obj, p)
 		{
-			w.Context.ObjectDefineProperty(obj, p.Name.ToString(), Get);	
+			w.Context.ObjectDefineProperty(obj, JSName, Get);	
 		}
 
 		object Get(object[] args)
@@ -37,6 +37,11 @@ namespace Fuse.Reactive
 		}
 
 		public string Name { get { return _property.Name; } }
+
+		protected string JSName
+		{
+			get { return JavaScript.ToValidName(Name); }
+		}
 
 		Observable _observable;
 

--- a/Source/Fuse.Reactive.JavaScript/RootableScriptModule.uno
+++ b/Source/Fuse.Reactive.JavaScript/RootableScriptModule.uno
@@ -50,8 +50,10 @@ namespace Fuse.Reactive
 				for (int i = 0; i < nt.Entries.Length; ++i)
 				{
 					var name = nt.Entries[i];
+					if (name == "this") continue;
+					
 					var key = IsReservedKeyword(name) ? "$" + name : name;
-					argsString += ", " + nt.Entries[i];
+					argsString += ", " + key;
 					args.Add(_worker.Unwrap(nt.Objects[i]));
 				}
 				nt = nt.ParentTable;
@@ -70,7 +72,8 @@ namespace Fuse.Reactive
 			"continue", "for", "switch", "while",
 			"debugger", "function", "this", "with",
 			"default", "if", "throw",
-			"delete", "in", "try"
+			"delete", "in", "try", 
+			"undefined" // not actually a reserved word in the spec, but most linters etc treat it as such
 		};
 
 		static bool IsReservedKeyword(string s)

--- a/Source/Fuse.Reactive.JavaScript/RootableScriptModule.uno
+++ b/Source/Fuse.Reactive.JavaScript/RootableScriptModule.uno
@@ -39,8 +39,7 @@ namespace Fuse.Reactive
 
 			foreach (var dep in Dependencies) 
 			{
-				var key = IsReservedKeyword(dep.Key) ? "$" + dep.Key : dep.Key;
-				argsString += ", " + key;
+				argsString += ", " + JavaScript.ToValidName(dep.Key);
 				args.Add(dep.Value);
 			}
 
@@ -52,33 +51,13 @@ namespace Fuse.Reactive
 					var name = nt.Entries[i];
 					if (name == "this") continue;
 					
-					var key = IsReservedKeyword(name) ? "$" + name : name;
-					argsString += ", " + key;
+					argsString += ", " + JavaScript.ToValidName(name);
 					args.Add(_worker.Unwrap(nt.Objects[i]));
 				}
 				nt = nt.ParentTable;
 			}
 
 			return argsString;
-		}
-
-		// Taken from the ECMAScript 5.1 Standard
-		// https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262%205th%20edition%20December%202009.pdf
-		static HashSet<string> _reservedKeywords = new HashSet<string>()
-		{
-			"break", "do", "instanceof", "typeof",
-			"case", "else", "new", "var",
-			"catch", "finally", "return", "void",
-			"continue", "for", "switch", "while",
-			"debugger", "function", "this", "with",
-			"default", "if", "throw",
-			"delete", "in", "try", 
-			"undefined" // not actually a reserved word in the spec, but most linters etc treat it as such
-		};
-
-		static bool IsReservedKeyword(string s)
-		{
-			return _reservedKeywords.Contains(s);
 		}
 
 		protected override void CallModuleFunc(Function moduleFunc, object[] args)

--- a/Source/Fuse.Reactive.JavaScript/RootableScriptModule.uno
+++ b/Source/Fuse.Reactive.JavaScript/RootableScriptModule.uno
@@ -39,7 +39,8 @@ namespace Fuse.Reactive
 
 			foreach (var dep in Dependencies) 
 			{
-				argsString += ", " + dep.Key;
+				var key = IsReservedKeyword(dep.Key) ? "$" + dep.Key : dep.Key;
+				argsString += ", " + key;
 				args.Add(dep.Value);
 			}
 
@@ -48,6 +49,8 @@ namespace Fuse.Reactive
 			{
 				for (int i = 0; i < nt.Entries.Length; ++i)
 				{
+					var name = nt.Entries[i];
+					var key = IsReservedKeyword(name) ? "$" + name : name;
 					argsString += ", " + nt.Entries[i];
 					args.Add(_worker.Unwrap(nt.Objects[i]));
 				}
@@ -55,6 +58,24 @@ namespace Fuse.Reactive
 			}
 
 			return argsString;
+		}
+
+		// Taken from the ECMAScript 5.1 Standard
+		// https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262%205th%20edition%20December%202009.pdf
+		static HashSet<string> _reservedKeywords = new HashSet<string>()
+		{
+			"break", "do", "instanceof", "typeof",
+			"case", "else", "new", "var",
+			"catch", "finally", "return", "void",
+			"continue", "for", "switch", "while",
+			"debugger", "function", "this", "with",
+			"default", "if", "throw",
+			"delete", "in", "try"
+		};
+
+		static bool IsReservedKeyword(string s)
+		{
+			return _reservedKeywords.Contains(s);
 		}
 
 		protected override void CallModuleFunc(Function moduleFunc, object[] args)

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/JavaScript.ReservedWord.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/JavaScript.ReservedWord.ux
@@ -1,0 +1,14 @@
+<Panel ux:Class="UX.JavaScriptReservedWord">
+	<Panel ux:Class="UX.JSReserved">
+		<Router ux:Name="undefined" />
+		<string ux:Dependency="function" />
+		<bool ux:Property="instanceof" />
+		<JavaScript dep:debugger="10">
+			if ($debugger !== 10) throw new Error();
+			if (!($undefined.goto instanceof Function)) throw new Error();
+			if ($function !== "yay!") throw new Error();
+			this.$instanceof.value = true;
+		</JavaScript>
+	</Panel>
+	<UX.JSReserved ux:Name="r" function="yay!" />
+</Panel>

--- a/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
@@ -12,6 +12,15 @@ namespace Fuse.Reactive.Test
 	public class VariousTest : TestBase
 	{
 		[Test]
+		public void JavaScriptReservedWords()
+		{
+			var e = new UX.JavaScriptReservedWord();
+			var root = TestRootPanel.CreateWithChild(e);
+			root.StepFrameJS();
+			// No JS exception = all good
+			Assert.AreEqual(true, e.r.instanceof); // assert script was actually run
+		}
+		[Test]
 		public void FunctionAsDataContext()
 		{
 			var e = new UX.FunctionAsDataContext();


### PR DESCRIPTION
This also fixes a regression introduced by https://github.com/fusetools/uno/pull/1215 where the root node `this` is now included in NameTable, which causes a crash in JavaScript when this is introduced as a variable to the script.

This PR contains:
- [x] Changelog
