### PR TITLE
appveyor: temporarily direct azure CDN to europe

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 version: '{build}'
 
+init:
+  - ps: '[System.IO.File]::AppendAllText("C:\Windows\System32\drivers\etc\hosts", "`n93.184.221.200  az664292.vo.msecnd.net")'
+
 install:
   - Stuff\stuff install Stuff
   - ps: Invoke-WebRequest http://downloads.fdossena.com/geth.php?r=mesa-latest -OutFile mesa.zip


### PR DESCRIPTION
This is a dirty work-around for a current incident on Appveyor,
and should be removed again once the problem has been solved in
their end.

For more information, see:
http://status.appveyor.com/incidents/m2vdvw39kdk8
