### PR TITLE
Fuse.Reactive.Expressions: correct typo

### DIFF
--- a/Source/Fuse.Reactive.Expressions/LookUp.uno
+++ b/Source/Fuse.Reactive.Expressions/LookUp.uno
@@ -43,8 +43,8 @@ namespace Fuse.Reactive
 			{
 				_listener = listener;
 				_lu = lu;
-				_colSub = _lu.Index.Subscribe(context, this);
-				_indexSub = _lu.Collection.Subscribe(context, this);
+				_colSub = _lu.Collection.Subscribe(context, this);
+				_indexSub = _lu.Index.Subscribe(context, this);
 			}
 
 			bool _hasCollection;


### PR DESCRIPTION
The subscription-fields vs subscribe-calls were swapped. In reality
this doesn't matter, because they are only kept around to be disposed.

But let's clean up this in case it becomes significant in the future.
Or just for clarity.