### PR TITLE
allows TemplateSource change post rooting. 

### DIFF
--- a/Source/Fuse.Reactive.Bindings/Instance.API.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.API.uno
@@ -197,7 +197,16 @@ namespace Fuse.Reactive
 		public ITemplateSource TemplateSource
 		{
 			get { return _weakTemplateSource; }
-			set { _weakTemplateSource = value; }
+			set 
+			{ 
+				_weakTemplateSource = value; 
+				
+				if (IsRootingCompleted)
+				{
+					_templateSource = _weakTemplateSource;
+					Repopulate();
+				}
+			}
 		}
 		//https://github.com/fusetools/fuselibs-public/issues/135
 		[WeakReference]

--- a/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
@@ -676,5 +676,28 @@ namespace Fuse.Reactive.Test
 				Assert.AreEqual( "1,2,1,2", GetText(e));
 			}
 		}
+		
+		[Test]
+		//change TemplateSource after rooting
+		public void TemplateSource()
+		{
+			var e=  new UX.Each.TemplateSource();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				Assert.AreEqual( "A", GetDudZ(e.tb));
+				
+				e.each.TemplateSource = e.tb;
+				root.PumpDeferred();
+				Assert.AreEqual( "B", GetDudZ(e.tb));
+				
+				e.each.TemplateSource = e.tc;
+				root.PumpDeferred();
+				Assert.AreEqual( "C", GetDudZ(e.tb));
+				
+				e.each.TemplateSource = null;
+				root.PumpDeferred();
+				Assert.AreEqual( "A", GetDudZ(e.tb));
+			}
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Each.TemplateSource.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Each.TemplateSource.ux
@@ -1,0 +1,13 @@
+<Panel ux:Class="UX.Each.TemplateSource">
+	<Panel ux:Name="tb">
+		<Each Count="1" TemplateKey="one" ux:Name="each">
+			<FuseTest.DudElement StringValue="A"/>
+		</Each>
+		
+		<FuseTest.DudElement ux:Template="one" StringValue="B"/>
+	</Panel>
+	
+	<Panel ux:Name="tc">
+		<FuseTest.DudElement ux:Template="one" StringValue="C"/>
+	</Panel>
+</Panel>


### PR DESCRIPTION
Charting depended on a particular initialization order (bad), this would correct that, but I also fixed Charting. This feature is not strictly required but it costs nothing to add (it may also address a very unlikely backwards incompatilbe issue with my fix for the memory loop on TemplateSource)

This PR contains:
- [-] Changelog : No effective change for users, addressed internal issue.
- [-] Documentation
- [x] Tests
