### PR TITLE
Android.TextEdit: fix TextEditRenderer alignment issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@
 ## Fuse.Drawing.Surface
 - Added support for the Surface API in native UI for iOS. Meaning that `Curve`, `VectorLayer` and charting will work inside a `NativeViewHost`.
 
+## TextInput
+- Fixed issue on Android causing text to align incorrectly if being scrolled and unfocused.
+
 ## WrapPanel
 - Added possibility to use `RowAlignment` to align the elements in the major direction of the `WrapPanel` as well as in the minor.
-# TextInput
-- Fixed issue on Android causing text to align incorrectly if being scrolled and unfocused.
 
 ## Triggers
 - Several triggers were modified to properly look up the tree for a target node, whereas previously they may have only checked the immediate parent. The affected triggers are `BringIntoView`, `Show`,`Hide`,`Collapse`, `Toggle`, `TransitionState`, `Callback`, `CancelInteractions`, `Stop`, `Play`, `Resume`, `Pause`, `TransitionLayout`, `BringToFront`, `SendToBack`, `EvaluateJS`, `RaiseUserEvent`, `ScrollTo`. This should only change previous behavior if the action was previously configured incorrectly and did nothing or already found the wrong node. Many of the actions have a `Target` to target a specific node, or `TargetNode` to specify where the search begins.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ## WrapPanel
 - Added possibility to use `RowAlignment` to align the elements in the major direction of the `WrapPanel` as well as in the minor.
+# TextInput
+- Fixed issue on Android causing text to align incorrectly if being scrolled and unfocused.
 
 ## Triggers
 - Several triggers were modified to properly look up the tree for a target node, whereas previously they may have only checked the immediate parent. The affected triggers are `BringIntoView`, `Show`,`Hide`,`Collapse`, `Toggle`, `TransitionState`, `Callback`, `CancelInteractions`, `Stop`, `Play`, `Resume`, `Pause`, `TransitionLayout`, `BringToFront`, `SendToBack`, `EvaluateJS`, `RaiseUserEvent`, `ScrollTo`. This should only change previous behavior if the action was previously configured incorrectly and did nothing or already found the wrong node. Many of the actions have a `Target` to target a specific node, or `TargetNode` to specify where the search begins.

--- a/Tests/ManualTests/ManualTestingApp/Singles/TextInputPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/TextInputPage.ux
@@ -22,32 +22,32 @@
 				<Change TheFill.Color="0.6,0.4,0.4,1" Duration="0.3"/>
 			</WhileTrue>
 		</ToggleControl>
-		
+
 		<Grid Columns="30,1*" CellSpacing="5" Margin="15" DefaultRow="auto">
 
 			<h2 ColumnSpan="2">Single Line</h2>
 			<Indicator ux:Name="IndSingle"/>
-			<StdTextInput ux:Name="SingleInput" Value="Scroll page up/down while editing"> 
+			<StdTextInput ux:Name="SingleInput" Value="Scroll page up/down while editing">
 			<!-- TODO:https://github.com/fusetools/fuselibs/issues/1465
 				TextAlignment="Center" -->
 				<WhileFocusWithin><Change IndSingle.Value="true"/></WhileFocusWithin>
 			</StdTextInput>
-			
+
 			<h2 ColumnSpan="2">Password text with background color</h2>
 			<Indicator ux:Name="IndPassword"/>
 			<StdTextInput ux:Name="PasswordInput" IsPassword="true" Value="Hidden text"
 				Background="#FFc">
-				<!-- TODO: https://github.com/fusetools/fuselibs/issues/1387 
+				<!-- TODO: https://github.com/fusetools/fuselibs/issues/1387
 					Alignment="Right" -->
 				<WhileFocusWithin><Change IndPassword.Value="true"/></WhileFocusWithin>
 			</StdTextInput>
-			
+
 			<h2 ColumnSpan="2">Disabled text, cannot edit</h2>
 			<Indicator ux:Name="IndDisabled"/>
 			<StdTextInput ux:Name="DisabledInput" Value="Disabled Input" IsEnabled="False">
 				<WhileFocusWithin><Change IndDisabled.Value="true"/></WhileFocusWithin>
 			</StdTextInput>
-			
+
 			<h2 ColumnSpan="2">Multiple lines, left aligned text, background color (whole width)</h2>
 			<Indicator ux:Name="IndMultiline"/>
 			<TextView ux:Name="MultilineInput" TextWrapping="Wrap"
@@ -57,7 +57,7 @@
 					<Stroke Width="1" Offset="1"><SolidColor Color="#cFc"/></Stroke>
 				</Rectangle>
 			</TextView>
-			
+
 			<h2 ColumnSpan="2">Switch between these two quickly</h2>
 			<Indicator ux:Name="IndSwitch1"/>
 			<StdTextInput Value="Switch between">
@@ -84,6 +84,43 @@
 					<Toggle Target="_linespacing" />
 				</Clicked>
 			</StdButton>
+
+			<h2 ColumnSpan="2">TextInput with TextAlignment</h2>
+			<Indicator ux:Name="IndTextAlignmentLeft"/>
+			<StdTextInput TextAlignment="Left" PlaceholderText="Left">
+				<WhileFocusWithin><Change IndTextAlignmentLeft.Value="true" /></WhileFocusWithin>
+			</StdTextInput>
+			<Indicator ux:Name="IndTextAlignmentCenter"/>
+			<StdTextInput TextAlignment="Center" PlaceholderText="Center">
+				<WhileFocusWithin><Change IndTextAlignmentCenter.Value="true" /></WhileFocusWithin>
+			</StdTextInput>
+			<Indicator ux:Name="IndTextAlignmentRight"/>
+			<StdTextInput TextAlignment="Right" PlaceholderText="Right">
+				<WhileFocusWithin><Change IndTextAlignmentRight.Value="true" /></WhileFocusWithin>
+			</StdTextInput>
+
+			<h2 ColumnSpan="2">Animating TextAlignment</h2>
+			<Indicator ux:Name="IndTextAlignmentAnimate"/>
+			<StdTextInput PlaceholderText="TextAlignment" ux:Name="_textAlignment">
+				<WhileFocusWithin><Change IndTextAlignmentAnimate.Value="true" /></WhileFocusWithin>
+			</StdTextInput>
+			<Grid ColumnSpan="2" Columns="1*,1*,1*">
+				<StdButton Text="Left">
+					<Clicked>
+						<Set _textAlignment.TextAlignment="Left" />
+					</Clicked>
+				</StdButton>
+				<StdButton Text="Center">
+					<Clicked>
+						<Set _textAlignment.TextAlignment="Center" />
+					</Clicked>
+				</StdButton>
+				<StdButton Text="Right">
+					<Clicked>
+						<Set _textAlignment.TextAlignment="Right" />
+					</Clicked>
+				</StdButton>
+			</Grid>
 		</Grid>
 	</ScrollView>
 </Page>


### PR DESCRIPTION
Text alignment always broke the first time drawing due to the internal text alignment state in TextView not being valid. The previous workaround was to align the text ourselves with a grid. This aligned the text correct as long as it did not overflow its layout bounds. By reading the source code for TextView I figured out what to do to make the internal state update appropriately. See the code for more details.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [x] Tests
