### PR TITLE
Fuse.Scripting.V8: do not release on the wrong context

### DIFF
--- a/Source/Fuse.Scripting.V8/Array.uno
+++ b/Source/Fuse.Scripting.V8/Array.uno
@@ -25,8 +25,8 @@ namespace Fuse.Scripting.V8
 
 		~Array()
 		{
-			var cxt = _context == null ? default(Simple.JSContext) : _context._context;
-			_array.AsValue().Release(cxt);
+			if (_context != null && !_context.IsDisposed)
+				_array.AsValue().Release(_context._context);
 		}
 
 		public override object this[int index]

--- a/Source/Fuse.Scripting.V8/Context.uno
+++ b/Source/Fuse.Scripting.V8/Context.uno
@@ -18,6 +18,7 @@ namespace Fuse.Scripting.V8
 		internal Function _instanceOf;
 		int _vmDepth;
 		internal Exception _cachedException;
+		internal bool IsDisposed { get; private set; }
 
 		static extern(CIL) Context()
 		{
@@ -140,6 +141,7 @@ namespace Fuse.Scripting.V8
 				_debugger.Dispose();
 				_debugger = null;
 			}
+			IsDisposed = true;
 			_context.Release();
 			_context = default(Simple.JSContext);
 		}

--- a/Source/Fuse.Scripting.V8/Function.uno
+++ b/Source/Fuse.Scripting.V8/Function.uno
@@ -25,8 +25,8 @@ namespace Fuse.Scripting.V8
 
 		~Function()
 		{
-			var cxt = _context == null ? default(Simple.JSContext) : _context._context;
-			_function.AsValue().Release(cxt);
+			if (_context != null && !_context.IsDisposed)
+				_function.AsValue().Release(_context._context);
 		}
 
 		public override object Call(params object[] args)

--- a/Source/Fuse.Scripting.V8/Object.uno
+++ b/Source/Fuse.Scripting.V8/Object.uno
@@ -26,8 +26,8 @@ namespace Fuse.Scripting.V8
 
 		~Object()
 		{
-			var cxt = _context == null ? default(Simple.JSContext) : _context._context;
-			_object.AsValue().Release(cxt);
+			if (_context != null && !_context.IsDisposed)
+				_object.AsValue().Release(_context._context);
 		}
 
 		public override object this[string key]

--- a/Source/Fuse.Scripting/Tests/Scripting.uno
+++ b/Source/Fuse.Scripting/Tests/Scripting.uno
@@ -463,7 +463,6 @@ namespace Fuse.Scripting.Test
 			}
 		}
 
-		[Ignore("https://github.com/fusetools/fuselibs-public/issues/237")]
 		[Test]
 		public void ExternalSameObject()
 		{


### PR DESCRIPTION
Sometimes when releasing JS-values after a context has been disposed,
we get an `AccessViolationException`, probably due to using different
contexts (or rather, null-contexts) than the actual context used.

the `_context == null`-case seems to be a similarly mis-guided attempt
at surviving, where we just end up releasing in a collected context.

Since disposing sets the _context-member to the same value as the
`_context == null`-case fudged it with, these two cases should actually
be the same, and just as potentially crashy.

Let's instead assume that disposing a context correctly destroy all of
its resources. There's no way we can do any better, because the handle
to the context is lost at this point.

This fixes #237

Unfortuantely, I was unable to come up with a way of testing this, as
it depends on a lot of hard-to-control things, like timing of finalizers,
and the memory mapping / unmapping pattern of the JS VM code
genrator.