### PR TITLE
Support for variable arguments to UX functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Router
 - Added `findRouter` function making it easier to use a router in a page deep inside the UI
+## UX Expressions (Uno-level)
+- Introduced support for variable arguments to UX functions - inherit from the `Fuse.Reactive.VarArgFunction` class.
+- The classes `Vector2`, `Vector3` and `Vector4` in `Fuse.Reactive` are now removed and replaced with the general purpose, variable-argument version `Vector` instead. This ensures vectors of any length are treated the same way. This is backwards incompatible in the unlikely case of having used these classes explicitly from Uno code.
 
 ## Templates
 - Added `Identity` and `IdentityKey` to `Each`. This allows created visuals to be reused when replaced with `replaceAt` or `replaceAll` in an Observable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Router
 - Added `findRouter` function making it easier to use a router in a page deep inside the UI
+
 ## UX Expressions (Uno-level)
 - Introduced support for variable arguments to UX functions - inherit from the `Fuse.Reactive.VarArgFunction` class.
 - The classes `Vector2`, `Vector3` and `Vector4` in `Fuse.Reactive` are now removed and replaced with the general purpose, variable-argument version `Vector` instead. This ensures vectors of any length are treated the same way. This is backwards incompatible in the unlikely case of having used these classes explicitly from Uno code.

--- a/Source/Fuse.Marshal/Marshal.Cast.uno
+++ b/Source/Fuse.Marshal/Marshal.Cast.uno
@@ -251,6 +251,7 @@ namespace Fuse
 			if (o is Size2) return (Size2) o;
 			else if (o is Size) return new Size2((Size)o, (Size)o);
 			else if (o is string) return StringToSize2((string)o);
+			else if (o is IArray) return ToSize2(ArrayToVector(o));
 			else return new Size2(ToFloat2(o).X, ToFloat2(o).Y);
 		}
 

--- a/Source/Fuse.Marshal/Marshal.Cast.uno
+++ b/Source/Fuse.Marshal/Marshal.Cast.uno
@@ -251,7 +251,7 @@ namespace Fuse
 			if (o is Size2) return (Size2) o;
 			else if (o is Size) return new Size2((Size)o, (Size)o);
 			else if (o is string) return StringToSize2((string)o);
-			else if (o is IArray) return ToSize2(ArrayToVector(o));
+			else if (o is IArray) return ToSize2(ToVector((IArray)o));
 			else return new Size2(ToFloat2(o).X, ToFloat2(o).Y);
 		}
 

