### PR TITLE
Fix a visibility error

### DIFF
--- a/Source/Fuse.Controls.ScrollView/ScrollView.Layout.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollView.Layout.uno
@@ -238,7 +238,7 @@ namespace Fuse.Controls
 		/**
 			The distance from the visible view area start or end for the provided position.
 		*/
-		protected float2 DistanceFromView(float2 position, DistanceFromViewTarget target)
+		internal float2 DistanceFromView(float2 position, DistanceFromViewTarget target)
 		{
 			float x = 0;
 			float y = 0;


### PR DESCRIPTION
The problem was that an internal enum was made visible through a protected
member which takes that type as an argument. Changing the visibility of
the member to internal instead.

Note: This only caused an issue for the docs generator.
