### PR TITLE
Cleaned up interface semantics & added docs in Fuse.Reactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Unreleased
 
 ## Fuse.Reactive cleanup (Uno-level)
-- These changes shouldn't affect your code unless you are specifically dealing with the `Fuse.Reactive` interfaces in your Uno code (unlikely): 
+- These changes shouldn't affect your code unless you are working against internal interfaces in `Fuse.Reactive` interfaces (unlikely): 
   * Introduced `IObservableArray` as an intermediary interface between `IArray` and `IObservable`, which holds the `Subscribe()` method.
   * Changed the return type of `IObservableArray.Subscribe` method from `ISubscription` to `IDisposable`. The method *may* still return
     an `ISubscription`, but this is no longer guaranteed. The subscriber must check this manually (with `value is ISubscription`) if an 
     `ISubscription` is anticipated.
+  * Introduced `IObservableObject` as a way for `IObject`s to propagate property changed events.
 - Added docs for many of the interfaces in the `Fuse.Reactive` namespace.
 
 ## Templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+## Fuse.Reactive cleanup (Uno-level)
+- These changes shouldn't affect your code unless you are specifically dealing with the `Fuse.Reactive` interfaces in your Uno code (unlikely): 
+  * Introduced `IObservableArray` as an intermediary interface between `IArray` and `IObservable`, which holds the `Subscribe()` method.
+  * Changed the return type of `IObservableArray.Subscribe` method from `ISubscription` to `IDisposable`. The method *may* still return
+    an `ISubscription`, but this is no longer guaranteed. The subscriber must check this manually (with `value is ISubscription`) if an 
+    `ISubscription` is anticipated.
+- Added docs for many of the interfaces in the `Fuse.Reactive` namespace.
+
 ## Templates
 - Triggers may now use templates which will be instantiated and added to the parent when active (like a node child).
 	<WhileActive>

--- a/Source/Fuse.Common/Tests/FuseTest/ObservableCollector.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/ObservableCollector.uno
@@ -25,15 +25,15 @@ namespace FuseTest
 		}
 		
 		bool _listening;
-		IObservable _items;
-		ISubscription _subscription;
+		IObservableArray _items;
+		Uno.IDisposable _subscription;
 		
 		public object Items
 		{
 			get { return _items;}
 			set
 			{
-				_items = value as IObservable;
+				_items = value as IObservableArray;
 				OnItemsChanged();
 			}
 		}
@@ -55,7 +55,7 @@ namespace FuseTest
 			CleanSubscription();
 			if (_items == null)
 				return;
-			_subscription = _items.Subscribe(this);
+			_subscription = (ISubscription)_items.Subscribe(this);
 		}
 		
 		void CleanSubscription()

--- a/Source/Fuse.Common/Tests/FuseTest/ObservableCollector.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/ObservableCollector.uno
@@ -26,7 +26,7 @@ namespace FuseTest
 		
 		bool _listening;
 		IObservableArray _items;
-		Uno.IDisposable _subscription;
+		ISubscription _subscription;
 		
 		public object Items
 		{

--- a/Source/Fuse.Nodes/Node.DataContext.uno
+++ b/Source/Fuse.Nodes/Node.DataContext.uno
@@ -39,7 +39,7 @@ namespace Fuse
 			{
 				if (_key == "")
 				{
-					Resolve(data);
+					Resolve(null, data);
 					return false;
 				}
 				else
@@ -49,7 +49,7 @@ namespace Fuse
 					{
 						if (obj.ContainsKey(_key))
 						{
-							Resolve(obj[_key]);
+							Resolve(obj, obj[_key]);
 							return false;
 						}
 					}
@@ -57,7 +57,7 @@ namespace Fuse
 
 				return true; // keep looking 
 			}
-			protected abstract void Resolve(object data);
+			protected abstract void Resolve(IObject provider, object data);
 		}
 
 		public object GetFirstData()

--- a/Source/Fuse.Nodes/Node.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Node.ScriptClass.uno
@@ -66,7 +66,7 @@ namespace Fuse
 			}
 
 			object _data;
