### PR TITLE
UX expressions name-value pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 ## UX Expressions (Uno-level)
 - Introduced support for variable arguments to UX functions - inherit from the `Fuse.Reactive.VarArgFunction` class.
 - The classes `Vector2`, `Vector3` and `Vector4` in `Fuse.Reactive` are now removed and replaced with the general purpose, variable-argument version `Vector` instead. This ensures vectors of any length are treated the same way. This is backwards incompatible in the unlikely case of having used these classes explicitly from Uno code.
-## UX Expressions
-- (Uno-level) Added support for name-value pair syntax: `name: value`. Can be used for JSON-like object notation and named arguments in custom functions.
+- Added support for name-value pair syntax: `name: value`. Can be used for JSON-like object notation and named arguments in custom functions.
 
 ## Templates
 - Added `Identity` and `IdentityKey` to `Each`. This allows created visuals to be reused when replaced with `replaceAt` or `replaceAll` in an Observable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## UX Expressions (Uno-level)
 - Introduced support for variable arguments to UX functions - inherit from the `Fuse.Reactive.VarArgFunction` class.
 - The classes `Vector2`, `Vector3` and `Vector4` in `Fuse.Reactive` are now removed and replaced with the general purpose, variable-argument version `Vector` instead. This ensures vectors of any length are treated the same way. This is backwards incompatible in the unlikely case of having used these classes explicitly from Uno code.
+## UX Expressions
+- (Uno-level) Added support for name-value pair syntax: `name: value`. Can be used for JSON-like object notation and named arguments in custom functions.
 
 ## Templates
 - Added `Identity` and `IdentityKey` to `Each`. This allows created visuals to be reused when replaced with `replaceAt` or `replaceAll` in an Observable.

--- a/Source/Fuse.Common/Json.Parse.uno
+++ b/Source/Fuse.Common/Json.Parse.uno
@@ -52,7 +52,7 @@ namespace Fuse
 			return null;
 		}
 
-		class Object : IObject
+		internal class Object : IObject
 		{
 			readonly Dictionary<string, object> _dict;
 

--- a/Source/Fuse.Common/NameValuePair.uno
+++ b/Source/Fuse.Common/NameValuePair.uno
@@ -1,0 +1,56 @@
+using Uno;
+using Uno.Collections;
+
+namespace Fuse
+{
+	/** Represents a name-value pair, as denoted by `name: value` in UX expressions.
+		
+		Implements `IObject`, which means the `NameValuePair` can be viewed as an object
+		with a single property.
+
+		An `IArray` containing some `NameValuePairs` can be converted to an `IObject`
+		implementation containing all those properties using the `ObjectFromArray` method.
+	*/
+	public sealed class NameValuePair : IObject
+	{
+		public string Name { get; private set; }
+		public object Value { get; private set; }
+		public NameValuePair(string name, object value)
+		{
+			Name = name;
+			Value = value;
+		}
+
+		public override string ToString()
+		{
+			return "(" + Name + ": " + Value + ")";
+		}
+
+		string[] IObject.Keys { get { return new [] { Name }; } }
+		bool IObject.ContainsKey(string key) { return Name == key; } 
+		object IObject.this[string key] 
+		{
+			get
+			{
+				if (key != Name) throw new ArgumentException("Object (NameValuePair) does not contain the given key");
+				return Value;
+			}
+		}
+
+		/** Creates an IObject implementation from an `IArray` of `NameValuePair`.
+			The array doesn't need to contain exclusively `NameValuePair` instances. Objects of other
+			types are ignored.
+		*/
+		public static IObject ObjectFromArray(IArray list)
+		{
+			var dict = new Dictionary<string, object>();
+			for (var i = 0; i < list.Length; i++)
+			{
+				var nvp = list[i] as NameValuePair;
+				if (nvp != null)
+					dict.Add(nvp.Name, nvp.Value);
+			}
+			return new Json.Object(dict);
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Expressions/NameValuePair.uno
+++ b/Source/Fuse.Reactive.Expressions/NameValuePair.uno
@@ -1,0 +1,21 @@
+using Uno.UX;
+
+namespace Fuse.Reactive
+{
+	/** Creates a `Fuse.NameValuePair` from a name and a value. */
+	public class NameValuePair: UnaryOperator
+	{
+		public string Name { get; private set; }
+
+		[UXConstructor]
+		public NameValuePair([UXParameter("Name")] string name, [UXParameter("Value")] Expression value) : base(value)
+		{
+			Name = name;
+		}
+
+		protected override object Compute(object value)
+		{
+			return new Fuse.NameValuePair(Name, value);
+		}
+	}
+}

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/NameValuePair.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/NameValuePair.ux
@@ -1,0 +1,11 @@
+<Panel ux:Class="UX.NameValuePair">
+	<JavaScript>
+		var Observable = require("FuseJS/Observable");
+		exports.v = Observable(false);
+		exports.flip = function() {
+			exports.v.value = true;
+		}
+	</JavaScript>
+	<Text ux:Name="t">{v?(bar:'foo' + v):('boo':v)}</Text>
+	<FuseTest.Invoke Handler="{flip}" ux:Name="flip" />
+</Panel>

--- a/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
@@ -12,6 +12,18 @@ namespace Fuse.Reactive.Test
 	public class VariousTest : TestBase
 	{
 		[Test]
+		public void NameValuePair()
+		{
+			var e = new UX.NameValuePair();
+			var root = TestRootPanel.CreateWithChild(e);
+			root.StepFrameJS();
+			Assert.AreEqual("(boo: False)", e.t.Value);
+			e.flip.Perform();
+			root.StepFrameJS();
+			Assert.AreEqual("(bar: fooTrue)", e.t.Value);
+		}
+
+		[Test]
 		public void FunctionAsDataContext()
 		{
 			var e = new UX.FunctionAsDataContext();


### PR DESCRIPTION
Adds support for Name-value pairs.

Requires new Uno stuff with https://github.com/fusetools/uno/pull/1222

This feature enables things like `<Button Clicked="goto('settings', {enabled: true})" />`

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