--- a/Source/Fuse.Marshal/Marshal.Compute.uno
+++ b/Source/Fuse.Marshal/Marshal.Compute.uno
@@ -46,6 +46,7 @@ namespace Fuse
 		public static object Add(object a, object b)
 		{
 			if (a == null || b == null) return null;
+			a = ArrayToVector(a);
 			var ta = a.GetType();
 			var tb = b.GetType();
 
@@ -64,6 +65,7 @@ namespace Fuse
 		public static object Subtract(object a, object b)
 		{
 			if (a == null || b == null) return null;
+			a = ArrayToVector(a);
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
@@ -76,6 +78,7 @@ namespace Fuse
 		public static object Multiply(object a, object b)
 		{
 			if (a == null || b == null) return null;
+			a = ArrayToVector(a);
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
@@ -88,6 +91,7 @@ namespace Fuse
 		public static object Divide(object a, object b)
 		{
 			if (a == null || b == null) return null;
+			a = ArrayToVector(a);
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;

--- a/Source/Fuse.Marshal/Marshal.Compute.uno
+++ b/Source/Fuse.Marshal/Marshal.Compute.uno
@@ -46,7 +46,7 @@ namespace Fuse
 		public static object Add(object a, object b)
 		{
 			if (a == null || b == null) return null;
-			a = ArrayToVector(a);
+			a = TryConvertArrayToVector(a);
 			var ta = a.GetType();
 			var tb = b.GetType();
 
@@ -65,7 +65,7 @@ namespace Fuse
 		public static object Subtract(object a, object b)
 		{
 			if (a == null || b == null) return null;
-			a = ArrayToVector(a);
+			a = TryConvertArrayToVector(a);
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
@@ -78,7 +78,7 @@ namespace Fuse
 		public static object Multiply(object a, object b)
 		{
 			if (a == null || b == null) return null;
-			a = ArrayToVector(a);
+			a = TryConvertArrayToVector(a);
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
@@ -91,7 +91,7 @@ namespace Fuse
 		public static object Divide(object a, object b)
 		{
 			if (a == null || b == null) return null;
-			a = ArrayToVector(a);
+			a = TryConvertArrayToVector(a);
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;

--- a/Source/Fuse.Marshal/Marshal.Vector.uno
+++ b/Source/Fuse.Marshal/Marshal.Vector.uno
@@ -27,7 +27,7 @@ namespace Fuse
 			else throw new MarshalException(arr, typeof(float4));
 		}
 
-		static object ArrayToVector(object arg)
+		static object TryConvertArrayToVector(object arg)
 		{
 			var arr = arg as IArray;
 			if (arr != null) return ToVector(arr);

--- a/Source/Fuse.Marshal/Marshal.Vector.uno
+++ b/Source/Fuse.Marshal/Marshal.Vector.uno
@@ -1,0 +1,37 @@
+using Uno.UX;
+
+namespace Fuse
+{
+	public static partial class Marshal
+	{
+		static object ToVector(IArray arr)
+		{
+			if (arr.Length == 1) 
+			{
+				if (arr[0] is Size) return (Size)arr[0];
+				else return Marshal.ToFloat(arr[0]);
+			}
+			else if (arr.Length == 2)
+			{
+				if (arr[0] is Size || arr[1] is Size) return new Size2(Marshal.ToSize(arr[0]), Marshal.ToSize(arr[1]));
+				else return float2(Marshal.ToFloat(arr[0]), Marshal.ToFloat(arr[1]));
+			}
+			else if (arr.Length == 3)
+			{
+				return float3(Marshal.ToFloat(arr[0]), Marshal.ToFloat(arr[1]), Marshal.ToFloat(arr[2]));
+			}
+			else if (arr.Length == 4)
+			{
+				return float4(Marshal.ToFloat(arr[0]), Marshal.ToFloat(arr[1]), Marshal.ToFloat(arr[2]), Marshal.ToFloat(arr[3]));
+			}
+			else throw new MarshalException(arr, typeof(float4));
+		}
+
+		static object ArrayToVector(object arg)
+		{
+			var arr = arg as IArray;
+			if (arr != null) return ToVector(arr);
+			return arg;
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Expressions/VarArgFunction.uno
+++ b/Source/Fuse.Reactive.Expressions/VarArgFunction.uno
@@ -43,7 +43,9 @@ namespace Fuse.Reactive
 			return new Subscription(this, context, listener);
 		}
 
-		/** Called when at least some arguments are ready and have new values. 
+		/** Called when arguments should be checked for a condition that might yield a new value to the listener.
+
+			This function is called immediately upon subscription, and when any of the arguments change.
 			
 			Override in subclass to handle partially complete arguments. If the function are not
 			interested in the arguments before they are all ready, override `OnNewArguments` instead.
@@ -60,6 +62,8 @@ namespace Fuse.Reactive
 		}
 
 		/** Called when all the arguments are ready and have new values.
+
+			If the function has zero arguments, this function is called immediately upon subscription.
 
 			Override in subclass to handle complete argument lists. If the function is interested in
 			partially ready argument lists, override `OnNewPartialArguments` instead.
@@ -92,6 +96,10 @@ namespace Fuse.Reactive
 				// get callbacks before we're fully initialized.
 				for (var i = 0; i < func.Arguments.Count; i++)
 					_arguments[i].Subscription = func.Arguments[i].Subscribe(context, this);
+
+				// To cover the case where the function has zero arguments, and also when
+				// having no arugments ready is a valid case
+				PushData();
 			}
 
 			protected override void OnNewData(IExpression source, object value)

--- a/Source/Fuse.Reactive.Expressions/VarArgFunction.uno
+++ b/Source/Fuse.Reactive.Expressions/VarArgFunction.uno
@@ -1,0 +1,128 @@
+using Uno;
+using Uno.Collections;
+
+namespace Fuse.Reactive
+{
+	/** Base class for UX functions that accept a variable number of arguments.
+
+		Derived classes must override exaclty one of either `OnNewPartialArguments` or `OnNewArguments`.
+	*/
+	public abstract class VarArgFunction: Expression
+	{
+		/** Holds information about an argument to a `VarArgFunction`. */
+		public class Argument 
+		{
+			internal IDisposable Subscription;
+
+			/** The current value of the argument. If `HasValue` is `false`, `null` is returned. */
+			public object Value { get; internal set; }
+
+			/** Whether or not this argument has yielded a value yet. 
+				This can only return false if `OnNewPartialArguments` was overridden.
+			*/
+			public bool HasValue { get; internal set; }
+			
+			internal void Dispose()
+			{
+				if (Subscription != null)
+				{
+					Subscription.Dispose();
+					Subscription = null;
+				}
+
+				Value = null;
+				HasValue = false;
+			}
+		}
+
+		List<Expression> _args = new List<Expression>();
+		public IList<Expression> Arguments { get { return _args; } }
+
+		public override IDisposable Subscribe(IContext context, IListener listener)
+		{
+			return new Subscription(this, context, listener);
+		}
+
+		/** Called when at least some arguments are ready and have new values. 
+			
+			Override in subclass to handle partially complete arguments. If the function are not
+			interested in the arguments before they are all ready, override `OnNewArguments` instead.
+
+			@param args An array of the arguments to the functoin and their status.
+			@param listener The listener which should receive any new data yielded from the function.
+		*/
+		protected virtual void OnNewPartialArguments(Argument[] args, IListener listener)
+		{
+			for (var i = 0; i < args.Length; i++)
+				if (!args[i].HasValue) return;
+
+			OnNewArguments(args, listener);
+		}
+
+		/** Called when all the arguments are ready and have new values.
+
+			Override in subclass to handle complete argument lists. If the function is interested in
+			partially ready argument lists, override `OnNewPartialArguments` instead.
+
+			@param args An array of the arguments to the functoin and their status. The `HasValue` flag is always true for all arguments in this callback.
+			@param listener The listener which should receive any new data yielded from the function.
+		*/
+		protected virtual void OnNewArguments(Argument[] args, IListener listener)
+		{
+			// Do nothing by defalt
+		}
+
+		public class Subscription: InnerListener
+		{
+			IListener _listener;
+			VarArgFunction _func;
+			Argument[] _arguments;
+
+			public Subscription(VarArgFunction func, IContext context, IListener listener)
+			{
+				_func = func;
+				_listener = listener;
+
+				_arguments = new Argument[func.Arguments.Count];
+
+				for (var i = 0; i < func.Arguments.Count; i++)
+					_arguments[i] = new Argument();
+
+				// First create argument objects, *then* subscribe. Otherwise we
+				// get callbacks before we're fully initialized.
+				for (var i = 0; i < func.Arguments.Count; i++)
+					_arguments[i].Subscription = func.Arguments[i].Subscribe(context, this);
+			}
+
+			protected override void OnNewData(IExpression source, object value)
+			{
+				for (var i = 0; i < _func.Arguments.Count; i++)
+					if (_func.Arguments[i] == source)
+					{
+						_arguments[i].Value = value;
+						_arguments[i].HasValue = true;
+					}
+
+				PushData();
+			}
+
+			internal void PushData()
+			{
+				_func.OnNewPartialArguments(_arguments, _listener);
+			}
+
+			public override void Dispose()
+			{
+				base.Dispose();
+
+				for (var i = 0; i < _arguments.Length; i++)
+					_arguments[i].Dispose();
+				
+				_listener = null;
+				_func = null;
+				_arguments = null;
+			}
+		}
+
+	}
+}

--- a/Source/Fuse.Reactive.Expressions/VectorFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/VectorFunctions.uno
@@ -1,53 +1,44 @@
+using Uno;
+using Uno.Collections;
 using Uno.UX;
+using Uno.Text;
 
 namespace Fuse.Reactive
 {
-	public class Vector2: BinaryOperator
+	/** Creates an `IArray` from an arbitrary number of arguments.
+		An `IArray` can be automatically marshalled to any Uno vector type (e.g. `float4`)
+	*/
+	public class Vector: VarArgFunction
 	{
-		[UXConstructor]
-		public Vector2([UXParameter("X")] Expression x, [UXParameter("Y")] Expression y): base(x, y) { }
-
-		protected override object Compute(object left, object right)
+		protected override void OnNewArguments(Argument[] args, IListener listener)
 		{
-			if (left is Size || right is Size) return new Size2(Marshal.ToSize(left), Marshal.ToSize(right));
-			return float2(Marshal.ToFloat(left), Marshal.ToFloat(right));
+			listener.OnNewData(this, new Array(args));
 		}
 
-		public override string ToString()
+		class Array: IArray
 		{
-			return "(" + Left + ", " + Right + ")";
-		}
-	}
+			object[] _items;
+			public Array(Argument[] args)
+			{
+				_items = new object[args.Length];
+				for (var i = 0; i < args.Length; i++)
+					_items[i] = args[i].Value;
+			}
+			object IArray.this[int index] { get { return _items[index]; } }
+			int IArray.Length { get { return _items.Length; } }
 
-	public class Vector3: TernaryOperator
-	{
-		[UXConstructor]
-		public Vector3([UXParameter("X")] Expression x, [UXParameter("Y")] Expression y, [UXParameter("Z")] Expression z) : base(x,y,z) {}
-
-		protected override object Compute(object first, object second, object third)
-		{
-			return float3(Marshal.ToFloat(first), Marshal.ToFloat(second), Marshal.ToFloat(third));
-		}
-
-		public override string ToString()
-		{
-			return "(" + First + ", " + Second + ", " + Third + ")";
-		}
-	}
-
-	public class Vector4: QuaternaryOperator
-	{
-		[UXConstructor]
-		public Vector4([UXParameter("X")] Expression x, [UXParameter("Y")] Expression y, [UXParameter("Z")] Expression z, [UXParameter("W")] Expression w) : base(x,y,z,w) {}
-
-		protected override object Compute(object first, object second, object third, object fourth)
-		{
-			return float4(Marshal.ToFloat(first), Marshal.ToFloat(second), Marshal.ToFloat(third), Marshal.ToFloat(fourth));
-		}
-
-		public override string ToString()
-		{
-			return "(" + First + ", " + Second + ", " + Third + ", " + Fourth + ")";
+			public override string ToString()
+			{
+				var sb = new StringBuilder();
+				sb.Append("(");
+				for (var i = 0; i < _items.Length; i++)
+				{
+					if (i > 0) sb.Append(", ");
+					sb.Append(_items[i].ToString());
+				}
+				sb.Append(")");
+				return sb.ToString();
+			}
 		}
 	}
 }

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/VarArgs.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/VarArgs.ux
@@ -1,3 +1,3 @@
 <Panel ux:Class="UX.VarArgs">
-	<Text ux:Name="t">{varargs_test(1,2,3,5,8,13,21,34) + varargs_test(1,1,1,1) + varargs_test() + varargs_test(19) + (varargs_test(5, never_yield(), 9) ?? 0)}</Text>	
+	<Text ux:Name="t">{varargs_test(1,2,3,5,8,13,21,34) + varargs_test(1,1,1,1) + varargs_test() + varargs_test((19,2)) + (varargs_test(5, never_yield(), 9) ?? 0)}</Text>	
 </Panel>

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/VarArgs.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/VarArgs.ux
@@ -1,0 +1,3 @@
+<Panel ux:Class="UX.VarArgs">
+	<Text ux:Name="t">{varargs_test(1,2,3,5,8,13,21,34) + varargs_test(1,1,1,1) + varargs_test() + varargs_test(19) + (varargs_test(5, never_yield(), 9) ?? 0)}</Text>	
+</Panel>

--- a/Source/Fuse.Reactive.JavaScript/Tests/VarArgsTest.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/VarArgsTest.uno
@@ -41,7 +41,8 @@ namespace Fuse.Reactive.Test
 			}
 			else if (args.Length == 1)
 			{
-				Assert.AreEqual(19, args[0].Value);
+				// Parenthesized comma-expressions should parse as vectors
+				Assert.AreEqual(float2(19,2), Marshal.ToFloat2(args[0].Value));
 			}
 			else if (args.Length != 0)
 			{

--- a/Source/Fuse.Reactive.JavaScript/Tests/VarArgsTest.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/VarArgsTest.uno
@@ -1,0 +1,66 @@
+using Uno;
+using Uno.Collections;
+using Uno.UX;
+using Uno.Testing;
+
+using Fuse.Controls;
+using Fuse.Navigation;
+using FuseTest;
+
+namespace Fuse.Reactive.Test
+{
+	[UXFunction("never_yield")]
+	public class VarArgsTestNeverYield: Fuse.Reactive.VarArgFunction
+	{
+		// A function that never yields any value
+	}
+
+	[UXFunction("varargs_test")]
+	public class VarArgsTestFunc: Fuse.Reactive.VarArgFunction
+	{
+		internal static int C;
+
+		protected override void OnNewPartialArguments(Argument[] args, IListener listener)
+		{
+			// We want to get this callback exactly 2 times for args.Length == 3
+			if (args.Length == 3) C++;
+			base.OnNewPartialArguments(args, listener);
+		}
+
+		protected override void OnNewArguments(Argument[] args, IListener listener)
+		{
+			if (args.Length == 8)
+			{
+				Assert.AreEqual(1, args[0].Value);
+				Assert.AreEqual(34, args[7].Value);
+			}
+			else if (args.Length == 4)
+			{
+				Assert.AreEqual(1, args[0].Value);
+				Assert.AreEqual(1, args[3].Value);
+			}
+			else if (args.Length == 1)
+			{
+				Assert.AreEqual(19, args[0].Value);
+			}
+			else if (args.Length != 0)
+			{
+				// We don't want to see the one with 3 components where the middle component never yields
+				Assert.IsTrue(false);
+			}
+			listener.OnNewData(this, 12);
+		}
+	}
+
+	public class VarArgs : TestBase
+	{
+		[Test]
+		public void Basics()
+		{
+			var e = new UX.VarArgs();
+			var root = TestRootPanel.CreateWithChild(e);
+			Assert.AreEqual("48", e.t.Value);
+			Assert.AreEqual(2, VarArgsTestFunc.C);
+		}
+	}
+}

--- a/Source/Fuse.Reactive.JavaScript/Tests/VarArgsTest.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/VarArgsTest.uno
@@ -22,8 +22,12 @@ namespace Fuse.Reactive.Test
 
 		protected override void OnNewPartialArguments(Argument[] args, IListener listener)
 		{
-			// We want to get this callback exactly 2 times for args.Length == 3
-			if (args.Length == 3) C++;
+			// We want to get this callback exactly 3 times for args.Length == 3 (0, 1 and 2 arguments ready)
+			if (args.Length == 3) 
+			{
+				C++;
+				Assert.IsFalse(args[1].HasValue);
+			}
 			base.OnNewPartialArguments(args, listener);
 		}
 
@@ -61,7 +65,7 @@ namespace Fuse.Reactive.Test
 			var e = new UX.VarArgs();
 			var root = TestRootPanel.CreateWithChild(e);
 			Assert.AreEqual("48", e.t.Value);
-			Assert.AreEqual(2, VarArgsTestFunc.C);
+			Assert.AreEqual(3, VarArgsTestFunc.C);
 		}
 	}
 }

--- a/Stuff/uno.stuff
+++ b/Stuff/uno.stuff
@@ -1,5 +1,5 @@
 if WIN32 {
-    /* 13.77MB */ bin: "https://az664292.vo.msecnd.net/files/cRt2qErfgxqOPpjt-uno-1.1.3+5523-master-849bf03-win32.zip"
+    /* 13.77MB */ bin: "https://az664292.vo.msecnd.net/files/DmBD14vXWXT7KU5B-uno-1.1.3+5528-master-c7be15e-win32.zip"
 } else if MAC {
-    /* 17.26MB */ bin: "https://az664292.vo.msecnd.net/files/eWYJq67c6Pyg2xEE-uno-1.1.3+5523-master-849bf03-macOS.zip"
+    /* 17.26MB */ bin: "https://az664292.vo.msecnd.net/files/9K3ZtDSeuaUY1At5-uno-1.1.3+5528-master-c7be15e-macOS.zip"
 }


### PR DESCRIPTION
Inheriting  from the `Fuse.Reactive.VarArgFunction` class gives variable argument support.

The classes `Vector2`, `Vector3` and `Vector4` in `Fuse.Reactive` are now removed and replaced with the general purpose, variable-argument version `Vector` instead. This ensures vectors of any length are treated the same way. These changes are covered by lots of existing tests.

Needs new Uno stuff with https://github.com/fusetools/uno/pull/1223

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