-			protected override void Resolve(object data)
+			protected override void Resolve(IObject provider, object data)
 			{
 				_data = data;
 				_context.Dispatcher.Invoke(Update);

--- a/Source/Fuse.Reactive.Bindings/DataBinding.uno
+++ b/Source/Fuse.Reactive.Bindings/DataBinding.uno
@@ -179,7 +179,11 @@ namespace Fuse.Reactive
 			{
 				if (_subscription != null)
 				{
-					if (Write) _subscription.SetExclusive(Target.GetAsObject());
+					if (Write) 
+					{
+						var sub = _subscription as ISubscription;
+						if (sub != null) sub.SetExclusive(Target.GetAsObject());
+					}
 				}
 				else if (CanWriteBack)
 				{
@@ -188,7 +192,7 @@ namespace Fuse.Reactive
 			}
 		}
 
-		ISubscription _subscription;
+		IDisposable _subscription;
 
 		internal override void NewValue(object value)
 		{
@@ -201,13 +205,14 @@ namespace Fuse.Reactive
 			if (Marshal.Is(value, Target.PropertyType))
 			{
 				// Note - this case is required in addition to the final 'else', because if the target
-				// property accepts Observable, we should not create a subscription, but pass it
+				// property accepts the observable object, we should not create a subscription, but pass it
 				// directly to the target
 
 				PushValue(value);
 			}
 			else if (Marshal.Is(value, typeof(IObservable)))
 			{
+				// Special treatment for the IObservable interface - see docs on IObservable for rationale
 				var obs = (IObservable)value;
 				_subscription = obs.Subscribe(this);
 			}

--- a/Source/Fuse.Reactive.Bindings/Instance.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.uno
@@ -331,7 +331,7 @@ namespace Fuse.Reactive
 
 			RemoveAll();
 
-			var obs = _items as IObservable;
+			var obs = _items as IObservableArray;
 			if (obs != null)
 			{
 				if (_subscription != null) _subscription.Dispose();
@@ -448,6 +448,7 @@ namespace Fuse.Reactive
 			var prevOCP =(this as Node.ISubtreeDataProvider).GetData(n);
 			object nextData = null;
 			
+			// If the data is a single-value observable (`IObservable`), create an observable link
 			var obs = data as IObservable;
 			if (obs != null)
 			{

--- a/Source/Fuse.Reactive.Bindings/Instance.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.uno
@@ -695,7 +695,7 @@ namespace Fuse.Reactive
 		string _matchKey;
 
 		/** Name of the field on each data object which selects templates for the data objects.
-		
+
 			If set, the `Each` will instantiate the template with a name matching the `MatchKey` instead of the 
 			default template for each data item.
 

--- a/Source/Fuse.Reactive.Bindings/Instance.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.uno
@@ -695,9 +695,12 @@ namespace Fuse.Reactive
 		string _matchKey;
 
 		/** Name of the field on each data object which selects templates for the data objects.
-
+		
 			If set, the `Each` will instantiate the template with a name matching the `MatchKey` instead of the 
 			default template for each data item.
+
+			> Note: `MatchKey` must be available synchronously at the time of instantiation. It cannot be an observable
+			or be changed after initial instantiation.
 
 			## Example
 

--- a/Source/Fuse.Reactive.Bindings/MatchCase.uno
+++ b/Source/Fuse.Reactive.Bindings/MatchCase.uno
@@ -108,7 +108,7 @@ namespace Fuse.Reactive
 			throw new Exception("<Match> can not be used on lists (received OnRemoveAt)");
 		}
 
-		ISubscription _subscription;
+		IDisposable _subscription;
 
 		object _realValue;
 		object _value;
@@ -131,6 +131,7 @@ namespace Fuse.Reactive
 
 					if (_value is IObservable)
 					{
+						// Special treatment for IObservable which can be interpreted as a single value
 						var obs = (IObservable)_value;
 						_subscription = obs.Subscribe(this);
 					}

--- a/Source/Fuse.Reactive.Bindings/Subscription/DataSubscription.uno
+++ b/Source/Fuse.Reactive.Bindings/Subscription/DataSubscription.uno
@@ -3,7 +3,7 @@ using Uno.Collections;
 
 namespace Fuse.Reactive
 {
-	class DataSubscription: Node.DataFinder, IDisposable, Node.IDataListener
+	class DataSubscription: Node.DataFinder, IDisposable, Node.IDataListener, IPropertyObserver
 	{
 		IExpression _source;
 		Node _origin;
@@ -36,8 +36,36 @@ namespace Fuse.Reactive
 		}
 
 		object _currentData;
+		IDisposable _sub;
 
-		protected override void Resolve(object data)
+		void DisposeSubscription()
+		{
+			if (_sub != null)
+			{
+				_sub.Dispose();
+				_sub = null;
+			}
+		}
+
+		protected override void Resolve(IObject provider, object data)
+		{
+			DisposeSubscription();
+
+			var obs = provider as IObservableObject;
+			if (obs != null)
+				_sub = obs.Subscribe(this);
+
+			ResolveInner(data);
+		}
+
+		void IPropertyObserver.OnPropertyChanged(IDisposable sub, string propertyName, object newValue)
+		{
+			if (sub != _sub) return;
+			if (propertyName != Key) return;
+			ResolveInner(newValue);
+		}
+
+		void ResolveInner(object data)
 		{
 			_isResolved = true;
 			if (data != _currentData)
@@ -49,6 +77,7 @@ namespace Fuse.Reactive
 
 		public void Dispose()
 		{
+			DisposeSubscription();
 			ClearDiagnostic();
 			_origin.RemoveDataListener(Key, this);
 			_origin = null;

--- a/Source/Fuse.Reactive.Bindings/WhileCount.uno
+++ b/Source/Fuse.Reactive.Bindings/WhileCount.uno
@@ -84,7 +84,7 @@ namespace Fuse.Reactive
 				
 			if (_subscription != null) _subscription.Dispose();
 			
-			var obs = _items as IObservable;
+			var obs = _items as IObservableArray;
 			if (obs != null)
 				_subscription = obs.Subscribe(this);
 			
@@ -103,7 +103,7 @@ namespace Fuse.Reactive
 				return;
 			}
 			
-			var obs = _items as IObservable;
+			var obs = _items as IObservableArray;
 			if (obs != null)
 			{
 				Assess(obs.Length);

--- a/Source/Fuse.Reactive.Bindings/With.uno
+++ b/Source/Fuse.Reactive.Bindings/With.uno
@@ -55,6 +55,7 @@ namespace Fuse.Reactive
 					var obs = value as IObservable;
 					if (obs != null) 
 					{
+						// Special case for `IObservable` which can be interpreted as a single value
 						SetSubtreeData(null);
 						_sub = new ValueForwarder(obs, this);
 					}

--- a/Source/Fuse.Reactive.Expressions/LookUp.uno
+++ b/Source/Fuse.Reactive.Expressions/LookUp.uno
@@ -31,7 +31,7 @@ namespace Fuse.Reactive
 			return new LookUpSubscription(this, context, listener);
 		}
 
-		sealed class LookUpSubscription: IDisposable, IObserver, IListener, ValueForwarder.IValueListener
+		sealed class LookUpSubscription: IDisposable, IObserver, IListener, ValueForwarder.IValueListener, IPropertyObserver
 		{
 			IListener _listener;
 			LookUp _lu;
@@ -111,12 +111,23 @@ namespace Fuse.Reactive
 				}
 			}
 
+			void DisposeCollectionObservableObjectSub()
+			{
+				if (_colObsObjSub != null)
+				{
+					_colObsObjSub.Dispose();
+					_colObsObjSub = null;
+				}
+			}
+
+			IDisposable _colObsObjSub;
 			IDisposable _colObservableSub;
 			void NewCollection(object col)
 			{
 				_collection = col;
 				_hasCollection = true;
 
+				DisposeCollectionObservableObjectSub();
 				DisposeCollectionObservableSub();
 
 				var obs = col as IObservable;
@@ -135,6 +146,8 @@ namespace Fuse.Reactive
 					_colObservableSub = null;
 				}
 			}
+
+			
 
 			void ResultChanged()
 			{
@@ -173,6 +186,10 @@ namespace Fuse.Reactive
 				var obj = _collection as IObject;
 				if (obj != null)
 				{
+					var obsObj = obj as IObservableObject;
+					if (obsObj != null)
+						_colObsObjSub = obsObj.Subscribe(this);
+
 					var key = _index.ToString();
 					if (obj.ContainsKey(key))
 					{
@@ -188,6 +205,13 @@ namespace Fuse.Reactive
 				SetDiagnostic("Look-up operator not supported on collection type: " + _collection, _lu.Collection);
 			}
 
+			void IPropertyObserver.OnPropertyChanged(IDisposable sub, string propertyName, object newValue)
+			{
+				if (sub != _colObsObjSub) return;
+				if (propertyName != _index.ToString()) return;
+				PushNewData(newValue);
+			}
+
 			void PushNewData(object value)
 			{
 				_listener.OnNewData(_lu, value);
@@ -196,6 +220,7 @@ namespace Fuse.Reactive
 			public void Dispose()
 			{
 				ClearDiagnostic();
+				DisposeCollectionObservableObjectSub();
 				DisposeCollectionObservableSub();
 				DisposeIndexSub();
 				_colSub.Dispose();

--- a/Source/Fuse.Reactive.Expressions/LookUp.uno
+++ b/Source/Fuse.Reactive.Expressions/LookUp.uno
@@ -67,6 +67,7 @@ namespace Fuse.Reactive
 				var obs = ind as IObservable;
 				if (obs != null)
 				{
+					// Special case for when index is an IObservable 
 					_indexForwarder = new ValueForwarder(obs, this);
 				}
 				else
@@ -120,6 +121,7 @@ namespace Fuse.Reactive
 
 				var obs = col as IObservable;
 				if (obs != null) 
+					// Special case for when the collection is an IObservable
 					_colObservableSub = obs.Subscribe(this);
 
 				ResultChanged();

--- a/Source/Fuse.Reactive.Expressions/Member.uno
+++ b/Source/Fuse.Reactive.Expressions/Member.uno
@@ -24,7 +24,7 @@ namespace Fuse.Reactive
 			return new MemberSubscription(this, context, listener);
 		}
 
-		class MemberSubscription: Subscription
+		class MemberSubscription: Subscription, IPropertyObserver
 		{
 			Member _member;
 			public MemberSubscription(Member member, IContext context, IListener listener): base(member, listener)
@@ -33,19 +33,48 @@ namespace Fuse.Reactive
 				Init(context);
 			}
 
+			IDisposable _obsObjSub;
+			void DisposeObservableObjectSubscription()
+			{
+				if (_obsObjSub != null)
+				{
+					_obsObjSub.Dispose();
+					_obsObjSub = null;
+				}
+			}
+
 			protected override void OnNewOperand(object obj)
 			{
+				DisposeObservableObjectSubscription();
+
 				ClearDiagnostic();
 
 				var io = obj as IObject;
 				if (io != null && io.ContainsKey(_member.Name))
 				{
+					var obsObj = io as IObservableObject;
+					if (obsObj != null)
+						_obsObjSub = obsObj.Subscribe(this);
+
 					PushNewData(io[_member.Name]);
 				}
 				else
 				{
 					SetDiagnostic("'" + _member.Operand.ToString() +"' does not contain property '" + _member.Name + "'", _member);
 				}
+			}
+
+			void IPropertyObserver.OnPropertyChanged(IDisposable sub, string propName, object newValue)
+			{
+				if (_obsObjSub != sub) return;
+				if (propName != _member.Name) return;
+				PushNewData(newValue);
+			}
+
+			public override void Dispose()
+			{
+				DisposeObservableObjectSubscription();
+				base.Dispose();
 			}
 		}
 	}

--- a/Source/Fuse.Reactive.Expressions/Subscription.uno
+++ b/Source/Fuse.Reactive.Expressions/Subscription.uno
@@ -55,9 +55,10 @@ namespace Fuse.Reactive
 				_obsSubs.Remove(source);
 			}
 
-			var obs = value as IObservable;
+			var obs = value as IObservable; 
 			if (obs != null)
 			{
+				// Special case for IObservable which can be interpreted as a single value
 				if (_obsSubs == null) _obsSubs = new Dictionary<IExpression, ObservableSubscription>();
 				_obsSubs.Add(source, new ObservableSubscription(source, obs, this));
 			}

--- a/Source/Fuse.Reactive.Expressions/Tests/ObservableObjectTest.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/ObservableObjectTest.uno
@@ -1,0 +1,99 @@
+using Uno;
+using Uno.Collections;
+using Uno.UX;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Reactive.Test
+{
+	class TestData : IObservableObject
+	{
+		string _foo = "haha";
+		string _bar = "hoho";
+		TestData _other = null;
+
+		public string Foo { get { return _foo; } set { _foo = value; OnPropertyChanged("Foo", value); } }
+		public string Bar { get { return _bar; } set { _bar = value; OnPropertyChanged("Bar", value); } }
+		[UXContent]
+		public TestData Other { get { return _other; } set { _other = value; OnPropertyChanged("Other", value); } }
+
+		public object this[string key]
+		{
+			get
+			{
+				if (key == "Foo") return Foo;
+				else if (key == "Bar") return Bar;
+				else if (key == "Other") return Other;
+				else throw new Exception();
+			}
+		}
+
+		public string[] Keys
+		{
+			get { return new [] { "Foo", "Bar", "Other"}; }
+		}
+
+		public bool ContainsKey(string key)
+		{
+			for (var i = 0; i < Keys.Length; i++)
+				if (Keys[i] == key) return true;
+
+			return false;
+		}
+
+		public void OnPropertyChanged(string key, object value)
+		{
+			for (var i = 0; i < _listeners.Count; i++)
+				_listeners[i].Observer.OnPropertyChanged(_listeners[i], key, value);
+		}
+
+		public IDisposable Subscribe(IPropertyObserver observer)
+		{
+			var sub = new Subscription(this, observer);
+			_listeners.Add(sub);
+			return sub;
+		}
+
+		List<Subscription> _listeners = new List<Subscription>();
+
+		class Subscription: IDisposable
+		{
+			TestData _td;
+			public readonly IPropertyObserver Observer;
+			public Subscription(TestData td, IPropertyObserver observer)
+			{
+				_td = td;
+				Observer = observer;
+			}
+			public void Dispose()
+			{
+				_td._listeners.Remove(this);
+			}
+		}
+	}
+
+	class ObservableObjectTest : TestBase
+	{
+		[Test]
+		public void Basics()
+		{
+			var c = new UX.ObservableObjectTest();
+			using (var root = TestRootPanel.CreateWithChild(c))
+			{
+				root.StepFrame();
+				Assert.AreEqual("Hey there haha and hoho and Lol! and yaya!", c.t.Value);
+				c.d.Foo = "kjeks";
+				Assert.AreEqual("Hey there kjeks and hoho and Lol! and yaya!", c.t.Value);
+				c.d.Bar = "kake";
+				Assert.AreEqual("Hey there kjeks and kake and Lol! and yaya!", c.t.Value);
+				c.td.Foo = "pepperkake";
+				Assert.AreEqual("Hey there kjeks and kake and pepperkake and yaya!", c.t.Value);
+				c.d.Other = new TestData();
+				Assert.AreEqual("Hey there kjeks and kake and haha and hoho!", c.t.Value);
+				c.td.Foo = "hest";
+				Assert.AreEqual("Hey there kjeks and kake and haha and hoho!", c.t.Value);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/ObservableObjectTest.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/ObservableObjectTest.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.ObservableObjectTest">
+	<With>
+		<Fuse.Reactive.Test.TestData ux:Binding="Data" ux:Name="d">
+			<Fuse.Reactive.Test.TestData ux:Name="td" Foo="Lol!" Bar="yaya" />
+		</Fuse.Reactive.Test.TestData>
+		<Text ux:Name="t">Hey there {Foo} and {Bar} and {Other.Foo} and {Other.Bar}!</Text>
+	</With>
+</Panel>

--- a/Source/Fuse.Reactive.JavaScript/Observable.uno
+++ b/Source/Fuse.Reactive.JavaScript/Observable.uno
@@ -143,6 +143,11 @@ namespace Fuse.Reactive
 			return new Subscription(this, observer);
 		}
 
+		IDisposable IObservableArray.Subscribe(IObserver observer)
+		{
+			return Subscribe(observer);
+		}
+
 		readonly ThreadWorker _worker;
 
 		Scripting.Object _observable;

--- a/Source/Fuse.Reactive/Fuse.Reactive.unoproj
+++ b/Source/Fuse.Reactive/Fuse.Reactive.unoproj
@@ -21,6 +21,7 @@
     "Fuse.Common.Test.Helpers",
     "Fuse.Reactive.Bindings",
     "Fuse.Reactive.Expressions",
+    "Fuse.Expressions.Test",
     "Fuse.Reactive.JavaScript",
     "Fuse.Scripting.Test",
     "Fuse.Selection",

--- a/Source/Fuse.Reactive/IObservable.uno
+++ b/Source/Fuse.Reactive/IObservable.uno
@@ -5,6 +5,30 @@ using Uno.Threading;
 
 namespace Fuse.Reactive
 {
+	/** Represents an object with reactive properties.
+
+		An `IObject` that also implements this interface will emit events to observers when the
+		value of any of its properties change.
+
+		This interface can be implemented by any reactive data provider that wants to interop
+		with the `Fuse.Reactive` framework.
+	*/
+	interface IObservableObject: IObject
+	{
+		/** Creates a new subscription to the object, which will pass change events to the given observer. */
+		IDisposable Subscribe(IPropertyObserver observer);
+	}
+
+	interface IPropertyObserver
+	{
+		/**
+			@param subscription The subscription that corresponds to this change event. Should be used to filter events that arrived after disposal.
+			@param propertyName The name of the property that changed
+			@param newValue The new value of the property
+		*/
+		void OnPropertyChanged(IDisposable subscription, string propertyName, object newValue);
+	}
+
 	/** Represents a reactive collection. 
 
 		This interface can be implemented by any reactive data provider that wants to interop

--- a/Source/Fuse.Reactive/IObservable.uno
+++ b/Source/Fuse.Reactive/IObservable.uno
@@ -5,18 +5,110 @@ using Uno.Threading;
 
 namespace Fuse.Reactive
 {
-	interface IObservable: IArray
+	/** Represents a reactive collection. 
+
+		This interface can be implemented by any reactive data provider that wants to interop
+		with the `Fuse.Reactive` framework.
+
+		## Availability of data
+
+		As `IObservableArray` extends `IArray`, it is always safe to read synchronously from
+		the collection in the range `0..Length`. However, any meaningful data may be unavailable 
+		(and hence `Length == 0`), or out of date. 
+		
+		A subscription is needed in order to instruct the implementation to fetch the
+		underlaying data or bring the collection up to date. When subscribed to, the data 
+		may then be fetched	asynchronously. The first reliable up-to-date data is passed 
+		to the subscription	via callbacks.
+	*/
+	interface IObservableArray: IArray
 	{
-		ISubscription Subscribe(IObserver observer);
+		/** Creates a new subscription to the collection, which will pass change events to the given observer. 
+
+			## Disposal of subscription
+
+			The returned object is an `IDisposable`. Calling `Dispose()` on the subscription will unsubscribe from further
+			callbacks to the subscriber. However, the subscriber cannot safely assume that no more callbacks will be made.
+			The implementation may have already queued additional callbacks	to the subscriber that cannot be cancelled.
+			The subscriber must filter out any late callback messages that arrives after disposal of the subscription.
+
+			## Write-back subscriptions
+			
+			The returned object may or may not support the `ISubscription` interface. The subscriber can test whether the
+			returned object `is ISubscription`.If so, the data source supports write-backs	to the data source, where
+			the current subscription can be excluded from callbacks.
+		*/
+		IDisposable Subscribe(IObserver observer);
 	}
 
+	/** Represents a single reactive value, or a reactive collection.
+
+		Note that `Fuse.Reactive.IObservable` has many differences from observables in other reactive
+		frameworks (such as Rx, or `Uno.IObservable`). This is to accommodate many different types of data providers.
+
+		An `IObservable` can be in several significant states:
+		 * It can be *empty*, i.e. have *no value* (`Length == 0`)
+		 * It can hold a single primary value (`Length == 1`)
+		 * It can hold multiple values (`Length > 1`). The value at index `0` is still refered to as the *primary value*.
+
+		The most significant implementation of this interface is `FuseJS/Observable`.
+
+		## Primary value usage
+
+		This interface extends the `IObservableArray` with the added contract of
+		being interpretable as a single value, called the *primary value*. The primary
+		value of the `IObservable` is the value at index `0` in the collection, if available.
+		
+		When interpreted as a single value, it is valid for the collection to be empty, 
+		which which means the primary value is not available. It is also valid for the
+		collection to have more than one value, in which case the other values will be ignored.
+		
+		The `IObservable` interface receives special treatment by the reactive operators. For 
+		example, consider the following data-binding expression:
+
+			<Text>Hello {user.name}!</Text>
+
+		If `user` is an `IObservable`, then this data binding refers to `user[0].name`, when
+		at least one element is available in the `IObservable`.
+
+		An `IObservable` also gets special treatment by `DataBinding`. If a bound expression
+		yields an `IObservable`, and the target property is not compatible with `IObservable`,
+		the data binding will create a subscription and feed the primary value to the target
+		property. Example:
+
+			<Text>{message}</Text>
+
+		If `message` yields an `IObservable`, the primary value (`message[0]`) of the observable 
+		will be displayed, if available. If there primary value is not available, the expression
+		will not yield any value (no value is written to the target property.)
+
+		Some properties accept all types (`object`), or `IObservable` explicitly. In these cases,
+		the data binding will not create a subscription, but rather pass the object directly to 
+		the target property for it to create a subscription. Examples of this is `Each.Items`,
+		`Selection.Values`, `Match.Value`, `With.Data` and `WhileCount.Items`.
+
+		## Multi-value usage
+
+		If an `IObservable` is subscribed to in a scenario where an array is expected,
+		the object behaves identically to `IObservableArray`.
+	*/
+	interface IObservable: IObservableArray
+	{
+
+	}
+
+	/** Represents a subscription to an `IObservableArray` that supports write-backs. */
 	interface ISubscription: IDisposable
 	{
+		/** Clears the contents of the `IObservableArray` without notifying this subscription of the change. */
 		void ClearExclusive();
+		/** Replaces the `IObservableArray` with a list of length 1, containting the given object, without notifying this subscription of the change. */
 		void SetExclusive(object newValue);
+		/** Replaces the `IObservableArray` with the given values, without notifying this subscription of the change. */
 		void ReplaceAllExclusive(IArray values);
 	}
 	
+	/** Represents an object that can receive change notifications for an `IObservableArray`. */
 	interface IObserver
 	{
 		/** Clear all items */

--- a/Source/Fuse.Reactive/ValueObserver.uno
+++ b/Source/Fuse.Reactive/ValueObserver.uno
@@ -3,6 +3,10 @@ using Uno;
 namespace Fuse.Reactive
 {
 	/** Utility base class that observes the first value of an `IObservable`.
+		
+		Note that this class should only be used with instances that support `IObservable`, 
+		not just `IObservableArray`. This ensures the collection is semantically inteneded
+		for single-value use.
 	*/
 	abstract class ValueObserver: IDisposable, IObserver
 	{

--- a/Source/Fuse.Selection/Selection.uno
+++ b/Source/Fuse.Selection/Selection.uno
@@ -355,7 +355,9 @@ namespace Fuse.Selection
 				
 			if (how == How.API && _subscription != null)
 			{
-				_subscription.ReplaceAllExclusive( new ListWrapper(_values) );
+				var sub = _subscription as ISubscription;
+				if (sub != null) sub.ReplaceAllExclusive( new ListWrapper(_values) );
+				else Diagnostics.UserWarning("Selection changed, but the bound collection is not writeable.", this);
 			}
 		}
 		
@@ -375,9 +377,9 @@ namespace Fuse.Selection
 			}
 		}
 		
-		Reactive.IObservable _observableValues;
+		Reactive.IObservableArray _observableValues;
 		/**
-			The current list of selected values. This should be bound to an `Observable` array in JavaScript in order to create a 2-way interface for the selected items.
+			The current list of selected values. This should be bound to an `IObservableArray` (e.g `FuseJS/Observable`) order to create a 2-way interface for the selected items.
 			
 			@examples Docs/example.md
 		*/
@@ -386,10 +388,10 @@ namespace Fuse.Selection
 			get { return _observableValues; }
 			set 
 			{ 
-				var q = value as Reactive.IObservable;
+				var q = value as Reactive.IObservableArray;
 				if (value != null && q == null)
 				{
-					Fuse.Diagnostics.UserError( "`Values` must be an Observable", this );
+					Fuse.Diagnostics.UserError( "`Values` must be an IObservableArray", this );
 					return;
 				}
 				
@@ -410,7 +412,7 @@ namespace Fuse.Selection
 			_subscription = _observableValues.Subscribe(this);
 		}
 		
-		ISubscription _subscription;
+		IDisposable _subscription;
 		void ClearSubscription()
 		{
 			if (_subscription != null)


### PR DESCRIPTION
This PR cleans up and documents more precisely the semantics around the interfaces in `Fuse.Reactive`. This only changes internal APIs, for now. The intention is to later make these APIs public to allow third parties to implement data providers to the data binding system.

This PR also introduces the `IObservableObject` interface and makes the data binding system respect it, which is needed to implement arbitrary data providers.

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests

