### PR TITLE
Android.TextEdit: fix TextEditRenderer alignment issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Image
 - Fixed issue where an `<Image />` could fail to display inside a `<NativeViewHost />` on iOS
 
+## TextInput
+- Fixed issue on Android causing text to align incorrectly if being scrolled and unfocused.
+
 ## Router
 - Added `findRouter` function making it easier to use a router in a page deep inside the UI
 - Fixed and issue where relative paths and nested `Router` gave an error about unknown paths


### PR DESCRIPTION
Text alignment always broke the first time drawing due to the internal text alignment state in TextView not being valid. The previous workaround was to align the text ourselves with a grid. This aligned the text correct as long as it did not overflow its layout bounds. By reading the source code for TextView I figured out what to do to make the internal state update appropriately. See the code for more details.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
