### PR TITLE
iOS: Make InputDispatch expand number of activePointers

### DIFF
--- a/Source/Fuse.Controls.Native/iOS/InputDispatch.uno
+++ b/Source/Fuse.Controls.Native/iOS/InputDispatch.uno
@@ -103,14 +103,12 @@ namespace Fuse.Controls.Native.iOS
 			return new RootInfo(rootVisual, rootView);
 		}
 
-		const int MaxPointerCount = 10;
-
-		static ObjC.Object[] _activePointers = new ObjC.Object[MaxPointerCount];
+		static List<ObjC.Object> _activePointers = new List<ObjC.Object>();
 
 		static int GetPointIndex(ObjC.Object uiTouch)
 		{
 			var firstUnused = -1;
-			for (var i = 0; i < MaxPointerCount; ++i)
+			for (var i = 0; i < _activePointers.Count; ++i)
 			{
 				var pointer = _activePointers[i];
 				if (CompareUITouch(pointer, null) && firstUnused < 0)
@@ -118,14 +116,18 @@ namespace Fuse.Controls.Native.iOS
 				else if (CompareUITouch(pointer, uiTouch))
 					return i;
 			}
-
+			if (firstUnused < 0)
+			{
+				_activePointers.Add(uiTouch);
+				firstUnused = _activePointers.Count - 1;
+			}
 			_activePointers[firstUnused] = uiTouch;
 			return firstUnused;
 		}
 
 		static void DeactivateTouch(ObjC.Object uiTouch)
 		{
-			for (var i = 0; i < MaxPointerCount; i++)
+			for (var i = 0; i < _activePointers.Count; i++)
 			{
 				if (CompareUITouch(_activePointers[i], uiTouch))
 				{

--- a/Tests/ManualTests/ManualTestingApp/Multitouch/Multitouch.ux.uno
+++ b/Tests/ManualTests/ManualTestingApp/Multitouch/Multitouch.ux.uno
@@ -1,22 +1,16 @@
 using Fuse;
 using Fuse.Input;
 using Uno;
+using Uno.Collections;
 
 public partial class Multitouch
 {
-	TouchCircle[] _touchCircles = new TouchCircle[10];
-	bool[] _down = new bool[10];
+	List<TouchCircle> _touchCircles = new List<TouchCircle>();
+	List<bool> _down = new List<bool>();
 
 	public Multitouch()
 	{
 		InitializeUX();
-		for (var i = 0; i < _touchCircles.Length; i++)
-		{
-			var t = new TouchCircle();
-			t.Label.Value = i.ToString();
-			_touchCircles[i] = t;
-			_testPanel.Children.Add(t);
-		}
 	}
 
 	protected override void OnRooted()
@@ -49,8 +43,20 @@ public partial class Multitouch
 		}
 	}
 
+	void AddToucheCircle()
+	{
+		var t = new TouchCircle();
+		t.Label.Value = _touchCircles.Count.ToString();
+		_touchCircles.Add(t);
+		_down.Add(false);
+		_testPanel.Children.Add(t);
+	}
+
 	void OnPointerPressed(object sender, PointerPressedArgs args)
 	{
+		if (args.PointIndex >= _touchCircles.Count)
+			AddToucheCircle();
+
 		var t = _touchCircles[args.PointIndex];
 		if (args.TryHardCapture(t, new LostCaptureCallback(this, args.PointIndex).LostCapture))
 		{


### PR DESCRIPTION
There is no public API on iOS that will tell us how many simultanious touches are supported. When writing this code I believed that 10 fingers were the max, but when testing this on iPad I found that iPad supports 11 simultanious touches. Also according to the internet iPhone supports only 5 simultanious touches.

Refactoring to just use a list instead so that we can support an arbitrary number of active pointers

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
