### PR TITLE
Trigger Action Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Triggers
+- Several triggers were modified to properly look up the tree for a target node, whereas previously they may have only checked the immediate parent. The affected triggers are `BringIntoView`, `Show`,`Hide`,`Collapse`, `Toggle`, `TransitionState`, `Callback`, `CancelInteractions`, `Stop`, `Play`, `Resume`, `Pause`, `TransitionLayout`, `BringToFront`, `SendToBack`, `EvaluateJS`, `RaiseUserEvent`, `ScrollTo`. This should only change previous behavior if the action was previously configured incorrectly and did nothing or already found the wrong node. Many of the actions have a `Target` to target a specific node, or `TargetNode` to specify where the search begins.
+
 ## Image
 - Fixed issue where an `<Image />` could fail to display inside a `<NativeViewHost />` on iOS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Triggers
 - Several triggers were modified to properly look up the tree for a target node, whereas previously they may have only checked the immediate parent. The affected triggers are `BringIntoView`, `Show`,`Hide`,`Collapse`, `Toggle`, `TransitionState`, `Callback`, `CancelInteractions`, `Stop`, `Play`, `Resume`, `Pause`, `TransitionLayout`, `BringToFront`, `SendToBack`, `EvaluateJS`, `RaiseUserEvent`, `ScrollTo`. This should only change previous behavior if the action was previously configured incorrectly and did nothing or already found the wrong node. Many of the actions have a `Target` to target a specific node, or `TargetNode` to specify where the search begins.
+- Changed/fixed `Trigger` to provide the trigger itself as the target node to a `TriggerAction`, previously it'd provide the parent of the trigger. The old behaviour was due to an old tree structure. This should have been updated a long time ago. This allows actions to reference the trigger in which they are contained. If you've created a custom Uno `TriggerAction` and need the old behaviour modify your `Perform(Node target)` to use `target.Parent`. Triggers should in general scan upwards from the target node.
 
 ## Image
 - Fixed issue where an `<Image />` could fail to display inside a `<NativeViewHost />` on iOS

--- a/Source/Fuse.Common/Tests/FuseTest/TestBase.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestBase.uno
@@ -156,6 +156,24 @@ namespace FuseTest
 			return q;
 		}
 		
+		/** Get a stringified version of the UseValue's of the DudElement children in Z order */
+		static public string GetDudZ(Visual root)
+		{
+			var q = "";
+			for (int i=0; i < root.ZOrderChildCount; ++i)
+			{
+				var t = root.GetZOrderChild(i) as FuseTest.DudElement;
+				if (t != null)
+				{
+					if (q.Length > 0)
+						q += ",";
+					q += t.UseValue;
+				}
+			}
+			return q;
+		}
+		
+		
 		/**
 			Use this rather than access Progress directly. It limits how many projects we have
 			to expose Internals to.

--- a/Source/Fuse.Controls.Navigation/NavigationActions.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationActions.uno
@@ -15,7 +15,7 @@ namespace Fuse.Triggers.Actions
 		protected override void Perform(Node n) 
 		{
 			_pendVisual = n.FindByType<Visual>();
-			_pendNavigator = n == null ? null : n.Parent as Navigator;
+			_pendNavigator = _pendVisual == null ? null : _pendVisual.Parent as Navigator;
 			if (_pendVisual == null || _pendNavigator == null)
 			{
 				Fuse.Diagnostics.UserError( "Requires a Visual and Navigator parent", this );

--- a/Source/Fuse.Controls.Navigation/NavigationActions.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationActions.uno
@@ -14,7 +14,7 @@ namespace Fuse.Triggers.Actions
 		Navigator _pendNavigator;
 		protected override void Perform(Node n) 
 		{
-			_pendVisual = n as Visual;
+			_pendVisual = n.FindByType<Visual>();
 			_pendNavigator = n == null ? null : n.Parent as Navigator;
 			if (_pendVisual == null || _pendNavigator == null)
 			{

--- a/Source/Fuse.Controls.ScrollView/ScrollView.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollView.uno
@@ -377,7 +377,12 @@ namespace Fuse.Controls
 		*/
 		public void GotoRelative( float2 position )
 		{
-			Goto( (MaxScroll - MinScroll) * position + MinScroll );
+			Goto( RelativeToAbsolutePosition(position) );
+		}
+		
+		public float2 RelativeToAbsolutePosition( float2 pos )
+		{
+			return MinScroll + (MaxScroll - MinScroll) * pos;
 		}
 		
 		float2 FromScalarPosition( float value )

--- a/Source/Fuse.Controls.ScrollView/ScrollView.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollView.uno
@@ -380,7 +380,7 @@ namespace Fuse.Controls
 			Goto( RelativeToAbsolutePosition(position) );
 		}
 		
-		public float2 RelativeToAbsolutePosition( float2 pos )
+		internal float2 RelativeToAbsolutePosition( float2 pos )
 		{
 			return MinScroll + (MaxScroll - MinScroll) * pos;
 		}

