### PR TITLE
Fuse.Reactive: survive Dispose after null-subscriptions

### DIFF
--- a/Source/Fuse.Reactive.Expressions/LookUp.uno
+++ b/Source/Fuse.Reactive.Expressions/LookUp.uno
@@ -196,8 +196,13 @@ namespace Fuse.Reactive
 				ClearDiagnostic();
 				DisposeCollectionObservableSub();
 				DisposeIndexSub();
-				_colSub.Dispose();
-				_indexSub.Dispose();
+
+				if (_colSub != null)
+					_colSub.Dispose();
+
+				if (_indexSub != null)
+					_indexSub.Dispose();
+
 				_colSub = null;
 				_indexSub = null;
 				_collection = null;

--- a/Source/Fuse.Reactive.JavaScript/Tests/UXExpressionsTest.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UXExpressionsTest.uno
@@ -41,77 +41,79 @@ namespace Fuse.Reactive.Test
 		public void ArrayLookup()
 		{
 			var e = new UX.ArrayLookup();
-			var root = TestRootPanel.CreateWithChild(e);
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+				root.StepFrameJS();
 
-			root.StepFrameJS();
-			root.StepFrameJS();
+				Assert.AreEqual("THIS IS FOO", e.t2.Value);
+				Assert.AreEqual("THIS IS BAR", e.t3.Value);
 
-			Assert.AreEqual("THIS IS FOO", e.t2.Value);
-			Assert.AreEqual("THIS IS BAR", e.t3.Value);
+				e.CallChangeObj.Perform();
+				root.StepFrameJS();
 
-			e.CallChangeObj.Perform();
-			root.StepFrameJS();
+				Assert.AreEqual("FOO HAS CHANGED", e.t2.Value);
+				Assert.AreEqual("BAR HAS CHANGED", e.t3.Value);
 
-			Assert.AreEqual("FOO HAS CHANGED", e.t2.Value);
-			Assert.AreEqual("BAR HAS CHANGED", e.t3.Value);
+				Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
 
-			Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
+				e.CallInc.Perform();
+				root.StepFrameJS();
+				root.StepFrameJS();
 
-			e.CallInc.Perform();
-			root.StepFrameJS();
-			root.StepFrameJS();
+				Assert.AreEqual("Hello foo : BAR!", e.t1.Value);
 
-			Assert.AreEqual("Hello foo : BAR!", e.t1.Value);
+				e.CallInc.Perform();
+				root.StepFrameJS();
 
-			e.CallInc.Perform();
-			root.StepFrameJS();
+				Assert.AreEqual("Hello bar : BAR!", e.t1.Value);
 
-			Assert.AreEqual("Hello bar : BAR!", e.t1.Value);
+				e.CallDec.Perform();
+				root.StepFrameJS();
 
-			e.CallDec.Perform();
-			root.StepFrameJS();
+				Assert.AreEqual("Hello foo : BAR!", e.t1.Value);
 
-			Assert.AreEqual("Hello foo : BAR!", e.t1.Value);
+				e.CallDec.Perform();
+				root.StepFrameJS();
 
-			e.CallDec.Perform();
-			root.StepFrameJS();
+				Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
 
-			Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
+				e.CallDec.Perform(); // index = -1 now, but that's fine since its /2 so = 0
+				root.StepFrameJS();
 
-			e.CallDec.Perform(); // index = -1 now, but that's fine since its /2 so = 0
-			root.StepFrameJS();
+				Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
 
-			Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
-
-			
-			if defined (FUSELIBS_NO_TOASTS)
-				using (var dg = new RecordDiagnosticGuard())
+				if defined(FUSELIBS_NO_TOASTS)
 				{
-					var diagnostics = dg.DequeueAll();
-					Assert.AreEqual(0, diagnostics.Count);
+					using (var dg = new RecordDiagnosticGuard())
+					{
+						var diagnostics = dg.DequeueAll();
+						Assert.AreEqual(0, diagnostics.Count);
 
-					e.CallDec.Perform(); // index = -2 now, so that's = -1 and should give errro
-					root.StepFrameJS();
+						e.CallDec.Perform(); // index = -2 now, so that's = -1 and should give errro
+						root.StepFrameJS();
 
-					Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
+						Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
 
-					diagnostics = dg.DequeueAll();
-					Assert.AreEqual(1, diagnostics.Count);
-					Assert.IsTrue(diagnostics[0].Message.Contains("Index was outside the bounds of the array"));
+						diagnostics = dg.DequeueAll();
+						Assert.AreEqual(1, diagnostics.Count);
+						Assert.IsTrue(diagnostics[0].Message.Contains("Index was outside the bounds of the array"));
 
-					e.CallInc.Perform();
-					root.StepFrameJS();
+						e.CallInc.Perform();
+						root.StepFrameJS();
 
-					diagnostics = dg.DequeueAll();
-					Assert.AreEqual(0, diagnostics.Count);
+						diagnostics = dg.DequeueAll();
+						Assert.AreEqual(0, diagnostics.Count);
 
-					e.CallIllegalIndex.Perform(); // index = 'foo', should give error
-					root.StepFrameJS();
+						e.CallIllegalIndex.Perform(); // index = 'foo', should give error
+						root.StepFrameJS();
 
-					diagnostics = dg.DequeueAll();
-					Assert.AreEqual(1, diagnostics.Count);
-					Assert.IsTrue(diagnostics[0].Message.Contains("Index must be a number"));
+						diagnostics = dg.DequeueAll();
+						Assert.AreEqual(1, diagnostics.Count);
+						Assert.IsTrue(diagnostics[0].Message.Contains("Index must be a number"));
+					}
 				}
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
Some subscriptions (like constant values that cannot change) simply
return a null-pointer, to avoid having to create needless objects.
This is considered legal by the expression-system.

However, the newly added array-lookup expression didn't take this
into account. Let's do this, by simply not disposing null-pointers.

This was discovered while adding test-disposal to the test for this
feature, which triggers the issue. So let's add that disposal around
this test now, so we'll detect if this regresses in the future. Some
minor clean-ups are also included.

This PR contains:
- [x] Tests
