### PR TITLE
Fuse.Scripting.V8: do not encourage use-after-free

### DIFF
--- a/Source/Fuse.Scripting.V8/V8SimpleExtensions.uno
+++ b/Source/Fuse.Scripting.V8/V8SimpleExtensions.uno
@@ -43,7 +43,7 @@ namespace Fuse.Scripting.V8
 		// Value
 		public static JSType GetJSType(this JSValue value) { return Simple.Value.GetType(value); }
 		public static JSValue Retain(this JSValue value, JSContext context) { Simple.Value.Retain(context, value); return value; }
-		public static JSValue Release(this JSValue value, JSContext context) { Simple.Value.Release(context, value); return value; }
+		public static void Release(this JSValue value, JSContext context) { Simple.Value.Release(context, value); }
 		public static JSValue Null() { return Simple.Value.JSNull(); }
 		public static JSValue NewInt(int value, AutoReleasePool pool) { return pool.AutoRelease(Simple.Value.CreateInt(value)); }
 		public static JSValue NewDouble(double value, AutoReleasePool pool) { return pool.AutoRelease(Simple.Value.CreateDouble(value)); }


### PR DESCRIPTION
It's nice to have methods that return a reference to the object it
works on so you can chain operations. However, release should never
be used like that, because it's effectively a free-method. Chaining
it like that will effectively be a use-after-free.

Luckily, nobody uses the return-value of the method, but let's just
get rid of it so nobody thinks this is a good idea in the future.