--- a/Source/Fuse.Controls.ScrollView/Scroller.Actions.uno
+++ b/Source/Fuse.Controls.ScrollView/Scroller.Actions.uno
@@ -6,6 +6,12 @@ using Fuse.Triggers.Actions;
 
 namespace Fuse.Gestures
 {
+	public enum ScrollToHow
+	{
+		Goto,
+		Seek,
+	}
+	
 	/** Scrolls a @ScrollView to a given position when triggered.
 	
 		### Absolute position
@@ -84,16 +90,31 @@ namespace Fuse.Gestures
 				_hasRelativePosition = true;
 			}
 		}
+	
+		ScrollToHow _how = ScrollToHow.Goto;
+		public ScrollToHow How
+		{
+			get { return _how; }
+			set { _how = value; }
+		}
 		
 		protected override void Perform(Node target)
 		{
-			if (Target == null)
+			var scrollView = Target ?? target.FindByType<ScrollView>();
+			if (scrollView == null)
+			{
+				Fuse.Diagnostics.UserError( "Unabled to locate ScrollView", this );
 				return;
+			}
 				
-			if (_hasRelativePosition)
-				Target.Goto(Target.MinScroll + (Target.MaxScroll - Target.MinScroll)*_relativePosition);
-			else if (_hasPosition)
-				Target.Goto(_position);
+			var toPos = _hasRelativePosition ?
+				scrollView.RelativeToAbsolutePosition(_relativePosition) :
+				_position;
+				
+			if (How == ScrollToHow.Goto)
+				scrollView.Goto(toPos);
+			else
+				scrollView.ScrollPosition = toPos;
 		}
 	}
 

--- a/Source/Fuse.Controls.ScrollView/Tests/ScrollTo.Test.uno
+++ b/Source/Fuse.Controls.ScrollView/Tests/ScrollTo.Test.uno
@@ -1,0 +1,46 @@
+using Uno;
+using Uno.UX;
+using Uno.Testing;
+
+using FuseTest;
+
+using Fuse.Elements;
+
+namespace Fuse.Controls.ScrollToTest
+{
+	public class ScrollToTest : TestBase
+	{
+		[Test]
+		public void Basic()
+		{
+			var s = new UX.ScrollTo.Basic();
+			using (var root = TestRootPanel.CreateWithChild(s,int2(500)))
+			{
+				s.stA.Pulse();
+				root.StepFrame(5); //stabilize animation
+				Assert.AreEqual(300,s.ScrollPosition.Y);
+				
+				s.stB.Pulse();
+				root.StepFrame(5); //stabilize animation
+				Assert.AreEqual(750,s.ScrollPosition.Y);
+			}
+		}
+		
+		[Test]
+		public void Target()
+		{
+			var p = new UX.ScrollTo.Target();
+			using (var root = TestRootPanel.CreateWithChild(p,int2(500)))
+			{
+				p.stA.Pulse();
+				root.StepFrame(5); //stabilize animation
+				Assert.AreEqual(300,p.s.ScrollPosition.Y);
+				
+				p.stB.Pulse();
+				//no need to wait, was seek
+				root.PumpDeferred();
+				Assert.AreEqual(750,p.s.ScrollPosition.Y);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Controls.ScrollView/Tests/ScrollView.Test.uno
+++ b/Source/Fuse.Controls.ScrollView/Tests/ScrollView.Test.uno
@@ -55,7 +55,7 @@ namespace Fuse.Controls.ScrollViewTest
 		public void BringIntoViewTest()
 		{
 			var root = new TestRootPanel();
-			var parent = new UX.BringIntoView();
+			var parent = new UX.ScrollView.BringIntoView();
 			root.Children.Add(parent);
 			
 			var scrollViewBehavior = parent.TestScroller;

--- a/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollTo.Basic.ux
+++ b/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollTo.Basic.ux
@@ -1,0 +1,11 @@
+<ScrollView ux:Class="UX.ScrollTo.Basic">
+	<Rectangle Height="2000">
+		<Timeline ux:Name="stB">
+			<ScrollTo RelativePosition="0.5"/>
+		</Timeline>
+	</Rectangle>
+	
+	<Timeline ux:Name="stA">
+		<ScrollTo Position="300"/>
+	</Timeline>
+</ScrollView>

--- a/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollTo.Target.ux
+++ b/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollTo.Target.ux
@@ -1,0 +1,14 @@
+<Panel ux:Class="UX.ScrollTo.Target">
+	<Panel>
+		<ScrollView ux:Name="s">
+			<Rectangle Height="2000"/>
+		</ScrollView>
+		
+		<Timeline ux:Name="stB">
+			<ScrollTo How="Seek" Target="s" RelativePosition="0.5"/>
+		</Timeline>
+	</Panel>
+	<Timeline ux:Name="stA">
+		<ScrollTo Target="s" Position="300"/>
+	</Timeline>
+</Panel>

--- a/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollView.BringIntoView.ux
+++ b/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollView.BringIntoView.ux
@@ -1,4 +1,4 @@
-<ScrollView ux:Class="UX.BringIntoView">
+<ScrollView ux:Class="UX.ScrollView.BringIntoView">
 	<StackPanel ux:Name="S1">
 		<Panel Height="300" ux:Name="P1"/>
 		<Panel Height="300" ux:Name="P2"/>

--- a/Source/Fuse.Controls.WebView/EvaluateJS.uno
+++ b/Source/Fuse.Controls.WebView/EvaluateJS.uno
@@ -134,12 +134,9 @@ namespace Fuse.Triggers.Actions
 
 		protected override void Perform(Node target)
 		{
-			if (_target == null && target is IWebView)
-			{
-				_target = target as IWebView;
-			}
+			var webView = _target ?? target.FindByType<IWebView>();
 
-			if (_target != null && _rawSource != "")
+			if (webView != null && _rawSource != "")
 			{
 				Execute();
 			}

--- a/Source/Fuse.Controls.WebView/WebViewNavActions.uno
+++ b/Source/Fuse.Controls.WebView/WebViewNavActions.uno
@@ -12,10 +12,7 @@ namespace Fuse.Triggers.Actions
 
 		protected override void Perform(Node target)
 		{
-			var v = target as Visual;
-			if (v == null) return;
-
-			var webView = v.FindByType<WebView>();
+			var webView = target.FindByType<WebView>();
 			if (webView != null)
 				Execute(webView);
 		}

--- a/Source/Fuse.Controls/Tests/BringToFront.Test.uno
+++ b/Source/Fuse.Controls/Tests/BringToFront.Test.uno
@@ -1,0 +1,47 @@
+using Uno;
+
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Controls.Test
+{
+	public class BringToFrontTest : TestBase
+	{
+		[Test]
+		public void ToFront()
+		{
+			var p = new UX.BringToFront.Basic();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( "C,B,A", GetDudZ(p));
+				
+				p.bFront.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( "C,A,B", GetDudZ(p));
+				
+				p.cFront.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( "A,B,C", GetDudZ(p));
+			}
+		}
+		
+		[Test]
+		public void ToBack()
+		{
+			var p = new UX.BringToFront.BackBasic();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( "C,B,A", GetDudZ(p));
+				
+				p.bBack.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( "B,C,A", GetDudZ(p));
+				
+				p.aBack.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( "A,B,C", GetDudZ(p));
+			}
+		}
+	}
+}

--- a/Source/Fuse.Controls/Tests/Fuse.Controls.Test.unoproj
+++ b/Source/Fuse.Controls/Tests/Fuse.Controls.Test.unoproj
@@ -22,20 +22,7 @@
     "Fuse.Controls.Test.Helpers/Fuse.Controls.Test.Helpers.unoproj"
   ],
   "Includes": [
-    "Button.Test.uno:Source",
-    "DockPanel.Test.uno:Source",
-    "WrapPanel.Test.uno:Source",
-    "Image.Test.uno:Source",
-    "Navigation.Test.uno:Source",
-    "Page.Test.uno:Source",
-    "Panel.Test.uno:Source",
-    "Slider.Test.uno:Source",
-    "StackPanel.Test.uno:Source",
-    "StatusBarBackground.Test.uno:Source",
-    "Switch.Test.uno:Source",
-    "TextInput.Test.uno:Source",
-    "Viewbox.Test.uno:Source",
-    "Viewport.Test.uno:Source",
+    "*.uno:Source",
     "UX/*.ux"
   ]
 }

--- a/Source/Fuse.Controls/Tests/UX/BringToFront.BackBasic.ux
+++ b/Source/Fuse.Controls/Tests/UX/BringToFront.BackBasic.ux
@@ -1,0 +1,13 @@
+<Panel ux:Class="UX.BringToFront.BackBasic">
+	<FuseTest.DudElement StringValue="A" ux:Name="a">
+		<Timeline ux:Name="aBack">
+			<SendToBack/>
+		</Timeline>
+	</FuseTest.DudElement>
+	<FuseTest.DudElement StringValue="B" ux:Name="b"/>
+	<FuseTest.DudElement StringValue="C" ux:Name="c"/>
+	
+	<Timeline ux:Name="bBack">
+		<SendToBack Target="b"/>
+	</Timeline>
+</Panel>

--- a/Source/Fuse.Controls/Tests/UX/BringToFront.Basic.ux
+++ b/Source/Fuse.Controls/Tests/UX/BringToFront.Basic.ux
@@ -1,0 +1,13 @@
+<Panel ux:Class="UX.BringToFront.Basic">
+	<FuseTest.DudElement StringValue="A" ux:Name="a"/>
+	<FuseTest.DudElement StringValue="B" ux:Name="b"/>
+	<FuseTest.DudElement StringValue="C" ux:Name="c">
+		<Timeline ux:Name="cFront">
+			<BringToFront/>
+		</Timeline>
+	</FuseTest.DudElement>
+	
+	<Timeline ux:Name="bFront">
+		<BringToFront Target="b"/>
+	</Timeline>
+</Panel>

--- a/Source/Fuse.Controls/Triggers/BringToFront.uno
+++ b/Source/Fuse.Controls/Triggers/BringToFront.uno
@@ -40,7 +40,7 @@ namespace Fuse.Triggers.Actions
 
 		protected override void Perform(Node target)
 		{
-			var elm = Target ?? target as Visual;
+			var elm = Target ?? target.FindByType<Visual>();
 			if (elm != null)
 			{
 				var panel = elm.Parent as Visual;
@@ -85,7 +85,7 @@ namespace Fuse.Triggers.Actions
 
 		protected override void Perform(Node target)
 		{
-			var elm = Target ?? target as Visual;
+			var elm = Target ?? target.FindByType<Visual>();
 			if (elm != null)
 			{
 				var panel = elm.Parent as Visual;

--- a/Source/Fuse.Elements/Tests/BringIntoView.Test.uno
+++ b/Source/Fuse.Elements/Tests/BringIntoView.Test.uno
@@ -1,0 +1,27 @@
+using Uno;
+using Uno.Compiler;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Elements.Test
+{
+	public class BringIntoViewTest : TestBase
+	{
+		[Test]
+		public void Basic()
+		{
+			var p = new global::UX.BringIntoView.Basic();
+			using (var root = TestRootPanel.CreateWithChild(p,int2(100)))
+			{
+				p.t1.Pulse();
+				root.StepFrame(5); //for scroll anim
+				Assert.AreEqual(275, p.ScrollPosition.Y, 1e-2);
+				
+				p.t2.Pulse();
+				root.StepFrame(5); //for scroll anim
+				Assert.AreEqual(580, p.ScrollPosition.Y, 1e-2);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Elements/Tests/Fuse.Elements.Test.unoproj
+++ b/Source/Fuse.Elements/Tests/Fuse.Elements.Test.unoproj
@@ -63,6 +63,7 @@
     "ImageTests/StackPanelScene7.ux:UX",
     "ImageTests/StackPanelScene8.ux:UX",
     "ImageTests/StackPanelScene9.ux:UX",
+    "LayoutAnimation.Test.uno:Source",
     "LayoutFunctions.Test.uno:Source",
     "LimitSizing.Test.uno:Source",
     "RenderBounds.Test.uno:Source",

--- a/Source/Fuse.Elements/Tests/Fuse.Elements.Test.unoproj
+++ b/Source/Fuse.Elements/Tests/Fuse.Elements.Test.unoproj
@@ -1,19 +1,7 @@
 {
   "Packages": [
-    "Fuse.Animations",
-    "Fuse.Controls",
-    "Fuse.Controls.Panels",
-    "Fuse.Controls.Primitives",
-    "Fuse.Controls.Native",
-    "Fuse.Drawing",
-    "Fuse.Elements",
-    "Fuse.Triggers",
-    "Fuse.Reactive",
-    "Fuse.Reactive.Bindings",
-    "Fuse.Reactive.Expressions",
-    "Fuse.Reactive.JavaScript",
-    "Fuse.Common",
-    "Fuse.Nodes",
+	"Fuse",
+	"FuseJS",
     "Uno.Testing"
   ],
   "Projects": [
@@ -23,6 +11,7 @@
   "Includes": [
     "AspectSizing.Test.uno:Source",
     "BoxSizing.Test.uno:Source",
+    "BringIntoView.Test.uno:Source",
     "Caching.Test.uno:Source",
     "ElementBatcher.Test.uno:Source",
     "ElementEventTester.uno:Source",

--- a/Source/Fuse.Elements/Tests/LayoutAnimation.Test.uno
+++ b/Source/Fuse.Elements/Tests/LayoutAnimation.Test.uno
@@ -1,0 +1,35 @@
+using Uno;
+using Uno.Compiler;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Elements.Test
+{
+	public class LayoutAnimationTest : TestBase
+	{
+		[Test]
+		public void TransitionLayout()
+		{
+			var p = new global::UX.LayoutAnimation.TransitionLayout();
+			using (var root = TestRootPanel.CreateWithChild(p,int2(1000)))
+			{
+				Assert.AreEqual(float2(0,0), p.m.LocalToParent(float2(0,0)));
+				Assert.AreEqual(float2(100,100), p.m.ActualSize);
+				
+				p.s1.Pulse();
+				root.StepFrame(); //TODO: in theory PumpDeferred should have been enough here...
+				//note these values should be exact. Animation start is intentionally deferred to the next frame
+				Assert.AreEqual(float2(800,950), p.m.LocalToParent(float2(0,0)));
+				Assert.AreEqual(float2(200,50), p.m.ActualSize);
+				
+				root.StepFrame(2);
+				
+				p.s2.Pulse();
+				root.StepFrame();
+				Assert.AreEqual(float2(0,800), p.m.LocalToParent(float2(0,0)));
+				Assert.AreEqual(float2(50,200), p.m.ActualSize);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Elements/Tests/UX/BringIntoView.Basic.ux
+++ b/Source/Fuse.Elements/Tests/UX/BringIntoView.Basic.ux
@@ -1,0 +1,14 @@
+<ScrollView ux:Class="UX.BringIntoView.Basic">
+	<Panel Height="1000">
+		<Panel ux:Name="a" Height="50" Y="300"/>
+		<Panel ux:Name="b" Height="60" Y="600">
+			<Timeline ux:Name="t2">
+				<BringIntoView/>
+			</Timeline>
+		</Panel>
+	</Panel>
+	
+	<Timeline ux:Name="t1">
+		<BringIntoView TargetNode="a"/>
+	</Timeline>
+</ScrollView>

--- a/Source/Fuse.Elements/Tests/UX/LayoutAnimation.TransitionLayout.ux
+++ b/Source/Fuse.Elements/Tests/UX/LayoutAnimation.TransitionLayout.ux
@@ -1,0 +1,19 @@
+<Panel ux:Class="UX.LayoutAnimation.TransitionLayout">
+	<Panel Height="100" Width="100" X="0" Y="0" ux:Name="m">
+		<LayoutAnimation>
+			<Move Vector="1" RelativeTo="WorldPositionChange" Duration="1" />
+			<Resize Vector="1" RelativeTo="SizeChange" Duration="1" />
+		</LayoutAnimation>
+		<Timeline ux:Name="s1">
+			<TransitionLayout From="f"/>
+		</Timeline>
+	</Panel>
+	
+	<Panel Height="50" Width="200" Alignment="BottomRight" ux:Name="f"/>
+	<Panel Height="200" Width="50" Alignment="BottomLeft" ux:Name="g">
+		<Timeline ux:Name="s2">
+			<TransitionLayout Target="m" From="g"/>
+		</Timeline>
+	</Panel>
+	
+</Panel>

--- a/Source/Fuse.Elements/Triggers/Actions/BringIntoView.uno
+++ b/Source/Fuse.Elements/Triggers/Actions/BringIntoView.uno
@@ -40,7 +40,8 @@ namespace Fuse.Triggers.Actions
 	{
 		protected override void Perform(Node target)
 		{
-			var elm = target as Element;
+			//use Visual for future-proofing this logic (it could be brought into view, just not supported now)
+			var elm = target.FindByType<Visual>() as Element;
 			if (elm != null)	
 				elm.BringIntoView();
 		}

--- a/Source/Fuse.Elements/Triggers/LayoutAnimation.uno
+++ b/Source/Fuse.Elements/Triggers/LayoutAnimation.uno
@@ -348,7 +348,8 @@ namespace Fuse.Triggers.Actions
 		
 		protected override void Perform(Node target)
 		{
-			_perform = Target ?? target.FindByType<Element>();
+			//use Visual search for future-proofing this logic (it could be transitioned, just not supported now)
+			_perform = Target ?? (target.FindByType<Visual>() as Element);
 			if (_perform == null || From == null)
 			{
 				Fuse.Diagnostics.UserError( "Missing `From` or cannot find `Element` target", this );

--- a/Source/Fuse.Elements/Triggers/LayoutAnimation.uno
+++ b/Source/Fuse.Elements/Triggers/LayoutAnimation.uno
@@ -341,12 +341,19 @@ namespace Fuse.Triggers.Actions
 	*/
 	public class TransitionLayout : TriggerAction
 	{
+		/** Explicit target that will be transitioned. If not specified the Element ancestor of the action will be used*/
+		public Element Target { get; set; }
+		/** Transition the element from this one. */
 		public Element From { get; set; }
+		
 		protected override void Perform(Node target)
 		{
-			_perform = target as Element;
+			_perform = Target ?? target.FindByType<Element>();
 			if (_perform == null || From == null)
+			{
+				Fuse.Diagnostics.UserError( "Missing `From` or cannot find `Element` target", this );
 				return;
+			}
 
 			//defer calculations until after layout since either element may have changed layout
 			UpdateManager.AddDeferredAction(Transition,UpdateStage.Layout, LayoutPriority.Placement);

--- a/Source/Fuse.Gestures/Tests/SwipeTests.uno
+++ b/Source/Fuse.Gestures/Tests/SwipeTests.uno
@@ -489,7 +489,7 @@ namespace Fuse.Gestures.Test
 		public double Normal=-1, Later=-1, Post=-1;
 		protected override void Perform(Node target)
 		{
-			SA = (target as UX.Swipe.SimpleDefer).SA;
+			SA = target.FindByType<UX.Swipe.SimpleDefer>().SA;
 			Normal = SA.Progress;
 			UpdateManager.AddDeferredAction(CheckLater, LayoutPriority.Later);
 			UpdateManager.AddDeferredAction(CheckPost, LayoutPriority.Post);

--- a/Source/Fuse.Navigation/Navigation.Locators.uno
+++ b/Source/Fuse.Navigation/Navigation.Locators.uno
@@ -35,7 +35,7 @@ namespace Fuse.Navigation
 			return null;
 		}
 
-		public static INavigation TryFind(Visual node)
+		public static INavigation TryFind(Node node)
 		{
 			//always take the first navigtaon object, even if it isn't an `INavigation`. This prevents
 			//confusing lookup across navigation bounds for different triggers
@@ -79,7 +79,7 @@ namespace Fuse.Navigation
 			This version of TryFindPage is suitable only for single lookups during event response
 			and the value should not be cached since it may change.
 		*/
-		public static Visual TryFindPage(Visual node)
+		public static Visual TryFindPage(Node node)
 		{
 			INavigation nav;
 			Visual bind;

--- a/Source/Fuse.Navigation/TriggerActions.uno
+++ b/Source/Fuse.Navigation/TriggerActions.uno
@@ -12,10 +12,7 @@ namespace Fuse.Navigation
 
 		protected override void Perform(Node n)
 		{
-			var v = n as Visual;
-			if (v == null) return;
-
-			var ctx = NavigationContext ?? Navigation.TryFind(v);
+			var ctx = NavigationContext ?? Navigation.TryFind(n);
 			if (ctx == null)
 			{
 				Fuse.Diagnostics.UserError( "No navigation context was found", this );
@@ -115,10 +112,7 @@ namespace Fuse.Navigation
 
 		protected override void Perform(INavigation ctx, Node n)
 		{
-			var v = n as Visual;
-			if (v == null) return;
-
-			var page = Navigation.TryFindPage(Target ?? v);
+			var page = Navigation.TryFindPage((Node)Target ?? n);
 			if (page != null)
 				ctx.Toggle(page);
 			else
@@ -133,10 +127,7 @@ namespace Fuse.Navigation
 
 		protected sealed override void Perform(Node n)
 		{
-			var v = n as Visual;
-			if (v == null) return;
-
-			var nav = NavigationContext ?? Navigation.TryFindBaseNavigation(v);
+			var nav = NavigationContext ?? Navigation.TryFindBaseNavigation(n);
 
 			if (nav != null)
 				Perform(nav, n);

--- a/Source/Fuse.Nodes/Node.uno
+++ b/Source/Fuse.Nodes/Node.uno
@@ -156,5 +156,22 @@ namespace Fuse
 			}
 			return null;
 		}
+		
+		public T FindByType<T>() where T : Node
+		{
+			if (this is T) return this as T;
+			return GetNearestAncestorOfType<T>();
+		}
+
+		public T GetNearestAncestorOfType<T>() where T : Node
+		{
+			Node current = Parent;
+			while(current != null)
+			{
+				if(current is T) return current as T;
+				current = current.Parent;
+			}
+			return null;
+		}
 	}
 }

--- a/Source/Fuse.Nodes/Node.uno
+++ b/Source/Fuse.Nodes/Node.uno
@@ -157,13 +157,13 @@ namespace Fuse
 			return null;
 		}
 		
-		public T FindByType<T>() where T : Node
+		public T FindByType<T>() where T : class
 		{
 			if (this is T) return this as T;
 			return GetNearestAncestorOfType<T>();
 		}
 
-		public T GetNearestAncestorOfType<T>() where T : Node
+		public T GetNearestAncestorOfType<T>() where T : class
 		{
 			Node current = Parent;
 			while(current != null)

--- a/Source/Fuse.Nodes/Visual.uno
+++ b/Source/Fuse.Nodes/Visual.uno
@@ -158,23 +158,6 @@ namespace Fuse
 				Children[i].VisitSubtree(action);
 		}
 
-		public T FindByType<T>() where T : Visual
-		{
-			if (this is T) return this as T;
-			return GetNearestAncestorOfType<T>();
-		}
-
-		public T GetNearestAncestorOfType<T>() where T : Visual
-		{
-			Visual current = Parent;
-			while(current != null)
-			{
-				if(current is T) return current as T;
-				current = current.Parent;
-			}
-			return null;
-		}
-
 		/**
 			Converts a coordinate from the parent space into the local space.
 			

--- a/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
@@ -402,22 +402,6 @@ namespace Fuse.Reactive.Test
 			return list;
 		}
 		
-		static internal string GetDudZ(Visual root)
-		{
-			var q = "";
-			for (int i=0; i < root.ZOrderChildCount; ++i)
-			{
-				var t = root.GetZOrderChild(i) as FuseTest.DudElement;
-				if (t != null)
-				{
-					if (q.Length > 0)
-						q += ",";
-					q += t.UseValue;
-				}
-			}
-			return q;
-		}
-		
 		[Test]
 		//index() retains the previous value if the item is removed, or rather it doesn't update if there is no value
 		public void FunctionRemove()

--- a/Source/Fuse.Triggers/Actions/Callback.uno
+++ b/Source/Fuse.Triggers/Actions/Callback.uno
@@ -36,7 +36,7 @@ namespace Fuse.Triggers.Actions
 				Action();
 				
 			if (Handler != null)
-				Handler(target, new VisualEventArgs(target as Visual) );
+				Handler(target, new VisualEventArgs(target.FindByType<Visual>()) );
 		}
 	}
 }

--- a/Source/Fuse.Triggers/Actions/CancelInteractions.uno
+++ b/Source/Fuse.Triggers/Actions/CancelInteractions.uno
@@ -11,7 +11,7 @@ namespace Fuse.Triggers.Actions
 		
 		protected override void Perform(Node target)
 		{
-			var t = Target ?? target as Visual;
+			var t = Target ?? target.FindByType<Visual>();
 			if (t != null)
 				t.CancelInteractions();
 		}

--- a/Source/Fuse.Triggers/Actions/Playback.uno
+++ b/Source/Fuse.Triggers/Actions/Playback.uno
@@ -113,7 +113,7 @@ namespace Fuse.Triggers.Actions
 	{
 		protected override void Perform(Node target)
 		{
-			var t = Target ?? (target as IPlayback);
+			var t = Target ?? target.FindByType<IPlayback>();
 			if (t != null)
 				t.Stop();
 		}
@@ -145,7 +145,7 @@ namespace Fuse.Triggers.Actions
 	{
 		protected override void Perform(Node target)
 		{
-			var t = Target ?? (target as IPlayback);
+			var t = Target ?? target.FindByType<IPlayback>();
 			if (t != null)
 				t.Pause();
 		}
@@ -214,7 +214,7 @@ namespace Fuse.Triggers.Actions
 	{
 		protected override void Perform(Node target)
 		{
-			var t = Target ?? (target as IPlayback);
+			var t = Target ?? target.FindByType<IPlayback>();
 			if (t != null)
 				t.Resume();
 		}
@@ -290,7 +290,7 @@ namespace Fuse.Triggers.Actions
 		
 		protected override void Perform(Node target)
 		{
-			var t = Target ?? (target as IPlayback);
+			var t = Target ?? target.FindByType<IPlayback>();
 			if (t != null)
 				t.PlayTo(Progress);		
 		}

--- a/Source/Fuse.Triggers/Actions/StateTransition.uno
+++ b/Source/Fuse.Triggers/Actions/StateTransition.uno
@@ -19,6 +19,12 @@ namespace Fuse.Triggers.Actions
 		protected override void Perform(Node target)
 		{
 			var t = Target;
+			if (t == null)
+			{
+				Fuse.Diagnostics.UserError( "Missing `Target`", this );
+				return;
+			}
+			
 			switch (Type)
 			{
 				case TransitionStateType.Next:

--- a/Source/Fuse.Triggers/Actions/Toggle.uno
+++ b/Source/Fuse.Triggers/Actions/Toggle.uno
@@ -28,23 +28,21 @@ namespace Fuse.Triggers.Actions
 	*/
 	public class Toggle : TriggerAction
 	{
+		/** The ToggleControl (or Switch) to toggle. 
+			If not specified this Action will look up the tree for the next control. 
+		*/
 		public IToggleable Target { get; set; }
 		
 		protected override void Perform(Node target)
 		{
-			var t = Target ?? FindTarget(target);
-			if (t != null) t.Toggle();
-		}
-
-		IToggleable FindTarget(Node n)
-		{
-			while (n != null)
+			var t = Target ?? target.FindByType<IToggleable>();
+			if (t == null)
 			{
-				var iv = n as IToggleable;
-				if (iv != null) return iv;
-				n = n.Parent;
+				Fuse.Diagnostics.UserError( "Could not find `IToggleable` target", this );
+				return;
 			}
-			return null;
+			
+			t.Toggle();
 		}
 	}
 }

--- a/Source/Fuse.Triggers/Actions/TriggerAction.uno
+++ b/Source/Fuse.Triggers/Actions/TriggerAction.uno
@@ -47,7 +47,12 @@ namespace Fuse.Triggers.Actions
 			}
 		}
 		
-		/** The node that the action targets. */
+		/** The node that the action targets. If not specified then the enclsoing Trigger will be used.
+			Several triggers can look for a target starting from this point. Some triggers require
+			a `Target` to be specified. 
+			
+			If a trigger has a `Target` then only one of `Target` or `TargetNode` should be used.
+		*/
 		public Node TargetNode { get; set; }
 
 		float _progress;

--- a/Source/Fuse.Triggers/Actions/Visibility.uno
+++ b/Source/Fuse.Triggers/Actions/Visibility.uno
@@ -31,7 +31,11 @@ namespace Fuse.Triggers.Actions
 	{
 		protected override void Perform(Node target)
 		{
-			if (target is IShow) ((IShow)target).Show();
+			var t = target.FindByType<IShow>();
+			if (t != null) 
+				t.Show();
+			else
+				Fuse.Diagnostics.UserError( "Cannot find an Element/IShow", this );
 		}
 	}
 
@@ -63,7 +67,11 @@ namespace Fuse.Triggers.Actions
 	{
 		protected override void Perform(Node target)
 		{
-			if (target is IHide) ((IHide)target).Hide();
+			var t = target.FindByType<IHide>();
+			if (t != null) 
+				t.Hide();
+			else
+				Fuse.Diagnostics.UserError( "Cannot find an Element/IHide", this );
 		}
 	}
 
@@ -95,7 +103,11 @@ namespace Fuse.Triggers.Actions
 	{
 		protected override void Perform(Node target)
 		{
-			if (target is ICollapse) ((ICollapse)target).Collapse();
+			var t = target.FindByType<ICollapse>();
+			if (t != null) 
+				t.Collapse();
+			else
+				Fuse.Diagnostics.UserError( "Cannot find an Element/ICollapse", this );
 		}
 	}
 }

