### PR TITLE
Made DataBinding.Key UXVerbatim to interpret in data space

### DIFF
--- a/Source/Fuse.Reactive.Bindings/DataBinding.uno
+++ b/Source/Fuse.Reactive.Bindings/DataBinding.uno
@@ -34,6 +34,8 @@ namespace Fuse.Reactive
 
 			<Panel ux:Name="panel1" Width="100" />
 			<DataBinding Target="panel1.Width" Key="panelWidth" />
+
+		> Note: The expression passed to `Key` in explicit mode is by default in the data scope. To reference global names, escape it using `{= }`
 		
 		The above code will use `100` as the default value for `panel1.Width` until the `panelWidth`
 		data is resolved.
@@ -50,7 +52,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public DataBinding(
 			[UXParameter("Target")] Uno.UX.Property target, 
-			[UXParameter("Key"), UXExpression] IExpression key, 
+			[UXParameter("Key"), UXVerbatim] IExpression key, 
 			[UXAutoNameTable, UXParameter("NameTable")] NameTable nameTable,
 			[UXParameter("Mode"), UXDefaultValue("Default")] BindingMode mode): base(key, nameTable)
 		{

--- a/Source/Fuse.Reactive.Bindings/EventBinding.uno
+++ b/Source/Fuse.Reactive.Bindings/EventBinding.uno
@@ -26,7 +26,7 @@ namespace Fuse.Reactive
 	public class EventBinding: ExpressionBinding
 	{
 		[UXConstructor]
-		public EventBinding([UXParameter("Key")] IExpression key, [UXAutoNameTable, UXParameter("NameTable")] NameTable nameTable): base(key, nameTable)
+		public EventBinding([UXParameter("Key"), UXVerbatim] IExpression key, [UXAutoNameTable, UXParameter("NameTable")] NameTable nameTable): base(key, nameTable)
 		{
 		}
 


### PR DESCRIPTION
This allows new features to use `IExpression` as data type for properties without hitting the legacy code path that always interprets those expressions in data space

This must be merged along with https://github.com/fusetools/uno/pull/1224

