### PR TITLE
Fuse.Nodes: survive if there's no DataWatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # 1.0
 
+### FuseJS
+- Fixed a bug where disposing a JavaScript tag that has called the findData-method could lead to a crash.
+
 ## 1.0.4
 
 ### GraphicsView

--- a/Source/Fuse.Nodes/Node.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Node.ScriptClass.uno
@@ -25,8 +25,11 @@ namespace Fuse
 
 		static void _destroyWatcher(Context c, Node n, object[] args)
 		{
-			var watcher = (DataWatcher)((External)args[0]).Object;
-			watcher.Dispose();
+			if (args[0] != null)
+			{
+				var watcher = (DataWatcher)((External)args[0]).Object;
+				watcher.Dispose();
+			}
 		}
 
 		class DataWatcher: Node.DataFinder, IDataListener

--- a/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
@@ -149,14 +149,14 @@ namespace Fuse.Reactive.Test
 		public void FindData()
 		{
 			var e = new UX.FindData();
-			var root = TestRootPanel.CreateWithChild(e);
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
 
-			root.StepFrameJS();
-
-			Assert.AreEqual("correct", e.t1.Value);
-			Assert.AreEqual("correct", e.t2.Value);
-			Assert.AreEqual("correct", e.t3.Value);
-
+				Assert.AreEqual("correct", e.t1.Value);
+				Assert.AreEqual("correct", e.t2.Value);
+				Assert.AreEqual("correct", e.t3.Value);
+			}
 		}
 
 		// Stuff needed by the OnValueChanged test


### PR DESCRIPTION
This seems to happen during shutdown in some tests, if enough
objects are being disposed. So let's try to survive in this case.

This was noticed while adding some disposing to a test, so let's
add that here also, so we have a chance to notice similar regressions
in this functionality in the future.

This PR contains:
- [x] Changelog
- [x] Tests