--- a/Source/Fuse.Triggers/Tests/StateGroup.Test.uno
+++ b/Source/Fuse.Triggers/Tests/StateGroup.Test.uno
@@ -130,5 +130,18 @@ namespace Fuse.Triggers.Test
 			}
 		}
 		
+		[Test]
+		public void TransitionState()
+		{
+			var p = new UX.StateGroup.TransitionState();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(p.s1,p.sg.Active);
+				
+				p.t1.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual(p.s2,p.sg.Active);
+			}
+		}
 	}
 }

--- a/Source/Fuse.Triggers/Tests/Toggle.Test.uno
+++ b/Source/Fuse.Triggers/Tests/Toggle.Test.uno
@@ -1,0 +1,31 @@
+using Uno;
+using Uno.Collections;
+using Uno.Testing;
+
+using Fuse.Controls;
+
+using FuseTest;
+
+namespace Fuse.Triggers.Test
+{
+	public class Toggle : TestBase
+	{
+		[Test]
+		public void Basic()
+		{
+			var p = new UX.Toggle.Basic();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.IsFalse(p.v.Value);
+				
+				p.t2.Pulse();
+				root.PumpDeferred();
+				Assert.IsTrue(p.v.Value);
+				
+				p.t1.Pulse();
+				root.PumpDeferred();
+				Assert.IsFalse(p.v.Value);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Triggers/Tests/UX/StateGroup.TransitionState.ux
+++ b/Source/Fuse.Triggers/Tests/UX/StateGroup.TransitionState.ux
@@ -1,0 +1,11 @@
+<Panel ux:Class="UX.StateGroup.TransitionState">
+	<StateGroup ux:Name="sg">
+		<State ux:Name="s1"/>
+		<State ux:Name="s2"/>
+		<State ux:Name="s3"/>
+	</StateGroup>
+	
+	<Timeline ux:Name="t1">
+		<TransitionState Target="sg" Type="Next"/>
+	</Timeline>
+</Panel>

--- a/Source/Fuse.Triggers/Tests/UX/Toggle.Basic.ux
+++ b/Source/Fuse.Triggers/Tests/UX/Toggle.Basic.ux
@@ -1,0 +1,16 @@
+<Panel ux:Class="UX.Toggle.Basic">
+	<Panel>
+		<ToggleControl ux:Name="v">
+			<Panel>	
+				<Timeline ux:Name="t1">
+					<Toggle/>
+				</Timeline>
+			</Panel>
+		</ToggleControl>
+	</Panel>
+	
+	<Timeline ux:Name="t2">
+		<Toggle Target="v"/>
+	</Timeline>
+
+</Panel>

--- a/Source/Fuse.Triggers/Tests/UX/Visibility.Basic.ux
+++ b/Source/Fuse.Triggers/Tests/UX/Visibility.Basic.ux
@@ -1,0 +1,24 @@
+<Panel ux:Class="UX.Visibility.Basic">
+	<Panel ux:Name="a">
+		<Timeline ux:Name="show1">
+			<Show/>
+		</Timeline>
+		<Timeline ux:Name="hide1">
+			<Hide/>
+		</Timeline>
+		<Timeline ux:Name="collapse1">
+			<Collapse/>
+		</Timeline>
+	</Panel>
+	
+	<Timeline ux:Name="show2">
+		<Show TargetNode="a"/>
+	</Timeline>
+	<Timeline ux:Name="hide2">
+		<Hide TargetNode="a"/>
+	</Timeline>
+	<Timeline ux:Name="collapse2">
+		<Collapse TargetNode="a"/>
+	</Timeline>
+	
+</Panel>

--- a/Source/Fuse.Triggers/Tests/Visibility.Test.uno
+++ b/Source/Fuse.Triggers/Tests/Visibility.Test.uno
@@ -1,0 +1,47 @@
+using Uno;
+using Uno.Collections;
+using Uno.Testing;
+
+using Fuse.Elements;
+
+using FuseTest;
+
+namespace Fuse.Triggers.Test
+{
+	public class VisibilityTest : TestBase
+	{
+		[Test]
+		public void Basic()
+		{
+			var p = new UX.Visibility.Basic();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( Visibility.Visible, p.a.Visibility );
+				
+				p.hide1.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( Visibility.Hidden, p.a.Visibility );
+				
+				p.show1.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( Visibility.Visible, p.a.Visibility );
+				
+				p.collapse1.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( Visibility.Collapsed, p.a.Visibility );
+				
+				p.hide2.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( Visibility.Hidden, p.a.Visibility );
+				
+				p.show2.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( Visibility.Visible, p.a.Visibility );
+				
+				p.collapse2.Pulse();
+				root.PumpDeferred();
+				Assert.AreEqual( Visibility.Collapsed, p.a.Visibility );
+			}
+		}
+	}
+}

--- a/Source/Fuse.Triggers/Trigger.uno
+++ b/Source/Fuse.Triggers/Trigger.uno
@@ -256,16 +256,16 @@ namespace Fuse.Triggers
 		class DeferredItem
 		{
 			public TriggerAction Action;
-			public Node Parent;
+			public Node Node;
 			
 			public void Perform()
 			{
-				Action.PerformFromNode(Parent);
+				Action.PerformFromNode(Node);
 			}
 		}
 		void AddDeferredAction(TriggerAction i)
 		{
-			UpdateManager.AddDeferredAction( new DeferredItem{ Action = i, Parent = Parent }.Perform );
+			UpdateManager.AddDeferredAction( new DeferredItem{ Action = i, Node = this }.Perform );
 		}
 		
 		protected virtual void OnPlayStateChanged(TriggerPlayState state)
@@ -341,7 +341,7 @@ namespace Fuse.Triggers
 					//a good idea, but was required for the Navigation preparation stuff (which likely
 					//needs to chagne anyway)
 					if (act.When == when)
-						act.PerformFromNode(Parent); 
+						act.PerformFromNode(this); 
 				}
 			}
 		}

