### PR TITLE
fixed visibility error on JavaScript member

### DIFF
--- a/Source/Fuse.Reactive.JavaScript/JavaScript.uno
+++ b/Source/Fuse.Reactive.JavaScript/JavaScript.uno
@@ -25,7 +25,7 @@ namespace Fuse.Reactive
 		internal static ThreadWorker Worker { get { return _worker; } }
 
 		readonly NameTable _nameTable;
-		protected RootableScriptModule _scriptModule;
+		RootableScriptModule _scriptModule;
 		internal RootableScriptModule ScriptModule { get { return _scriptModule; } }
 
 		[UXConstructor]

--- a/Source/Fuse.Testing/JavaScriptTest.uno
+++ b/Source/Fuse.Testing/JavaScriptTest.uno
@@ -53,8 +53,8 @@ namespace Fuse.Testing
 		[UXConstructor]
 		public JavaScriptTest([UXAutoNameTable] NameTable nameTable) : base(nameTable)
 		{
-			_scriptModule.Preamble = "try {\n";
-			_scriptModule.Postamble = "\n} catch (err) {\n" +
+			ScriptModule.Preamble = "try {\n";
+			ScriptModule.Postamble = "\n} catch (err) {\n" +
 			                          "\tvar helper = require(\"FuseJS/Internal/UnoTestingHelper\");\n" +
 			                          "\thelper.testFailed(\"stack\" in err ? err.stack : err.message);\n" +
 			                          "}\n";


### PR DESCRIPTION
Since RootableScriptModule is `internal` i made JavaScript._scriptModule `protected internal`.

The unodoc backend complains otherwise even though the uno compiler doesn't for some reason.