### PR TITLE
Image: set container IsRooted to true after subscribing for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Image
+- Fixed issue where an `<Image />` could fail to display inside a `<NativeViewHost />` on iOS
+
 ## Router
 - Added `findRouter` function making it easier to use a router in a page deep inside the UI
 

--- a/Source/Fuse.Controls.Primitives/Image.uno
+++ b/Source/Fuse.Controls.Primitives/Image.uno
@@ -94,10 +94,10 @@ namespace Fuse.Controls
 			AddDrawCost(1.0);
 
 			IsVisibleChanged += OnIsVisibleChanged;
-			_container.IsRooted = true;
 			_container.ParamChanged += OnContainerParamChanged;
 			_container.SourceChanged += OnContainerSourceChanged;
 			_container.SourceError += OnContainerSourceError;
+			_container.IsRooted = true;
 		}
 		
 		protected override void OnUnrooted()


### PR DESCRIPTION
If the ImageContainer emits any of its events we want to know, must move the IsRooted = true to after subscribing to the events since that might make it emit events.

Fixes https://github.com/fusetools/fuselibs-public/issues/164. Caused by the SourceChanged event firing before we had subscribed

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