--- a/Source/Fuse.UserEvents/RaiseUserEvent.uno
+++ b/Source/Fuse.UserEvents/RaiseUserEvent.uno
@@ -52,8 +52,9 @@ namespace Fuse.Triggers.Actions
 				_event = null;
 			}
 		}
-			
-		Visual _eventTarget;
+		
+		//caches found Event to avoid multiple lookups	
+		Node _eventTarget;
 		UserEvent _event;
 		
 		IList<UserEventArg> _args;
@@ -74,14 +75,11 @@ namespace Fuse.Triggers.Actions
 		
 		protected override void Perform(Node target)
 		{
-			var v = target as Visual;
-			if (v == null) return;
-
-			if (_event == null || _eventTarget != v)
+			if (_event == null || _eventTarget != target)
 			{
 				Visual n;
-				_event = UserEvent.ScanTree(v, EventName, out n);
-				_eventTarget = v;
+				_event = UserEvent.ScanTree(target, EventName, out n);
+				_eventTarget = target;
 			}
 				
 			if (_event == null)


### PR DESCRIPTION
Corrects/changes what node a trigger provides to an action. Updates all actions to work appropriately, including extend their ability to search upwards.
This branch is preparation for another branch. I wanted to separate out this change.

This PR contains:
- [x] Changelog
- [x] Documentation -- minimal added, but mostly no new public API
- [x] Tests
