### PR TITLE
Implemented Visual.Children as an implicitly linked list (optimization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## ScrollView
 - Added minimal support to WhileVisibleInScrollView for changes in Element layout updating the status
+## Optimizations for long list of elements
+- Several low-level optimizations that speeds up scenarios with long lists (e.g. scrollviews). Here are the Uno-level details:
+ * Optimized the implementation of the `Visual.Children` collection to be an implicitly linked list. This avoids all memory allocation and shifting in connection with inserting and removing nodes from a parent, and ensures a `O(1)` cost for all child list manipulations.
+ * Introduced new public API: `Node.NextSibling<T>()` and `Node.PreviousSibling<T>()`, which can be together with `Visual.FirstChild<T>()` and `Visual.LastChild<T>()`. The recommended way of iterating over the children of a `Visual` is now `for (var c = parent.FirstChild<Visual>(); c != null; c = c.NextSibling<Visual>())` where `Visual` can be replaced with the desired node type to visit.
 
 ## Fuse.Drawing.Surface
 - Added support for the Surface API in native UI for iOS. Meaning that `Curve`, `VectorLayer` and charting will work inside a `NativeViewHost`.

--- a/Source/Fuse.Common/Internal/Pointer.uno
+++ b/Source/Fuse.Common/Internal/Pointer.uno
@@ -1,0 +1,35 @@
+using Uno.Compiler.ExportTargetInterop;
+
+namespace Fuse.Internal
+{
+    /** A reference that in C++ behaves just like a plain pointer. Faster than weakref, but not technically a weakref.
+
+        This is unsafe to use. The user must take special care that a separate reference to the object
+        exists before de-referencing an `Pointer`.
+
+        Used internally with special care in performance critical contexts.
+    */
+    [extern(CPLUSPLUS) TargetSpecificType]
+    struct Pointer<T> where T : class
+    {
+        extern(!CPLUSPLUS) readonly T _object;
+
+        extern(!CPLUSPLUS) Pointer(T obj) { _object = obj; }
+
+        public static explicit operator T(Pointer<T> weak)
+        {
+            if defined(CPLUSPLUS)
+                return extern<T> "(uObject*) $0";
+            else
+                return weak._object;
+        }
+
+        public static implicit operator Pointer<T>(T obj)
+        {
+            if defined(CPLUSPLUS)
+                return extern<Pointer<T>> "(void*) $0";
+            else
+                return new Pointer<T>(obj);
+        }
+    }
+}

--- a/Source/Fuse.Common/Internal/RawPointer.uno
+++ b/Source/Fuse.Common/Internal/RawPointer.uno
@@ -5,18 +5,18 @@ namespace Fuse.Internal
     /** A reference that in C++ behaves just like a plain pointer. Faster than weakref, but not technically a weakref.
 
         This is unsafe to use. The user must take special care that a separate reference to the object
-        exists before de-referencing an `Pointer`.
+        exists before de-referencing an `RawPointer`.
 
         Used internally with special care in performance critical contexts.
     */
     [extern(CPLUSPLUS) TargetSpecificType]
-    struct Pointer<T> where T : class
+    struct RawPointer<T> where T : class
     {
         extern(!CPLUSPLUS) readonly T _object;
 
-        extern(!CPLUSPLUS) Pointer(T obj) { _object = obj; }
+        extern(!CPLUSPLUS) RawPointer(T obj) { _object = obj; }
 
-        public static explicit operator T(Pointer<T> weak)
+        public static explicit operator T(RawPointer<T> weak)
         {
             if defined(CPLUSPLUS)
                 return extern<T> "(uObject*) $0";
@@ -24,12 +24,12 @@ namespace Fuse.Internal
                 return weak._object;
         }
 
-        public static implicit operator Pointer<T>(T obj)
+        public static implicit operator RawPointer<T>(T obj)
         {
             if defined(CPLUSPLUS)
-                return extern<Pointer<T>> "(void*) $0";
+                return extern<RawPointer<T>> "(void*) $0";
             else
-                return new Pointer<T>(obj);
+                return new RawPointer<T>(obj);
         }
     }
 }

--- a/Source/Fuse.Controls.Navigation/EdgeNavigator.uno
+++ b/Source/Fuse.Controls.Navigation/EdgeNavigator.uno
@@ -144,11 +144,8 @@ namespace Fuse.Controls
 		
 		void GotoEdge(NavigationEdge edge)
 		{
-			for (int i=0; i < Children.Count; ++i)
+			for (var elm = FirstChild<Visual>(); elm != null; elm = elm.NextSibling<Visual>())
 			{
-				var elm = Children[i] as Visual;
-				if (elm == null)
-					continue;
 				var e = EdgeNavigation.GetEdge(elm);
 				if (e != edge)
 					continue;

--- a/Source/Fuse.Controls.Navigation/NavigationControl.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.uno
@@ -113,11 +113,8 @@ namespace Fuse.Controls
 			//defer first update to rooted, to avoid creating/deleting unused Swipe behavior if None
 			UpdateInteraction();
 			
-			for (int i=0; i < Children.Count; ++i)
-			{
-				var c = Children[i] as Element;
-				if (c != null) UpdateChild(c);
-			}
+			for (var c = FirstChild<Element>(); c != null; c = c.NextSibling<Element>())
+				UpdateChild(c);
 			
 			Navigation.PageProgressChanged += OnPageProgressChanged;
 		}
@@ -167,11 +164,8 @@ namespace Fuse.Controls
 			
 			Navigation.PageProgressChanged -= OnPageProgressChanged;
 			
-			for (int i=0; i < Children.Count; ++i)
+			for (var c = FirstChild<Element>(); c != null; c = c.NextSibling<Element>())
 			{
-				var c = Children[i] as Element;
-				if (c == null) continue;
-
 				var pd = GetPageData(c,false);
 				if (pd == null)
 					continue;

--- a/Source/Fuse.Controls.Navigation/Navigator.uno
+++ b/Source/Fuse.Controls.Navigation/Navigator.uno
@@ -388,10 +388,9 @@ namespace Fuse.Controls
 		
 		Visual FindPage(Selector path)
 		{
-			for (int i=0; i < Children.Count; ++i)
+			for (var c = FirstChild<Visual>(); c != null; c = c.NextSibling<Visual>())
 			{
-				var c = Children[i] as Visual;
-				if (c == null || c.Name != path)
+				if (c.Name != path)
 					continue;
 					
 				if (GetPageData(c).FromTemplate)
@@ -620,10 +619,9 @@ namespace Fuse.Controls
 		
 		void CleanupChildren(Visual exclude = null)
 		{
-			for (int i=Children.Count-1; i >= 0; --i)
+			for (var c = LastChild<Visual>(); c != null; c = c.PreviousSibling<Visual>())
 			{
-				var c = Children[i] as Visual;
-				if (c != null && Fuse.Navigation.Navigation.IsPage(c) && c != exclude)
+				if (Fuse.Navigation.Navigation.IsPage(c) && c != exclude)
 				{
 					if (IsRemoveLevel(c, RemoveType.Cleared) || GetReuse(c) == ReuseType.None)
 						BeginRemoveChild(c);

--- a/Source/Fuse.Controls.Navigation/PageControl.uno
+++ b/Source/Fuse.Controls.Navigation/PageControl.uno
@@ -141,12 +141,11 @@ namespace Fuse.Controls
 			RoutingOperation direction, string operationStyle, out Visual page)
 		{
 			page = null;
-			for (int i=0; i < Children.Count; ++i)
+			for (var n = FirstChild<Visual>(); n != null; n = n.NextSibling<Visual>())
 			{
-				var n = Children[i];
 				if ((string)n.Name == path)
-					{
-					page = n as Visual;
+				{
+					page = n;
 					break;
 				}
 			}

--- a/Source/Fuse.Controls.Navigation/PageIndicator.uno
+++ b/Source/Fuse.Controls.Navigation/PageIndicator.uno
@@ -115,10 +115,8 @@ namespace Fuse.Controls
 			}
 
 			var p = 0;
-			for (int i = 0; i < Children.Count; i++)
+			for (var v = FirstChild<Visual>(); v != null; v = v.NextSibling<Visual>())
 			{
-				var v = Children[i] as Visual;
-				if (v == null) continue;
 				var page = _pageProgress.GetPage(p++);
 				NavigationPageProperty.SetNavigationPage(v, page);
 			}

--- a/Source/Fuse.Controls.Panels/LayoutControl.uno
+++ b/Source/Fuse.Controls.Panels/LayoutControl.uno
@@ -131,7 +131,7 @@ namespace Fuse.Controls
 			var b = base.GetContentSize( lp );
 
 			if (HasVisualChildren)
-				return Math.Max(b, Layout.GetContentSize(Children, lp));
+				return Math.Max(b, Layout.GetContentSize(this, lp));
 
 			return b;
 		}
@@ -141,7 +141,7 @@ namespace Fuse.Controls
 			base.ArrangePaddingBox(lp);
 			
 			if (HasVisualChildren) // optimization
-				Layout.ArrangePaddingBox(Children, Padding, lp);
+				Layout.ArrangePaddingBox(this, Padding, lp);
 		}
 
 		protected override void OnChildAdded(Node elm)

--- a/Source/Fuse.Controls.Panels/Layouts/CircleLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/CircleLayout.uno
@@ -97,7 +97,7 @@ namespace Fuse.Layouts
 			}
 		}
 
-		internal override float2 GetContentSize(IList<Node> elements, LayoutParams lp)
+		internal override float2 GetContentSize(Visual elements, LayoutParams lp)
 		{
 			//TODO: something sensible?
 			return float2(0);
@@ -109,15 +109,15 @@ namespace Fuse.Layouts
 			all as circles, such that arranging them they all just touch the Radius edge and each other (with
 			a zero arc-spacing).
 		*/
-		internal override void ArrangePaddingBox(IList<Node> elements, float4 padding, LayoutParams lp)
+		internal override void ArrangePaddingBox(Visual elements, float4 padding, LayoutParams lp)
 		{
 			var nlp = lp.CloneAndDerive();
 			nlp.RemoveSize(padding);
 
 			int c = 0;
-			for (int i=0; i < elements.Count; ++i)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var e = elements[i] as Visual;
+				var e = cn as Visual;
 				if (e == null) continue;
 				if (ArrangeMarginBoxSpecial(e, padding, lp))
 					continue;
@@ -133,9 +133,9 @@ namespace Fuse.Layouts
 			var angle = _startAngle;
 			nlp.SetSize(elementSize);
 
-			for (int i=0; i < elements.Count; ++i)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var e = elements[i] as Visual;
+				var e = cn as Visual;
 				if (!AffectsLayout(e))
 					continue;
 

--- a/Source/Fuse.Controls.Panels/Layouts/CircleLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/CircleLayout.uno
@@ -115,10 +115,8 @@ namespace Fuse.Layouts
 			nlp.RemoveSize(padding);
 
 			int c = 0;
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var e = container.FirstChild<Visual>(); e != null; e = e.NextSibling<Visual>())
 			{
-				var e = cn as Visual;
-				if (e == null) continue;
 				if (ArrangeMarginBoxSpecial(e, padding, lp))
 					continue;
 				c++;
@@ -133,9 +131,8 @@ namespace Fuse.Layouts
 			var angle = _startAngle;
 			nlp.SetSize(elementSize);
 
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var e = container.FirstChild<Visual>(); e != null; e = e.NextSibling<Visual>())
 			{
-				var e = cn as Visual;
 				if (!AffectsLayout(e))
 					continue;
 

--- a/Source/Fuse.Controls.Panels/Layouts/CircleLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/CircleLayout.uno
@@ -97,7 +97,7 @@ namespace Fuse.Layouts
 			}
 		}
 
-		internal override float2 GetContentSize(Visual elements, LayoutParams lp)
+		internal override float2 GetContentSize(Visual container, LayoutParams lp)
 		{
 			//TODO: something sensible?
 			return float2(0);
@@ -109,13 +109,13 @@ namespace Fuse.Layouts
 			all as circles, such that arranging them they all just touch the Radius edge and each other (with
 			a zero arc-spacing).
 		*/
-		internal override void ArrangePaddingBox(Visual elements, float4 padding, LayoutParams lp)
+		internal override void ArrangePaddingBox(Visual container, float4 padding, LayoutParams lp)
 		{
 			var nlp = lp.CloneAndDerive();
 			nlp.RemoveSize(padding);
 
 			int c = 0;
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var e = cn as Visual;
 				if (e == null) continue;
@@ -133,7 +133,7 @@ namespace Fuse.Layouts
 			var angle = _startAngle;
 			nlp.SetSize(elementSize);
 
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var e = cn as Visual;
 				if (!AffectsLayout(e))

--- a/Source/Fuse.Controls.Panels/Layouts/ColumnLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/ColumnLayout.uno
@@ -218,17 +218,17 @@ namespace Fuse.Layouts
 			return mx;
 		}
 		
-		internal override float2 GetContentSize(IList<Node> visuals, LayoutParams lp)
+		internal override float2 GetContentSize(Visual visuals, LayoutParams lp)
 		{
 			return Arrange(visuals, lp);
 		}
 		
-		internal override void ArrangePaddingBox(IList<Node> visuals, float4 padding, LayoutParams lp)
+		internal override void ArrangePaddingBox(Visual visuals, float4 padding, LayoutParams lp)
 		{
 			Arrange(visuals, lp, true, padding);
 		}
 		
-		float2 Arrange(IList<Node> visuals, LayoutParams lp, 
+		float2 Arrange(Visual visuals, LayoutParams lp, 
 			bool doArrange = false, float4 padding=float4(0) )
 		{
 			bool vert = Orientation == Orientation.Vertical;
@@ -245,9 +245,9 @@ namespace Fuse.Layouts
 			{
 				//assume all columns contain max/fixed-size elements
 				var mx = float2(0);
-				foreach (var n in visuals)
+				for (var cn = visuals.Children_first; cn != null; cn = cn.Children_next)
 				{
-					var v = n as Visual;
+					var v = cn as Visual;
 					if (!AffectsLayout(v))
 						continue;
 					var c = v.GetMarginSize(LayoutParams.CreateEmpty());
@@ -285,9 +285,9 @@ namespace Fuse.Layouts
 
 			var at = new float[columnCount];
 			
-			foreach (var n in visuals)
+			for (var cn = visuals.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var v = n as Visual;
+				var v = cn as Visual;
 				if (v == null) continue;
 
 				var avs = float2(vert ? columnSize : 0.0f, vert ? 0.0f : columnSize);

--- a/Source/Fuse.Controls.Panels/Layouts/ColumnLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/ColumnLayout.uno
@@ -218,17 +218,17 @@ namespace Fuse.Layouts
 			return mx;
 		}
 		
-		internal override float2 GetContentSize(Visual visuals, LayoutParams lp)
+		internal override float2 GetContentSize(Visual container, LayoutParams lp)
 		{
-			return Arrange(visuals, lp);
+			return Arrange(container, lp);
 		}
 		
-		internal override void ArrangePaddingBox(Visual visuals, float4 padding, LayoutParams lp)
+		internal override void ArrangePaddingBox(Visual container, float4 padding, LayoutParams lp)
 		{
-			Arrange(visuals, lp, true, padding);
+			Arrange(container, lp, true, padding);
 		}
 		
-		float2 Arrange(Visual visuals, LayoutParams lp, 
+		float2 Arrange(Visual container, LayoutParams lp, 
 			bool doArrange = false, float4 padding=float4(0) )
 		{
 			bool vert = Orientation == Orientation.Vertical;
@@ -245,7 +245,7 @@ namespace Fuse.Layouts
 			{
 				//assume all columns contain max/fixed-size elements
 				var mx = float2(0);
-				for (var cn = visuals.Children_first; cn != null; cn = cn.Children_next)
+				for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 				{
 					var v = cn as Visual;
 					if (!AffectsLayout(v))
@@ -285,7 +285,7 @@ namespace Fuse.Layouts
 
 			var at = new float[columnCount];
 			
-			for (var cn = visuals.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var v = cn as Visual;
 				if (v == null) continue;

--- a/Source/Fuse.Controls.Panels/Layouts/ColumnLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/ColumnLayout.uno
@@ -245,9 +245,8 @@ namespace Fuse.Layouts
 			{
 				//assume all columns contain max/fixed-size elements
 				var mx = float2(0);
-				for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+				for (var v = container.FirstChild<Visual>(); v != null; v = v.NextSibling<Visual>())
 				{
-					var v = cn as Visual;
 					if (!AffectsLayout(v))
 						continue;
 					var c = v.GetMarginSize(LayoutParams.CreateEmpty());
@@ -285,11 +284,8 @@ namespace Fuse.Layouts
 
 			var at = new float[columnCount];
 			
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var v = container.FirstChild<Visual>(); v != null; v = v.NextSibling<Visual>())
 			{
-				var v = cn as Visual;
-				if (v == null) continue;
-
 				var avs = float2(vert ? columnSize : 0.0f, vert ? 0.0f : columnSize);
 				int col = LeastAt(at);
 				float2 nsz;

--- a/Source/Fuse.Controls.Panels/Layouts/DefaultLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/DefaultLayout.uno
@@ -11,7 +11,7 @@ namespace Fuse.Layouts
 
 	public sealed class DefaultLayout : Layout
 	{
-		internal override float2 GetContentSize(IList<Node> elements, LayoutParams lp)
+		internal override float2 GetContentSize(Visual elements, LayoutParams lp)
 		{
 			var size = GetElementsSize(elements, lp);
 			
@@ -37,12 +37,12 @@ namespace Fuse.Layouts
 			return size;
 		}
 
-		float2 GetElementsSize(IList<Node> elements, LayoutParams lp)
+		float2 GetElementsSize(Visual elements, LayoutParams lp)
 		{
 			var ds = float2(0);
-			for (int i = 0; i < elements.Count; i++)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var e = elements[i] as Visual;
+				var e = cn as Visual;
 				if (!AffectsLayout(e)) continue;
 
 				ds = Math.Max( ds, e.GetMarginSize(lp) );
@@ -50,13 +50,13 @@ namespace Fuse.Layouts
 			return ds;
 		}
 
-		internal override void ArrangePaddingBox(IList<Node> elements, float4 padding, LayoutParams lp)
+		internal override void ArrangePaddingBox(Visual elements, float4 padding, LayoutParams lp)
 		{
 			var av = lp.CloneAndDerive();
 			av.RemoveSize(padding.XY+padding.ZW);
-			for (int i = 0; i < elements.Count; i++)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var e = elements[i] as Visual;
+				var e = cn as Visual;
 				if (e == null) continue;
 				if (!ArrangeMarginBoxSpecial(e, padding, lp))
 				{

--- a/Source/Fuse.Controls.Panels/Layouts/DefaultLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/DefaultLayout.uno
@@ -11,9 +11,9 @@ namespace Fuse.Layouts
 
 	public sealed class DefaultLayout : Layout
 	{
-		internal override float2 GetContentSize(Visual elements, LayoutParams lp)
+		internal override float2 GetContentSize(Visual container, LayoutParams lp)
 		{
-			var size = GetElementsSize(elements, lp);
+			var size = GetElementsSize(container, lp);
 			
 			/*
 			bool recalc = false;
@@ -31,16 +31,16 @@ namespace Fuse.Layouts
 			}
 			
 			if (recalc)
-				size = GetElementsSize(elements, fillSize, fillSet);
+				size = GetElementsSize(container, fillSize, fillSet);
 			*/
 				
 			return size;
 		}
 
-		float2 GetElementsSize(Visual elements, LayoutParams lp)
+		float2 GetElementsSize(Visual container, LayoutParams lp)
 		{
 			var ds = float2(0);
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var e = cn as Visual;
 				if (!AffectsLayout(e)) continue;
@@ -50,11 +50,11 @@ namespace Fuse.Layouts
 			return ds;
 		}
 
-		internal override void ArrangePaddingBox(Visual elements, float4 padding, LayoutParams lp)
+		internal override void ArrangePaddingBox(Visual container, float4 padding, LayoutParams lp)
 		{
 			var av = lp.CloneAndDerive();
 			av.RemoveSize(padding.XY+padding.ZW);
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var e = cn as Visual;
 				if (e == null) continue;

--- a/Source/Fuse.Controls.Panels/Layouts/DefaultLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/DefaultLayout.uno
@@ -40,9 +40,8 @@ namespace Fuse.Layouts
 		float2 GetElementsSize(Visual container, LayoutParams lp)
 		{
 			var ds = float2(0);
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var e = container.FirstChild<Visual>(); e != null; e = e.NextSibling<Visual>())
 			{
-				var e = cn as Visual;
 				if (!AffectsLayout(e)) continue;
 
 				ds = Math.Max( ds, e.GetMarginSize(lp) );
@@ -54,10 +53,8 @@ namespace Fuse.Layouts
 		{
 			var av = lp.CloneAndDerive();
 			av.RemoveSize(padding.XY+padding.ZW);
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var e = container.FirstChild<Visual>(); e != null; e = e.NextSibling<Visual>())
 			{
-				var e = cn as Visual;
-				if (e == null) continue;
 				if (!ArrangeMarginBoxSpecial(e, padding, lp))
 				{
 					e.ArrangeMarginBox(padding.XY, av);

--- a/Source/Fuse.Controls.Panels/Layouts/DockLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/DockLayout.uno
@@ -45,7 +45,7 @@ namespace Fuse.Layouts
 		{
 			var nlp = lp.CloneAndDerive();
 			nlp.SetRelativeSize(lp.Size,lp.HasX,lp.HasY);
-			return MeasureSubtree(container, container.Children_first, nlp);
+			return MeasureSubtree(container, container.FirstChild<Node>(), nlp);
 		}
 
 		//LayoutParams is mutated (not relevant if a struct)
@@ -56,9 +56,8 @@ namespace Fuse.Layouts
 			{
 				//max size of all fill children
 				var mx = float2(0);
-				for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+				for (c = container.FirstChild<Visual>(); c != null; c = c.NextSibling<Visual>())
 				{
-					c = cn as Visual;
 					if (!AffectsLayout(c)) continue;
 
 					if (GetDock(c) == Dock.Fill)
@@ -70,7 +69,7 @@ namespace Fuse.Layouts
 				return mx;
 			}
 
-			if (c == null) return MeasureSubtree(container, child.Children_next, lp);
+			if (c == null) return MeasureSubtree(container, child.NextSibling<Node>(), lp);
 
 			switch (GetDock(c))
 			{
@@ -82,7 +81,7 @@ namespace Fuse.Layouts
 					var cds = c.GetMarginSize( nlp );
 					
 					lp.RemoveSize(float2(cds.X,0));
-					var subtree = MeasureSubtree(container, child.Children_next, lp);
+					var subtree = MeasureSubtree(container, child.NextSibling<Node>(), lp);
 					return float2(cds.X + subtree.X, 
 						Math.Max(cds.Y, subtree.Y));
 				}
@@ -95,13 +94,13 @@ namespace Fuse.Layouts
 					var cds = c.GetMarginSize( nlp );
 					
 					lp.RemoveSize(float2(0,cds.Y));
-					var subtree = MeasureSubtree(container, child.Children_next, lp);
+					var subtree = MeasureSubtree(container, child.NextSibling<Node>(), lp);
 					return float2(Math.Max(cds.X, subtree.X), 
 						cds.Y + subtree.Y);
 				}
 
 				case Dock.Fill:
-					return MeasureSubtree(container, child.Children_next, lp);
+					return MeasureSubtree(container, child.NextSibling<Node>(), lp);
 			}
 			
 			return float2(0);
@@ -116,10 +115,8 @@ namespace Fuse.Layouts
 			var nlp = lp.CloneAndDerive();
 			nlp.SetRelativeSize(lp.Size,lp.HasX,lp.HasY);
 			
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var c = container.FirstChild<Visual>(); c != null; c = c.NextSibling<Visual>())
 			{
-				var c = cn as Visual;
-				if (c == null) continue;
 				if (ArrangeMarginBoxSpecial(c, padding, lp))
 					continue;
 
@@ -170,9 +167,8 @@ namespace Fuse.Layouts
 			}
 			
 			nlp.SetSize(availableSize);
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var c = container.FirstChild<Visual>(); c != null; c = c.NextSibling<Visual>())
 			{
-				var c = cn as Visual;
 				if (!AffectsLayout(c)) continue;
 				
 				if (GetDock(c) != Dock.Fill)

--- a/Source/Fuse.Controls.Panels/Layouts/DockLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/DockLayout.uno
@@ -41,22 +41,22 @@ namespace Fuse.Layouts
 			elm.InvalidateLayout();
 		}
 
-		internal override float2 GetContentSize(Visual elements, LayoutParams lp)
+		internal override float2 GetContentSize(Visual container, LayoutParams lp)
 		{
 			var nlp = lp.CloneAndDerive();
 			nlp.SetRelativeSize(lp.Size,lp.HasX,lp.HasY);
-			return MeasureSubtree(elements, elements.Children_first, nlp);
+			return MeasureSubtree(container, container.Children_first, nlp);
 		}
 
 		//LayoutParams is mutated (not relevant if a struct)
-		float2 MeasureSubtree(Visual elements, Node child, LayoutParams lp)
+		float2 MeasureSubtree(Visual container, Node child, LayoutParams lp)
 		{
 			Visual c = child as Visual;
 			if (child == null)
 			{
 				//max size of all fill children
 				var mx = float2(0);
-				for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+				for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 				{
 					c = cn as Visual;
 					if (!AffectsLayout(c)) continue;
@@ -70,7 +70,7 @@ namespace Fuse.Layouts
 				return mx;
 			}
 
-			if (c == null) return MeasureSubtree(elements, child.Children_next, lp);
+			if (c == null) return MeasureSubtree(container, child.Children_next, lp);
 
 			switch (GetDock(c))
 			{
@@ -82,7 +82,7 @@ namespace Fuse.Layouts
 					var cds = c.GetMarginSize( nlp );
 					
 					lp.RemoveSize(float2(cds.X,0));
-					var subtree = MeasureSubtree(elements, child.Children_next, lp);
+					var subtree = MeasureSubtree(container, child.Children_next, lp);
 					return float2(cds.X + subtree.X, 
 						Math.Max(cds.Y, subtree.Y));
 				}
@@ -95,19 +95,19 @@ namespace Fuse.Layouts
 					var cds = c.GetMarginSize( nlp );
 					
 					lp.RemoveSize(float2(0,cds.Y));
-					var subtree = MeasureSubtree(elements, child.Children_next, lp);
+					var subtree = MeasureSubtree(container, child.Children_next, lp);
 					return float2(Math.Max(cds.X, subtree.X), 
 						cds.Y + subtree.Y);
 				}
 
 				case Dock.Fill:
-					return MeasureSubtree(elements, child.Children_next, lp);
+					return MeasureSubtree(container, child.Children_next, lp);
 			}
 			
 			return float2(0);
 		}
 
-		internal override void ArrangePaddingBox(Visual elements, float4 padding, 
+		internal override void ArrangePaddingBox(Visual container, float4 padding, 
 			LayoutParams lp)
 		{
 			var availablePosition = padding.XY;
@@ -116,7 +116,7 @@ namespace Fuse.Layouts
 			var nlp = lp.CloneAndDerive();
 			nlp.SetRelativeSize(lp.Size,lp.HasX,lp.HasY);
 			
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var c = cn as Visual;
 				if (c == null) continue;
@@ -170,7 +170,7 @@ namespace Fuse.Layouts
 			}
 			
 			nlp.SetSize(availableSize);
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var c = cn as Visual;
 				if (!AffectsLayout(c)) continue;

--- a/Source/Fuse.Controls.Panels/Layouts/GridLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/GridLayout.uno
@@ -510,15 +510,15 @@ namespace Fuse.Layouts
 			else return 0;
 		}
 		
-		void CalcActualPositions(IList<Node> elements)
+		void CalcActualPositions(Visual elements)
 		{
 			bool rowMajor = ChildOrder == GridChildOrder.RowMajor;
 			
 			//find expected max column
 			int minorCount = Math.Max(1,rowMajor ? UserCount(ColumnList) : UserCount(RowList));
-			for (int nx = 0; nx < elements.Count; nx++)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var e = elements[nx] as Visual;
+				var e = cn as Visual;
 				if (!AffectsLayout(e)) continue;
 
 				if (rowMajor)
@@ -541,9 +541,9 @@ namespace Fuse.Layouts
 			int maxRow = 0;
 			int maxCol = 0;
 			
-			for (int nx = 0; nx < elements.Count; nx++)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var elm = elements[nx] as Visual;
+				var elm = cn as Visual;
 				if (!AffectsLayout(elm)) continue;
 
 				object v;
@@ -728,7 +728,7 @@ namespace Fuse.Layouts
 			_rows.RootUnsubscribe();
 		}
 
-		internal override float2 GetContentSize(IList<Node> elements, LayoutParams lp)
+		internal override float2 GetContentSize(Visual elements, LayoutParams lp)
 		{
 			return Measure(elements, lp);	
 		}
@@ -870,13 +870,13 @@ namespace Fuse.Layouts
 			return sz;
 		}
 		
-		void CalcAuto(IList<Node> elements, ref float availableWidth, ref float availableHeight, bool secondPass,
+		void CalcAuto(Visual elements, ref float availableWidth, ref float availableHeight, bool secondPass,
 			bool hasFirstHorzSize, bool hasFirstVertSize,
 			bool expandWidth, bool expandHeight)
 		{
-			for (int nx = 0; nx < elements.Count; nx++)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var child = elements[nx] as Visual;
+				var child = cn as Visual;
 				if (!AffectsLayout(child)) continue;
 
 				int x = GetActualColumn(child);
@@ -928,7 +928,7 @@ namespace Fuse.Layouts
 			availableHeight = Math.Max(availableHeight, 0.0f);
 		}
 		
-		float2 Measure(IList<Node> elements, LayoutParams lp)
+		float2 Measure(Visual elements, LayoutParams lp)
 		{
 			var effectiveCellSpacing = EffectiveCellSpacing;
 			
@@ -1013,7 +1013,7 @@ namespace Fuse.Layouts
 			}
 		}
 		
-		internal override void ArrangePaddingBox(IList<Node> elements, float4 padding, 
+		internal override void ArrangePaddingBox(Visual elements, float4 padding, 
 			LayoutParams lp)
 		{
 			var remainSize = lp.Size - padding.XY - padding.ZW;
@@ -1048,9 +1048,9 @@ namespace Fuse.Layouts
 			
 			var effectiveCellSpacing = EffectiveCellSpacing;
 			var nlp = lp.CloneAndDerive();
-			for (int nx = 0; nx < elements.Count; nx++)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var child = elements[nx] as Visual;
+				var child = cn as Visual;
 				if (child == null) continue;
 				if (ArrangeMarginBoxSpecial(child, padding, lp))
 					continue;

--- a/Source/Fuse.Controls.Panels/Layouts/GridLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/GridLayout.uno
@@ -510,13 +510,13 @@ namespace Fuse.Layouts
 			else return 0;
 		}
 		
-		void CalcActualPositions(Visual elements)
+		void CalcActualPositions(Visual container)
 		{
 			bool rowMajor = ChildOrder == GridChildOrder.RowMajor;
 			
 			//find expected max column
 			int minorCount = Math.Max(1,rowMajor ? UserCount(ColumnList) : UserCount(RowList));
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var e = cn as Visual;
 				if (!AffectsLayout(e)) continue;
@@ -541,7 +541,7 @@ namespace Fuse.Layouts
 			int maxRow = 0;
 			int maxCol = 0;
 			
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var elm = cn as Visual;
 				if (!AffectsLayout(elm)) continue;
@@ -728,9 +728,9 @@ namespace Fuse.Layouts
 			_rows.RootUnsubscribe();
 		}
 
-		internal override float2 GetContentSize(Visual elements, LayoutParams lp)
+		internal override float2 GetContentSize(Visual container, LayoutParams lp)
 		{
-			return Measure(elements, lp);	
+			return Measure(container, lp);	
 		}
 
 		float EffectiveCellSpacing
@@ -870,11 +870,11 @@ namespace Fuse.Layouts
 			return sz;
 		}
 		
-		void CalcAuto(Visual elements, ref float availableWidth, ref float availableHeight, bool secondPass,
+		void CalcAuto(Visual container, ref float availableWidth, ref float availableHeight, bool secondPass,
 			bool hasFirstHorzSize, bool hasFirstVertSize,
 			bool expandWidth, bool expandHeight)
 		{
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var child = cn as Visual;
 				if (!AffectsLayout(child)) continue;
@@ -928,11 +928,11 @@ namespace Fuse.Layouts
 			availableHeight = Math.Max(availableHeight, 0.0f);
 		}
 		
-		float2 Measure(Visual elements, LayoutParams lp)
+		float2 Measure(Visual container, LayoutParams lp)
 		{
 			var effectiveCellSpacing = EffectiveCellSpacing;
 			
-			CalcActualPositions(elements);
+			CalcActualPositions(container);
 			
 			var fillHorizontal = lp.HasX;
 			var fillVertical = lp.HasY;
@@ -976,7 +976,7 @@ namespace Fuse.Layouts
 			}
 			
 			// Measure cols/rows with auto metrics in both dimensions
-			CalcAuto(elements, ref availableWidth, ref availableHeight, false, hasFirstHorzSize, hasFirstVertSize,
+			CalcAuto(container, ref availableWidth, ref availableHeight, false, hasFirstHorzSize, hasFirstVertSize,
 				expandWidth, expandHeight);
 
 			// do fill for axes not done before
@@ -987,7 +987,7 @@ namespace Fuse.Layouts
 				CalcFill(_rows, availableHeight, heightProportion, expandHeight);
 			
 			//measure again for auto cells that didn't get measured the first pass
-			CalcAuto(elements, ref availableWidth, ref availableHeight, true, hasFirstHorzSize, hasFirstVertSize,
+			CalcAuto(container, ref availableWidth, ref availableHeight, true, hasFirstHorzSize, hasFirstVertSize,
 				expandWidth, expandHeight);
 
 			// Place rows/cols
@@ -1013,11 +1013,11 @@ namespace Fuse.Layouts
 			}
 		}
 		
-		internal override void ArrangePaddingBox(Visual elements, float4 padding, 
+		internal override void ArrangePaddingBox(Visual container, float4 padding, 
 			LayoutParams lp)
 		{
 			var remainSize = lp.Size - padding.XY - padding.ZW;
-			var measured = Measure( elements, LayoutParams.Create(remainSize) );
+			var measured = Measure( container, LayoutParams.Create(remainSize) );
 
 			var off = float2(0);
 			var eca = EffectiveContentAlignment;
@@ -1048,7 +1048,7 @@ namespace Fuse.Layouts
 			
 			var effectiveCellSpacing = EffectiveCellSpacing;
 			var nlp = lp.CloneAndDerive();
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var child = cn as Visual;
 				if (child == null) continue;

--- a/Source/Fuse.Controls.Panels/Layouts/GridLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/GridLayout.uno
@@ -516,9 +516,8 @@ namespace Fuse.Layouts
 			
 			//find expected max column
 			int minorCount = Math.Max(1,rowMajor ? UserCount(ColumnList) : UserCount(RowList));
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var e = container.FirstChild<Visual>(); e != null; e = e.NextSibling<Visual>())
 			{
-				var e = cn as Visual;
 				if (!AffectsLayout(e)) continue;
 
 				if (rowMajor)
@@ -541,9 +540,8 @@ namespace Fuse.Layouts
 			int maxRow = 0;
 			int maxCol = 0;
 			
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var elm = container.FirstChild<Visual>(); elm != null; elm = elm.NextSibling<Visual>())
 			{
-				var elm = cn as Visual;
 				if (!AffectsLayout(elm)) continue;
 
 				object v;
@@ -874,9 +872,8 @@ namespace Fuse.Layouts
 			bool hasFirstHorzSize, bool hasFirstVertSize,
 			bool expandWidth, bool expandHeight)
 		{
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var child = container.FirstChild<Visual>(); child != null; child = child.NextSibling<Visual>())
 			{
-				var child = cn as Visual;
 				if (!AffectsLayout(child)) continue;
 
 				int x = GetActualColumn(child);
@@ -1048,10 +1045,8 @@ namespace Fuse.Layouts
 			
 			var effectiveCellSpacing = EffectiveCellSpacing;
 			var nlp = lp.CloneAndDerive();
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var child = container.FirstChild<Visual>(); child != null; child = child.NextSibling<Visual>())
 			{
-				var child = cn as Visual;
-				if (child == null) continue;
 				if (ArrangeMarginBoxSpecial(child, padding, lp))
 					continue;
 

--- a/Source/Fuse.Controls.Panels/Layouts/Layout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/Layout.uno
@@ -71,8 +71,8 @@ namespace Fuse.Layouts
 		//true at the start of rooting, prior to OnRooted call
 		internal bool IsRootingStarted { get { return Container != null; } }
 	
-		internal abstract float2 GetContentSize(IList<Node> elements, LayoutParams lp);
-		internal abstract void ArrangePaddingBox(IList<Node> elements, float4 padding, LayoutParams lp);
+		internal abstract float2 GetContentSize(Visual elementOwner, LayoutParams lp);
+		internal abstract void ArrangePaddingBox(Visual elementOwner, float4 padding, LayoutParams lp);
 		
 		protected bool AffectsLayout(Node n)
 		{

--- a/Source/Fuse.Controls.Panels/Layouts/StackLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/StackLayout.uno
@@ -87,7 +87,7 @@ namespace Fuse.Layouts
 		}
 
 
-		internal override float2 GetContentSize(Visual elements, LayoutParams lp)
+		internal override float2 GetContentSize(Visual container, LayoutParams lp)
 		{
 			var orientation = Orientation;
 
@@ -95,7 +95,7 @@ namespace Fuse.Layouts
 			var nlp = lp.CloneAndDerive();
 			nlp.RetainXY(vert, !vert);
 
-			var size = GetElementsSize(elements, nlp);
+			var size = GetElementsSize(container, nlp);
 			
 			if (Mode == StackLayoutMode.TwoPass)
 			{
@@ -118,7 +118,7 @@ namespace Fuse.Layouts
 				}
 				
 				if (recalc)
-					size = GetElementsSize(elements, nlp);
+					size = GetElementsSize(container, nlp);
 			}
 				
 			return size;
@@ -133,14 +133,14 @@ namespace Fuse.Layouts
 			}
 		}
 		
-		float2 GetElementsSize(Visual elements, LayoutParams lp)
+		float2 GetElementsSize(Visual container, LayoutParams lp)
 		{
 			var orientation = Orientation;
 			var desiredSize = float2(0);
 
 			var effectiveSpacing = EffectiveItemSpacing;
 			bool firstItem = true;
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var c = cn as Visual;
 				if (!AffectsLayout(c)) continue;
@@ -183,7 +183,7 @@ namespace Fuse.Layouts
 			}
 		}
 		
-		internal override void ArrangePaddingBox(Visual elements, float4 padding, 
+		internal override void ArrangePaddingBox(Visual container, float4 padding, 
 			LayoutParams lp)
 		{
 			var d = 0.0f;
@@ -207,7 +207,7 @@ namespace Fuse.Layouts
 
 			var effectiveSpacing = EffectiveItemSpacing;
 			var hasItem = false;
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 			{
 				var c = cn as Visual;
 				if (c == null) continue;
@@ -230,7 +230,7 @@ namespace Fuse.Layouts
 				else
 					off = Vector.Dot(lp.Size-pad,axis)/2 - d/2;
 
-				for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+				for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 				{
 					var e = cn as Visual;
 					if (AffectsLayout(e))

--- a/Source/Fuse.Controls.Panels/Layouts/StackLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/StackLayout.uno
@@ -140,9 +140,8 @@ namespace Fuse.Layouts
 
 			var effectiveSpacing = EffectiveItemSpacing;
 			bool firstItem = true;
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var c = container.FirstChild<Visual>(); c != null; c = c.NextSibling<Visual>())
 			{
-				var c = cn as Visual;
 				if (!AffectsLayout(c)) continue;
 
 				var spacing = effectiveSpacing;
@@ -207,10 +206,8 @@ namespace Fuse.Layouts
 
 			var effectiveSpacing = EffectiveItemSpacing;
 			var hasItem = false;
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+			for (var c = container.FirstChild<Visual>(); c != null; c = c.NextSibling<Visual>())
 			{
-				var c = cn as Visual;
-				if (c == null) continue;
 				if (ArrangeMarginBoxSpecial(c, padding, lp)) //TODO: hmm, used to drop X/Y Flag
 					continue;
 				
@@ -230,9 +227,8 @@ namespace Fuse.Layouts
 				else
 					off = Vector.Dot(lp.Size-pad,axis)/2 - d/2;
 
-				for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+				for (var e = container.FirstChild<Visual>(); e != null; e = e.NextSibling<Visual>())
 				{
-					var e = cn as Visual;
 					if (AffectsLayout(e))
 					{
 						var old = e.MarginBoxPosition;

--- a/Source/Fuse.Controls.Panels/Layouts/StackLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/StackLayout.uno
@@ -87,7 +87,7 @@ namespace Fuse.Layouts
 		}
 
 
-		internal override float2 GetContentSize(IList<Node> elements, LayoutParams lp)
+		internal override float2 GetContentSize(Visual elements, LayoutParams lp)
 		{
 			var orientation = Orientation;
 
@@ -133,16 +133,16 @@ namespace Fuse.Layouts
 			}
 		}
 		
-		float2 GetElementsSize(IList<Node> elements, LayoutParams lp)
+		float2 GetElementsSize(Visual elements, LayoutParams lp)
 		{
 			var orientation = Orientation;
 			var desiredSize = float2(0);
 
 			var effectiveSpacing = EffectiveItemSpacing;
 			bool firstItem = true;
-			for (int i = 0; i < elements.Count; i++)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var c = elements[i] as Visual;
+				var c = cn as Visual;
 				if (!AffectsLayout(c)) continue;
 
 				var spacing = effectiveSpacing;
@@ -183,7 +183,7 @@ namespace Fuse.Layouts
 			}
 		}
 		
-		internal override void ArrangePaddingBox(IList<Node> elements, float4 padding, 
+		internal override void ArrangePaddingBox(Visual elements, float4 padding, 
 			LayoutParams lp)
 		{
 			var d = 0.0f;
@@ -207,9 +207,9 @@ namespace Fuse.Layouts
 
 			var effectiveSpacing = EffectiveItemSpacing;
 			var hasItem = false;
-			for (int i = 0; i < elements.Count; i++)
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 			{
-				var c = elements[i] as Visual;
+				var c = cn as Visual;
 				if (c == null) continue;
 				if (ArrangeMarginBoxSpecial(c, padding, lp)) //TODO: hmm, used to drop X/Y Flag
 					continue;
@@ -230,9 +230,9 @@ namespace Fuse.Layouts
 				else
 					off = Vector.Dot(lp.Size-pad,axis)/2 - d/2;
 
-				for (int i = 0; i < elements.Count; i++)
+				for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 				{
-					var e = elements[i] as Visual;
+					var e = cn as Visual;
 					if (AffectsLayout(e))
 					{
 						var old = e.MarginBoxPosition;

--- a/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
@@ -134,9 +134,8 @@ namespace Fuse.Layouts
 			int currentRow = 0;
 			
 			int i = 0;
-			for (var cn = container.Children_first; cn != null; cn = cn.Children_next, i++)
+			for (var e = container.FirstChild<Visual>(); e != null; e = e.NextSibling<Visual>(), i++)
 			{
-				var e = cn as Visual;
 				if (!AffectsLayout(e))
 					continue;
 
@@ -184,10 +183,8 @@ namespace Fuse.Layouts
 				var saMin = IsVert ? AlignmentHelpers.GetHorizontalSimpleAlignOptional(RowAlignment) : AlignmentHelpers.GetVerticalSimpleAlignOptional(RowAlignment);
 				var saMaj = IsVert ? AlignmentHelpers.GetVerticalSimpleAlignOptional(RowAlignment) : AlignmentHelpers.GetHorizontalSimpleAlignOptional(RowAlignment);
 				var elp = lp.CloneAndDerive();
-				for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
+				for (var element = container.FirstChild<Visual>(); element != null; element = element.NextSibling<Visual>())
 				{
-					var element = cn as Visual;
-					if (element == null) continue;
 					if (ArrangeMarginBoxSpecial(element, padding, lp ))
 						continue;
 

--- a/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
@@ -82,21 +82,21 @@ namespace Fuse.Layouts
 		public string ID { get; set; }
 
 		internal override float2 GetContentSize(
-			Visual elements,
+			Visual container,
 			LayoutParams lp)
 		{
-			return Arrange(elements, lp, false);
+			return Arrange(container, lp, false);
 		}
 		
 		internal override void ArrangePaddingBox(
-			Visual elements,
+			Visual container,
 			float4 padding,
 			LayoutParams lp)
 		{
-			Arrange(elements, lp, true, padding);
+			Arrange(container, lp, true, padding);
 		}
 		
-		float2 Arrange(Visual elements, LayoutParams lp,	
+		float2 Arrange(Visual container, LayoutParams lp,	
 			bool doArrange, float4 padding = float4(0))
 		{
 			var nlp = lp.CloneAndDerive();
@@ -121,20 +121,20 @@ namespace Fuse.Layouts
 			if (_hasItemHeight)
 				clp.SetY(ItemHeight);
 
-			var placements = new float4[elements.Children.Count];
+			var placements = new float4[container.Children.Count];
 			//minorMaxSize in each major row, assinged per element
-			var minorSizes = new float[elements.Children.Count];
+			var minorSizes = new float[container.Children.Count];
 			// save the row each element is on
-			var elementOnRow = new int[elements.Children.Count];
+			var elementOnRow = new int[container.Children.Count];
 			// save the available space for each row
-			var majorRest = new float[elements.Children.Count];
+			var majorRest = new float[container.Children.Count];
 			//where this row starts
 			int majorStart = 0;
 			// current row
 			int currentRow = 0;
 			
 			int i = 0;
-			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next, i++)
+			for (var cn = container.Children_first; cn != null; cn = cn.Children_next, i++)
 			{
 				var e = cn as Visual;
 				if (!AffectsLayout(e))
@@ -174,7 +174,7 @@ namespace Fuse.Layouts
 			}
 
 			//final bits
-			for (int j=majorStart; j < elements.Children.Count; ++j)
+			for (int j=majorStart; j < container.Children.Count; ++j)
 				minorSizes[j] = minorMaxSize;
 			majorMaxUsed = Math.Max(majorMaxUsed, majorUsed);
 			minorUsed += minorMaxSize;
@@ -184,7 +184,7 @@ namespace Fuse.Layouts
 				var saMin = IsVert ? AlignmentHelpers.GetHorizontalSimpleAlignOptional(RowAlignment) : AlignmentHelpers.GetVerticalSimpleAlignOptional(RowAlignment);
 				var saMaj = IsVert ? AlignmentHelpers.GetVerticalSimpleAlignOptional(RowAlignment) : AlignmentHelpers.GetHorizontalSimpleAlignOptional(RowAlignment);
 				var elp = lp.CloneAndDerive();
-				for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
+				for (var cn = container.Children_first; cn != null; cn = cn.Children_next)
 				{
 					var element = cn as Visual;
 					if (element == null) continue;

--- a/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
@@ -183,7 +183,8 @@ namespace Fuse.Layouts
 				var saMin = IsVert ? AlignmentHelpers.GetHorizontalSimpleAlignOptional(RowAlignment) : AlignmentHelpers.GetVerticalSimpleAlignOptional(RowAlignment);
 				var saMaj = IsVert ? AlignmentHelpers.GetVerticalSimpleAlignOptional(RowAlignment) : AlignmentHelpers.GetHorizontalSimpleAlignOptional(RowAlignment);
 				var elp = lp.CloneAndDerive();
-				for (var element = container.FirstChild<Visual>(); element != null; element = element.NextSibling<Visual>())
+				i = 0;
+				for (var element = container.FirstChild<Visual>(); element != null; element = element.NextSibling<Visual>(), i++)
 				{
 					if (ArrangeMarginBoxSpecial(element, padding, lp ))
 						continue;

--- a/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
@@ -188,6 +188,7 @@ namespace Fuse.Layouts
 				for (var n = container.FirstChild<Node>(); n != null; n = n.NextSibling<Node>(), i++)
 				{
 					var element = n as Visual;
+					if (element == null) continue;
 					if (ArrangeMarginBoxSpecial(element, padding, lp ))
 						continue;
 

--- a/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
@@ -134,8 +134,9 @@ namespace Fuse.Layouts
 			int currentRow = 0;
 			
 			int i = 0;
-			for (var e = container.FirstChild<Visual>(); e != null; e = e.NextSibling<Visual>(), i++)
+			for (var n = container.FirstChild<Node>(); n != null; n = n.NextSibling<Node>(), i++)
 			{
+				var e = n as Visual;
 				if (!AffectsLayout(e))
 					continue;
 
@@ -184,8 +185,9 @@ namespace Fuse.Layouts
 				var saMaj = IsVert ? AlignmentHelpers.GetVerticalSimpleAlignOptional(RowAlignment) : AlignmentHelpers.GetHorizontalSimpleAlignOptional(RowAlignment);
 				var elp = lp.CloneAndDerive();
 				i = 0;
-				for (var element = container.FirstChild<Visual>(); element != null; element = element.NextSibling<Visual>(), i++)
+				for (var n = container.FirstChild<Node>(); n != null; n = n.NextSibling<Node>(), i++)
 				{
+					var element = n as Visual;
 					if (ArrangeMarginBoxSpecial(element, padding, lp ))
 						continue;
 

--- a/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/WrapLayout.uno
@@ -82,21 +82,21 @@ namespace Fuse.Layouts
 		public string ID { get; set; }
 
 		internal override float2 GetContentSize(
-			IList<Node> elements,
+			Visual elements,
 			LayoutParams lp)
 		{
 			return Arrange(elements, lp, false);
 		}
 		
 		internal override void ArrangePaddingBox(
-			IList<Node> elements,
+			Visual elements,
 			float4 padding,
 			LayoutParams lp)
 		{
 			Arrange(elements, lp, true, padding);
 		}
 		
-		float2 Arrange(IList<Node> elements, LayoutParams lp,	
+		float2 Arrange(Visual elements, LayoutParams lp,	
 			bool doArrange, float4 padding = float4(0))
 		{
 			var nlp = lp.CloneAndDerive();
@@ -121,21 +121,22 @@ namespace Fuse.Layouts
 			if (_hasItemHeight)
 				clp.SetY(ItemHeight);
 
-			var placements = new float4[elements.Count];
+			var placements = new float4[elements.Children.Count];
 			//minorMaxSize in each major row, assinged per element
-			var minorSizes = new float[elements.Count];
+			var minorSizes = new float[elements.Children.Count];
 			// save the row each element is on
-			var elementOnRow = new int[elements.Count];
+			var elementOnRow = new int[elements.Children.Count];
 			// save the available space for each row
-			var majorRest = new float[elements.Count];
+			var majorRest = new float[elements.Children.Count];
 			//where this row starts
 			int majorStart = 0;
 			// current row
 			int currentRow = 0;
 			
-			for (int i = 0; i < elements.Count;++i)
+			int i = 0;
+			for (var cn = elements.Children_first; cn != null; cn = cn.Children_next, i++)
 			{
-				var e = elements[i] as Visual;
+				var e = cn as Visual;
 				if (!AffectsLayout(e))
 					continue;
 
@@ -173,7 +174,7 @@ namespace Fuse.Layouts
 			}
 
 			//final bits
-			for (int j=majorStart; j < elements.Count; ++j)
+			for (int j=majorStart; j < elements.Children.Count; ++j)
 				minorSizes[j] = minorMaxSize;
 			majorMaxUsed = Math.Max(majorMaxUsed, majorUsed);
 			minorUsed += minorMaxSize;
@@ -183,9 +184,9 @@ namespace Fuse.Layouts
 				var saMin = IsVert ? AlignmentHelpers.GetHorizontalSimpleAlignOptional(RowAlignment) : AlignmentHelpers.GetVerticalSimpleAlignOptional(RowAlignment);
 				var saMaj = IsVert ? AlignmentHelpers.GetVerticalSimpleAlignOptional(RowAlignment) : AlignmentHelpers.GetHorizontalSimpleAlignOptional(RowAlignment);
 				var elp = lp.CloneAndDerive();
-				for (int i=0; i < elements.Count; ++i)
+				for (var cn = elements.Children_first; cn != null; cn = cn.Children_next)
 				{
-					var element = elements[i] as Visual;
+					var element = cn as Visual;
 					if (element == null) continue;
 					if (ArrangeMarginBoxSpecial(element, padding, lp ))
 						continue;

--- a/Source/Fuse.Controls.Panels/MultiLayoutPanel.uno
+++ b/Source/Fuse.Controls.Panels/MultiLayoutPanel.uno
@@ -23,9 +23,8 @@ namespace Fuse.Controls
 				return;
 
 			// Avoid changing layout on inner multi layout panels
-			for (int i = 0; i < layoutRoot.Children.Count; i++)
-				if (layoutRoot.Children[i] is MultiLayout)
-					return;
+			if (layoutRoot.FirstChild<MultiLayout>() != null)
+				return;
 
 			if (layoutRoot is Placeholder)
 			{

--- a/Source/Fuse.Controls.Panels/Tests/Grid.Test.uno
+++ b/Source/Fuse.Controls.Panels/Tests/Grid.Test.uno
@@ -455,12 +455,12 @@ namespace Fuse.Controls.Test
 				root.Layout(int2(1000));
 				Assert.AreEqual(float2(1000,300),g.G.ActualSize);
 				
-				g.G.Children.Remove(g.G.FirstVisualChild);
+				g.G.Children.Remove(g.G.FirstChild<Visual>());
 				root.Layout(int2(1000));
 				Assert.AreEqual(float2(1000,200),g.G.ActualSize);
 				
 				while(g.G.ZOrderChildCount > 0)
-					g.G.Children.Remove(g.G.FirstVisualChild);
+					g.G.Children.Remove(g.G.FirstChild<Visual>());
 				root.Layout(int2(1000));
 				Assert.AreEqual(float2(1000,0),g.G.ActualSize);
 				
@@ -473,8 +473,8 @@ namespace Fuse.Controls.Test
 				Assert.AreEqual(float2(1000,1000),g.P.ActualSize);
 				Assert.AreEqual(float2(1000/3.0f),q.ActualSize);
 				
-				g.P.Children.Remove(g.P.FirstVisualChild);
-				g.P.Children.Remove(g.P.FirstVisualChild);
+				g.P.Children.Remove(g.P.FirstChild<Visual>());
+				g.P.Children.Remove(g.P.FirstChild<Visual>());
 				root.Layout(int2(1000));
 				Assert.AreEqual(float2(1000,1000),g.P.ActualSize);
 				Assert.AreEqual(float2(1000/3.0f,500),q.ActualSize);

--- a/Source/Fuse.Controls.Primitives/Behaviors/Shadow.uno
+++ b/Source/Fuse.Controls.Primitives/Behaviors/Shadow.uno
@@ -179,7 +179,7 @@ namespace Fuse.Controls
 					_rectangleTranslation.XY = Offset;
 					_rectangle.Children.Add(_rectangleTranslation);
 
-					_elementParent.Children.Insert(_elementParent.Children.IndexOf(this) + 1, _rectangle);
+					_elementParent.InsertAfter(this, _rectangle);
 					break;
 
 				case ShadowMode.PerPixel:
@@ -193,7 +193,7 @@ namespace Fuse.Controls
 						Angle = _angle,
 						Distance = _distance
 					};
-					_elementParent.Children.Insert(_elementParent.Children.IndexOf(this) + 1, _dropShadow);
+					_elementParent.InsertAfter(this, _dropShadow);
 					break;
 			}
 		}

--- a/Source/Fuse.Controls.Primitives/Shapes/Curve.uno
+++ b/Source/Fuse.Controls.Primitives/Shapes/Curve.uno
@@ -267,12 +267,8 @@ namespace Fuse.Controls
 		{
 			InvalidateSurfacePath();
 			_points.Clear();
-			for (int i=0; i < Children.Count; ++i)
-			{
-				var lp = Children[i] as CurvePoint;
-				if (lp != null)
-					_points.Add(lp);
-			}
+			for (var n = FirstChild<CurvePoint>(); n != null; n = n.NextSibling<CurvePoint>())
+				_points.Add(n);
 		}
 		
 		void IPropertyListener.OnPropertyChanged(PropertyObject obj, Selector prop)

--- a/Source/Fuse.Controls.ScrollView/ScrollView.Layout.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollView.Layout.uno
@@ -112,10 +112,9 @@ namespace Fuse.Controls
 			var relAnchor = AlignmentHelpers.GetAnchor(_contentAlignment);
 			var anchor = relAnchor * ActualSize;
 			
-			for (int i=0; i < Element.Children.Count; ++i)
+			for (var c = Element.FirstChild<Element>(); c != null; c = c.NextSibling<Element>())
 			{
-				var c = Element.Children[i] as Element;
-				if (c == null || !c.HasMarginBox || c.LayoutRole != LayoutRole.Standard)
+				if (!c.HasMarginBox || c.LayoutRole != LayoutRole.Standard)
 					continue;
 					
 				var cAnchor = Content.ActualPosition - ScrollPosition + c.ActualPosition + c.ActualSize * relAnchor;

--- a/Source/Fuse.Controls/Tests/Fuse.Controls.Test.Helpers/PanelTester.uno
+++ b/Source/Fuse.Controls/Tests/Fuse.Controls.Test.Helpers/PanelTester.uno
@@ -110,9 +110,12 @@ namespace Fuse.Controls.Test
 				panelToTest.SnapToPixels = false;
 				LayoutTestHelper.TestElementLayout(root, panelToTest, int2(420,80), float2(100, 71),
 					float2(420 - 100 - 21.4f, 5.3f));
+
+				root.Children.Remove(parent);
 			}
 
 			panelToTest.SnapToPixels = true;
+
 
 			var screenDensity = 2f;
 			using (var root = new TestRootPanel(false, screenDensity))
@@ -122,6 +125,8 @@ namespace Fuse.Controls.Test
 				LayoutTestHelper.TestElementLayout(root, panelToTest, int2(800,600),
 					root.SnapToPixelsSize(float2(100, 71)), float2(800 - 100 - root.SnapToPixelsPos(21.4f),
 					root.SnapToPixelsPos(5.3f)));
+
+				root.Children.Remove(parent);
 			}
 
 			screenDensity = 0.75f;
@@ -133,6 +138,8 @@ namespace Fuse.Controls.Test
 				LayoutTestHelper.TestElementLayout(root, panelToTest, int2(600,600), 
 					root.SnapToPixelsSize(float2(100, 71)) , float2(600 - 100 - root.SnapToPixelsPos(21.4f),
 					root.SnapToPixelsPos(5.3f)), 0.0001f);
+
+				root.Children.Remove(parent);
 			}
 
 			screenDensity = 1.4f;
@@ -146,6 +153,8 @@ namespace Fuse.Controls.Test
 
 				panelToTest.SnapToPixels = false;
 				parent.Children.Clear();
+
+				root.Children.Remove(parent);
 			}
 		}
 

--- a/Source/Fuse.Navigation/Navigation.Locators.uno
+++ b/Source/Fuse.Navigation/Navigation.Locators.uno
@@ -26,11 +26,10 @@ namespace Fuse.Navigation
 			if (t != null)
 				return t;
 				
-			for (int i = 0; i < node.Children.Count; i++)
+			for (var x = node.FirstChild<Behavior>(); x != null; x = x.NextSibling<Behavior>())
 			{
-				var c = node.Children[i] as IBaseNavigation;
-				//mean to check only behaviours (as was a distinct list before), so exclude visuals
-				if (c != null && !(c is Visual)) return c;
+				var c = x as IBaseNavigation;
+				if (c != null) return c;
 			}
 			return null;
 		}

--- a/Source/Fuse.Navigation/Router.uno
+++ b/Source/Fuse.Navigation/Router.uno
@@ -558,9 +558,9 @@ namespace Fuse.Navigation
 				if (HasOtherRouter(v))
 					return null;
 				
-				for (int i = 0; i < v.Children.Count; i++)
+				for (var ue = v.FirstChild<Node>(); ue != null; ue = ue.NextSibling<Node>())
 				{
-					ro = FindOutletDown(v.Children[i]);
+					ro = FindOutletDown(ue);
 					if (ro != null) return ro;
 				}
 			}

--- a/Source/Fuse.Navigation/VisualNavigation.uno
+++ b/Source/Fuse.Navigation/VisualNavigation.uno
@@ -167,9 +167,9 @@ namespace Fuse.Navigation
 		{
 			_pages.Clear();
 			int c = 0;
-			for (int i = 0; i < Parent.Children.Count; i++)
+			for (var x = Parent.FirstChild<Visual>(); x != null; x = x.NextSibling<Visual>())
 			{
-				var x = Parent.Children[i] as Visual; //we require Visual (though IsPage tends to check that anyway)
+				//we require Visual (though IsPage tends to check that anyway)
 				if (!Navigation.IsPage(x))
 					continue;
 					

--- a/Source/Fuse.Nodes/Input/Focus.Prediction.uno
+++ b/Source/Fuse.Nodes/Input/Focus.Prediction.uno
@@ -121,23 +121,12 @@ namespace Fuse.Input
 
 		static Visual FirstVisualChild(Visual visual)
 		{
-			foreach (var c in visual.Children)
-			{
-				if (c is Visual)
-					return (Visual)c;
-			}
-			return null;
+			return visual.FirstChild<Visual>();
 		}
 
 		static Visual LastVisualChild(Visual visual)
 		{
-			for (var i = visual.Children.Count - 1; i >= 0; i--)
-			{
-				var c = visual.Children[i] as Visual;
-				if (c != null)
-					return c;
-			}
-			return null;
+			return visual.LastChild<Visual>();
 		}
 	}
 }

--- a/Source/Fuse.Nodes/Node.DataContext.uno
+++ b/Source/Fuse.Nodes/Node.DataContext.uno
@@ -87,13 +87,13 @@ namespace Fuse
 				var p = np as Visual;
 				if (p != null)
 				{
-					for (var c = p.Children_last; c != null; c = c.Children_previous)
+					for (var dp = p.LastChild<Node>(); dp != null; dp = dp.PreviousSibling<Node>())
 					{
-						var sibdp = c as ISiblingDataProvider;
-						if (sibdp != null)
+						var sdp = dp as ISiblingDataProvider;
+						if (sdp != null)
 						{
-							var data = sibdp.Data;
-							if (data != null && !e.NextData(sibdp.Data)) return;
+							var data = sdp.Data;
+							if (data != null && !e.NextData(data)) return;
 						}
 					}
 				}

--- a/Source/Fuse.Nodes/Node.DataContext.uno
+++ b/Source/Fuse.Nodes/Node.DataContext.uno
@@ -87,9 +87,9 @@ namespace Fuse
 				var p = np as Visual;
 				if (p != null)
 				{
-					for (var i = p.Children.Count-1; i >= 0; i--)
+					for (var c = p.Children_last; c != null; c = c.Children_previous)
 					{
-						var sibdp = p.Children[i] as ISiblingDataProvider;
+						var sibdp = c as ISiblingDataProvider;
 						if (sibdp != null)
 						{
 							var data = sibdp.Data;

--- a/Source/Fuse.Nodes/NodeGroup.uno
+++ b/Source/Fuse.Nodes/NodeGroup.uno
@@ -173,14 +173,6 @@ namespace Fuse
 			if (NodeCount == 0 && _templates.Count == 0)
 				return;
 				
-			//add after the location of `this` in Parent
-			int where = Parent.Children.IndexOf(this);
-			if (where == -1)
-			{
-				Fuse.Diagnostics.InternalError( "Could not locate node in parent, content not added", this );
-				return;
-			}
-
 			int addedNodesCount = NodeCount + (_useTemplates ? _templates.Count : 0);
 			_addedNodes = new Node[addedNodesCount];
 			int addedNodesAt = 0;
@@ -210,7 +202,7 @@ namespace Fuse
 			if (addedNodesAt != addedNodesCount)	
 				throw new Exception( "mismatch in added nodes" );
 				
-			Parent.InsertNodes( where, ((IEnumerable<Node>)_addedNodes).GetEnumerator() );
+			Parent.InsertNodesAfter( this, ((IEnumerable<Node>)_addedNodes).GetEnumerator() );
 		}
 
 		void RemoveContent()

--- a/Source/Fuse.Nodes/RootViewport.uno
+++ b/Source/Fuse.Nodes/RootViewport.uno
@@ -98,11 +98,8 @@ namespace Fuse
 
 		public override void Draw(DrawContext dc)
 		{
-			for (int i = 0; i < Children.Count; i++)
-			{
-				var v = Children[i] as Visual;
+			for (var v = FirstChild<Visual>(); v != null; v = v.NextSibling<Visual>())
 				v.Draw(dc);
-			}
 		}
 
 		void OnGotFocus(object sender, EventArgs args)

--- a/Source/Fuse.Nodes/Visual.BeginRemove.uno
+++ b/Source/Fuse.Nodes/Visual.BeginRemove.uno
@@ -108,9 +108,9 @@ namespace Fuse
 		{
 			SetBit(FastProperty1.PendingRemove, true);
 
-			for (int i = 0; i < Children.Count; i++)
+			for (var n = FirstChild<Node>(); n != null; n = n.NextSibling<Node>())
 			{
-				var rvl = Children[i] as IBeginRemoveVisualListener;
+				var rvl = n as IBeginRemoveVisualListener;
 				if (rvl != null) rvl.OnBeginRemoveVisual(args);
 			}
 		}

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -9,7 +9,7 @@ namespace Fuse
 {
 	public partial class Node
 	{
-		const int OrphanParentID = -1;
+		internal const int OrphanParentID = -1;
 		internal Node _nextSibling;
 		internal Node _previousSibling;
 		internal int _parentID = OrphanParentID;

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -107,13 +107,13 @@ namespace Fuse
 			if (_firstChild == n)
 			{
 				_firstChild = n._nextSibling;
-				_firstChild._previousSibling = null;
+				if (_firstChild != null) _firstChild._previousSibling = null;
 				if (_lastChild == n) _lastChild = null;
 			}
 			else if (_lastChild == n)
 			{
 				_lastChild = n._previousSibling;
-				_lastChild._nextSibling = null;
+				if (_lastChild != null) _lastChild._nextSibling = null;
 			}
 			else
 			{

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -1,0 +1,216 @@
+using Uno;
+using Uno.Collections;
+using Uno.Text;
+using Uno.UX;
+
+using Fuse.Internal;
+
+namespace Fuse
+{
+	public partial class Node
+	{
+		internal Node Children_next;
+		internal Node Children_previous;
+		internal int Children_parentID = -1;
+	}
+
+	public partial class Visual
+	{
+		static int Children_thisIDEnumerator;
+		readonly int Children_thisID = Children_thisIDEnumerator++;
+
+		void Children_MakeParent(Visual parent, Node child)
+		{
+			if (child.Children_parentID != -1) throw new Exception();
+			child.Children_parentID = parent.Children_thisID;
+		}
+
+		void Children_MakeOrphan(Node child)
+		{
+			child.Children_parentID = -1;
+		}
+
+		internal Node Children_first;
+		internal Node Children_last;
+		int Children_count;
+
+		void Children_Add(Node n)
+		{
+			Children_CompleteCurrentAction();
+			Children_InvalidateCache();
+			Children_MakeParent(this, n);
+
+			if (Children_first == null) 
+			{
+				Children_first = n;
+				Children_last = n;
+			}
+			else
+			{
+				Children_last.Children_next = n;
+				n.Children_previous = Children_last;
+				Children_last = n;
+			}
+
+			Children_count++;
+		}
+
+		bool Children_Remove(Node n)
+		{
+			if (n.Children_parentID != Children_thisID) return false;
+
+			Children_CompleteCurrentAction();
+			Children_InvalidateCache();
+			Children_MakeOrphan(n);
+
+			if (Children_first == n)
+			{
+				Children_first = n.Children_next;
+				if (Children_last == n) Children_last = null;
+			}
+			else if (Children_last == n)
+			{
+				Children_last = n.Children_previous;
+			}
+			else
+			{
+				n.Children_previous.Children_next = n.Children_next;
+			}
+			n.Children_next = null;
+			n.Children_previous = null;
+			Children_count--;
+			return true;
+		}
+
+		int Children_IndexOf(Node n)
+		{
+			var k = Children_first;
+			int i = 0;
+			while (k != null)
+			{
+				if (k == n) return i;
+				i++;
+				k = k.Children_next;
+			}
+			return -1;
+		}
+
+		Node Children_ItemAt(int index)
+		{
+			Node k = Children_first;
+			int i = 0;
+			while (k != null)
+			{
+				if (i == index) return k;
+				i++;
+				k = k.Children_next;
+			}
+			throw new IndexOutOfRangeException();
+		}
+
+		// Returns the node appropriate to pass to InsertAt(node, elm)
+		// if the intention is to Insert(index, elm)
+		// This means it returns null if the index == 0, and throws exception
+		// if the index was outside bounds
+		Node Children_ItemBefore(int index)
+		{
+			if (index == 0) return null;
+			else return Children_ItemAt(index-1);
+		}
+
+		void Children_Insert(int index, Node newNode)
+		{
+			var preceeder = Children_ItemBefore(index);
+			Children_InsertAfter(preceeder, newNode);
+		}
+
+		void Children_InsertAfter(Node preceeder, Node newNode)
+		{
+			if (preceeder != null && !Children_Contains(preceeder)) throw new Exception();
+
+			Children_InvalidateCache();
+			Children_CompleteCurrentAction();
+
+			if (preceeder == null)
+			{
+				if (Children_first == null) Children_Add(newNode);
+				else
+				{
+					Children_MakeParent(this, newNode);
+					newNode.Children_next = Children_first;
+					Children_first.Children_previous = newNode;
+					Children_first = newNode;
+					Children_count++;
+				}
+			}
+			else
+			{
+				if (Children_last == preceeder) Children_Add(newNode);
+				else
+				{
+					Children_MakeParent(this, newNode);
+					newNode.Children_previous = preceeder;
+					newNode.Children_next = preceeder.Children_next;
+					preceeder.Children_next.Children_previous = newNode;
+					preceeder.Children_next = newNode;
+					Children_count++;
+				}
+			}
+
+		}
+
+		bool Children_Contains(Node n)
+		{
+			return n.Children_parentID == Children_thisID;
+		}
+
+		Node Children_CurrentNode;
+		Action<Visual, Node> Children_CurrentAction;
+
+		void Children_SafeForEach(Action<Visual, Node> action)
+		{
+			Children_CompleteCurrentAction();
+			Children_CurrentAction = action;
+			Children_CurrentNode = Children_first;
+			Children_CompleteCurrentAction();
+		}
+
+		void Children_CompleteCurrentAction()
+		{
+			while (Children_CurrentNode != null)
+			{
+				Children_CurrentAction(this, Children_CurrentNode);
+				Children_CurrentNode = Children_CurrentNode.Children_next;
+			}
+			Children_CurrentAction = null;
+		}
+
+		Node[] Children_cachedArray;
+		Node[] Children_ToArray()
+		{
+			if (Children_cachedArray != null) return Children_cachedArray;
+
+			var nodes = new Node[Children_count];
+			var c = Children_first;
+			int i = 0;
+			while (c != null)
+			{
+				nodes[i] = c;
+				c = c.Children_next;
+			}
+			Children_cachedArray = nodes;
+			return nodes;
+		}
+
+		void Children_InvalidateCache()
+		{
+			Children_cachedArray = null;
+		}
+
+		IEnumerator<Node> Children_GetEnumerator()
+		{
+			return ((IEnumerable<Node>)Children_ToArray()).GetEnumerator();
+		}
+
+	}
+}

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -78,8 +78,7 @@ namespace Fuse
 
 		void Children_Add(Node n)
 		{
-			Children_CompleteCurrentAction();
-			Children_InvalidateCache();
+			Children_Invalidate();
 			Children_MakeParent(this, n);
 
 			if (_firstChild == null) 
@@ -101,8 +100,7 @@ namespace Fuse
 		{
 			if (n._parentID != _thisID) return false;
 
-			Children_CompleteCurrentAction();
-			Children_InvalidateCache();
+			Children_Invalidate();
 			Children_MakeOrphan(n);
 
 			if (_firstChild == n)
@@ -137,19 +135,6 @@ namespace Fuse
 			return -1;
 		}
 
-		Node Children_ItemAt(int index)
-		{
-			Node k = _firstChild;
-			int i = 0;
-			while (k != null)
-			{
-				if (i == index) return k;
-				i++;
-				k = k._nextSibling;
-			}
-			throw new IndexOutOfRangeException();
-		}
-
 		// Returns the node appropriate to pass to InsertAt(node, elm)
 		// if the intention is to Insert(index, elm)
 		// This means it returns null if the index == 0, and throws exception
@@ -170,8 +155,7 @@ namespace Fuse
 		{
 			if (preceeder != null && !Children_Contains(preceeder)) throw new Exception();
 
-			Children_InvalidateCache();
-			Children_CompleteCurrentAction();
+			Children_Invalidate();
 
 			if (preceeder == null)
 			{
@@ -204,54 +188,6 @@ namespace Fuse
 		bool Children_Contains(Node n)
 		{
 			return n._parentID == _thisID;
-		}
-
-		Node Children_CurrentNode;
-		Action<Visual, Node> Children_CurrentAction;
-
-		void Children_SafeForEach(Action<Visual, Node> action)
-		{
-			Children_CompleteCurrentAction();
-			Children_CurrentAction = action;
-			Children_CurrentNode = _firstChild;
-			Children_CompleteCurrentAction();
-		}
-
-		void Children_CompleteCurrentAction()
-		{
-			while (Children_CurrentNode != null)
-			{
-				Children_CurrentAction(this, Children_CurrentNode);
-				Children_CurrentNode = Children_CurrentNode._nextSibling;
-			}
-			Children_CurrentAction = null;
-		}
-
-		Node[] Children_cachedArray;
-		Node[] Children_ToArray()
-		{
-			if (Children_cachedArray != null) return Children_cachedArray;
-
-			var nodes = new Node[_childCount];
-			var c = _firstChild;
-			int i = 0;
-			while (c != null)
-			{
-				nodes[i] = c;
-				c = c._nextSibling;
-			}
-			Children_cachedArray = nodes;
-			return nodes;
-		}
-
-		void Children_InvalidateCache()
-		{
-			Children_cachedArray = null;
-		}
-
-		IEnumerator<Node> Children_GetEnumerator()
-		{
-			return ((IEnumerable<Node>)Children_ToArray()).GetEnumerator();
 		}
 
 	}

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -9,9 +9,10 @@ namespace Fuse
 {
 	public partial class Node
 	{
+		const int OrphanParentID = -1;
 		internal Node _nextSibling;
 		internal Node _previousSibling;
-		internal int _parentID = -1;
+		internal int _parentID = OrphanParentID;
 
 		/** Returns the next sibling node of the given type. */
 		public T NextSibling<T>() where T: Node
@@ -47,13 +48,13 @@ namespace Fuse
 
 		void Children_MakeParent(Visual parent, Node child)
 		{
-			if (child._parentID != -1) throw new Exception();
+			if (child._parentID != Node.OrphanParentID) throw new Exception();
 			child._parentID = parent._thisID;
 		}
 
 		void Children_MakeOrphan(Node child)
 		{
-			child._parentID = -1;
+			child._parentID = Node.OrphanParentID;
 		}
 
 		Node _firstChild, _lastChild;

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -99,7 +99,7 @@ namespace Fuse
 
 		bool Children_Remove(Node n)
 		{
-			if (n._parentID != _thisID) throw new Exception("Node not a child of this parent");
+			if (n._parentID != _thisID) return false;
 
 			Children_Invalidate();
 			Children_MakeOrphan(n);

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -74,6 +74,7 @@ namespace Fuse
 			
 			_firstChild = null;
 			_lastChild = null;
+			_childCount = 0;
 		}
 
 		void Children_Add(Node n)
@@ -98,7 +99,7 @@ namespace Fuse
 
 		bool Children_Remove(Node n)
 		{
-			if (n._parentID != _thisID) return false;
+			if (n._parentID != _thisID) throw new Exception("Node not a child of this parent");
 
 			Children_Invalidate();
 			Children_MakeOrphan(n);
@@ -106,15 +107,18 @@ namespace Fuse
 			if (_firstChild == n)
 			{
 				_firstChild = n._nextSibling;
+				_firstChild._previousSibling = null;
 				if (_lastChild == n) _lastChild = null;
 			}
 			else if (_lastChild == n)
 			{
 				_lastChild = n._previousSibling;
+				_lastChild._nextSibling = null;
 			}
 			else
 			{
 				n._previousSibling._nextSibling = n._nextSibling;
+				n._nextSibling._previousSibling = n._previousSibling;
 			}
 			n._nextSibling = null;
 			n._previousSibling = null;

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -48,7 +48,7 @@ namespace Fuse
 
 		void Children_MakeParent(Visual parent, Node child)
 		{
-			if (child._parentID != Node.OrphanParentID) throw new Exception();
+			if (child._parentID != Node.OrphanParentID) throw new Exception("Node already has a parent - can only have one");
 			child._parentID = parent._thisID;
 		}
 

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -63,7 +63,7 @@ namespace Fuse
 		// Internal for now, make public when API matures
 		internal int ChildCount { get { return _childCount; } }
 		
-		void Children_clear()
+		void Children_Clear()
 		{
 			for (var c = _firstChild; c != null; c = c._nextSibling)
 			{

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -11,8 +11,13 @@ namespace Fuse
 	{
 		internal const int OrphanParentID = -1;
 		internal Node _nextSibling;
-		internal Node _previousSibling;
+		
 		internal int _parentID = OrphanParentID;
+
+		// Using Fuse.Internal.Pointer<T> to avoid reference loop
+		// use this field with special caution!
+		internal Pointer<Node> _previousSibling;
+
 
 		/** Returns the next sibling node of the given type. */
 		public T NextSibling<T>() where T: Node
@@ -30,12 +35,12 @@ namespace Fuse
 		/** Returns the next sibling node of the given type. */
 		public T PreviousSibling<T>() where T: Node 
 		{ 
-			var n = _previousSibling;
+			var n = (Node)_previousSibling;
 			while (n != null)
 			{
 				var v = n as T;
 				if (v != null) return v;
-				n = n._previousSibling;
+				n = (Node)n._previousSibling;
 			}
 			return null;
 		}
@@ -69,7 +74,7 @@ namespace Fuse
 			{
 				Children_MakeOrphan(c);
 				c._nextSibling = null;
-				c._previousSibling = null;
+				c._previousSibling = (Node)null;
 			}
 			
 			_firstChild = null;
@@ -107,21 +112,21 @@ namespace Fuse
 			if (_firstChild == n)
 			{
 				_firstChild = n._nextSibling;
-				if (_firstChild != null) _firstChild._previousSibling = null;
+				if (_firstChild != null) _firstChild._previousSibling = (Node)null;
 				if (_lastChild == n) _lastChild = null;
 			}
 			else if (_lastChild == n)
 			{
-				_lastChild = n._previousSibling;
+				_lastChild = (Node)n._previousSibling;
 				if (_lastChild != null) _lastChild._nextSibling = null;
 			}
 			else
 			{
-				n._previousSibling._nextSibling = n._nextSibling;
-				n._nextSibling._previousSibling = n._previousSibling;
+				((Node)n._previousSibling)._nextSibling = n._nextSibling;
+				n._nextSibling._previousSibling = (Node)n._previousSibling;
 			}
 			n._nextSibling = null;
-			n._previousSibling = null;
+			n._previousSibling = (Node)null;
 			_childCount--;
 			return true;
 		}

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -63,6 +63,18 @@ namespace Fuse
 		// Internal for now, make public when API matures
 		internal int ChildCount { get { return _childCount; } }
 		
+		void Children_clear()
+		{
+			for (var c = _firstChild; c != null; c = c._nextSibling)
+			{
+				Children_MakeOrphan(c);
+				c._nextSibling = null;
+				c._previousSibling = null;
+			}
+			
+			_firstChild = null;
+			_lastChild = null;
+		}
 
 		void Children_Add(Node n)
 		{

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -16,7 +16,7 @@ namespace Fuse
 
 		// Using Fuse.Internal.Pointer<T> to avoid reference loop
 		// use this field with special caution!
-		internal Pointer<Node> _previousSibling;
+		internal Fuse.Internal.Pointer<Node> _previousSibling;
 
 
 		/** Returns the next sibling node of the given type. */

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -14,9 +14,9 @@ namespace Fuse
 		
 		internal int _parentID = OrphanParentID;
 
-		// Using Fuse.Internal.Pointer<T> to avoid reference loop
+		// Using Fuse.Internal.RawPointer<T> to avoid reference loop
 		// use this field with special caution!
-		internal Fuse.Internal.Pointer<Node> _previousSibling;
+		internal RawPointer<Node> _previousSibling;
 
 
 		/** Returns the next sibling node of the given type. */

--- a/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
+++ b/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
@@ -23,7 +23,7 @@ namespace Fuse
 			int i = 0;
 			while (c != null)
 			{
-				nodes[i] = c;
+				nodes[i++] = c;
 				c = c._nextSibling;
 			}
 			Children_cachedArray = nodes;
@@ -66,8 +66,16 @@ namespace Fuse
 			{
 				get
 				{
-					if (_array != null) return _array[_pos];
-					else return _current;
+					if (_array != null) 
+					{
+						if (_array[_pos] == null) throw new Exception();
+						return _array[_pos];
+					}
+					else 
+					{
+						if (_current == null) throw new Exception();
+						return _current;
+					}
 				}
 			}
 

--- a/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
+++ b/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
@@ -60,6 +60,7 @@ namespace Fuse
 			internal SafeIterator(Visual v)
 			{
 				_v = v;
+				AddToIteratorList();
 			}
 
 			public Node Current
@@ -83,17 +84,9 @@ namespace Fuse
 			{
 				if (_pos == -1)
 				{
-					AddToIteratorList();
 					_array = _v.Children_cachedArray; // If we have a cached array, go ahead and use that
 				}
 
-				var res = MoveNextInternal();
-				if (!res) RemoveFromIteratorList();
-				return res;
-			}
-
-			bool MoveNextInternal()
-			{
 				_pos++;
 
 				if (_array != null)
@@ -108,6 +101,7 @@ namespace Fuse
 			public void Dispose()
 			{
 				Reset();
+				RemoveFromIteratorList();
 				_v = null;
 			}
 
@@ -116,7 +110,6 @@ namespace Fuse
 				_pos = -1;
 				_current = null;
 				_array = null;
-				RemoveFromIteratorList();
 			}
 
 			void AddToIteratorList()
@@ -130,7 +123,6 @@ namespace Fuse
 				if (_v._safeIterator == this)
 				{
 					_v._safeIterator = _nextIterator;
-					_v._safeIterator = null;
 				}
 				else
 				{
@@ -145,24 +137,21 @@ namespace Fuse
 
 			internal void SecureCopy()
 			{
-				if (_pos != -1 && _array == null)
-					CopyRemainingNodes();
-			}
-
-			void CopyRemainingNodes()
-			{
-				_array = new Node[_v._childCount-_pos];
-				int i = 0;
-				while (_current != null)
+				if (_array == null)
 				{
-					_array[i++] = _current;
-					_current = _current._nextSibling;
-				}
-				// the copied array is just a subset, so reset index
-				_pos = 0; 
+					_array = new Node[_v._childCount-_pos];
+					int i = 0;
+					while (_current != null)
+					{
+						_array[i++] = _current;
+						_current = _current._nextSibling;
+					}
+					// the copied array is just a subset, so reset index
+					if (_pos != -1 && _array.Length > 0) _pos = 0; 
 
-				// tempting, but not correct. when _pos != -1, it uses _array[_pos]
-				// _current = _array[0]; 
+					// tempting, but not correct. when _pos != -1, it uses _array[_pos]
+					// _current = _array[0]; 
+				}
 			}
 		}
 	}

--- a/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
+++ b/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
@@ -1,0 +1,158 @@
+using Uno;
+using Uno.Collections;
+using Uno.Text;
+using Uno.UX;
+
+using Fuse.Internal;
+
+namespace Fuse
+{
+	public partial class Visual
+	{
+		// Performance critical code paths should not need to create this array.
+		// This is here to optimize the corner cases where we need indexed lookup.
+		// The SafeIterator also takes advantage of this if available at the time
+		// it needs a copy
+		Node[] Children_cachedArray;
+		Node[] Children_GetCachedArray()
+		{
+			if (Children_cachedArray != null) return Children_cachedArray;
+
+			var nodes = new Node[_childCount];
+			var c = _firstChild;
+			int i = 0;
+			while (c != null)
+			{
+				nodes[i] = c;
+				c = c._nextSibling;
+			}
+			Children_cachedArray = nodes;
+			return nodes;
+		}
+
+		Node Children_ItemAt(int index)
+		{
+			var arr = Children_GetCachedArray();
+			return arr[index];
+		}
+
+		void Children_Invalidate()
+		{
+			if (_safeIterator != null) _safeIterator.SecureCopy();
+			Children_cachedArray = null;
+		}
+
+		IEnumerator<Node> Children_GetEnumerator()
+		{
+			return new SafeIterator(this);
+		}
+
+		SafeIterator _safeIterator; // Linked list
+
+		class SafeIterator: IEnumerator<Node>
+		{
+			Node[] _array;
+			int _pos = -1;
+			Node _current;
+			SafeIterator _nextIterator;
+			Visual _v;
+
+			internal SafeIterator(Visual v)
+			{
+				_v = v;
+			}
+
+			public Node Current
+			{
+				get
+				{
+					if (_array != null) return _array[_pos];
+					else return _current;
+				}
+			}
+
+			public bool MoveNext()
+			{
+				if (_pos == -1)
+				{
+					AddToIteratorList();
+					_array = _v.Children_cachedArray; // If we have a cached array, go ahead and use that
+				}
+
+				var res = MoveNextInternal();
+				if (!res) RemoveFromIteratorList();
+				return res;
+			}
+
+			bool MoveNextInternal()
+			{
+				_pos++;
+
+				if (_array != null)
+					return _pos < _array.Length;
+				
+				if (_current == null) _current = _v._firstChild;
+				else _current = _current._nextSibling;
+
+				return _current != null;
+			}
+
+			public void Dispose()
+			{
+				Reset();
+				_v = null;
+			}
+
+			public void Reset()
+			{
+				_pos = -1;
+				_current = null;
+				_array = null;
+				RemoveFromIteratorList();
+			}
+
+			void AddToIteratorList()
+			{
+				_nextIterator = _v._safeIterator;
+				_v._safeIterator = this;
+			}
+
+			void RemoveFromIteratorList()
+			{
+				if (_v._safeIterator == this)
+				{
+					_v._safeIterator = _nextIterator;
+					_v._safeIterator = null;
+				}
+				else
+				{
+					for (var si = _v._safeIterator; si != null; si = si._nextIterator)
+						if (si._nextIterator == this)
+						{
+							si._nextIterator = this._nextIterator;
+							return;
+						}
+				}
+			}
+
+			internal void SecureCopy()
+			{
+				if (_pos != -1 && _array == null)
+					CopyRemainingNodes();
+			}
+
+			void CopyRemainingNodes()
+			{
+				_array = new Node[_v._childCount-_pos];
+				int i = 0;
+				while (_current != null)
+				{
+					_array[i++] = _current;
+					_current = _current._nextSibling;
+				}
+				// the copied array is just a subset, so reset index
+				_pos = 0; 
+			}
+		}
+	}
+}

--- a/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
+++ b/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
@@ -135,23 +135,36 @@ namespace Fuse
 				}
 			}
 
+			bool MultipleIterators { get { return _v._safeIterator._nextIterator != null; } }
+
 			internal void SecureCopy()
 			{
 				if (_array == null)
 				{
-					_array = new Node[_v._childCount-_pos];
-					int i = 0;
-					while (_current != null)
+					if (MultipleIterators)
 					{
-						_array[i++] = _current;
-						_current = _current._nextSibling;
+						// If early there are multiple iterators, get reuse of the array
+						_array = _v.Children_GetCachedArray();
 					}
-					// the copied array is just a subset, so reset index
-					if (_pos != -1 && _array.Length > 0) _pos = 0; 
+					else
+					{
+						// Otherwise, just copy the remaining items
+						_array = new Node[_v._childCount-_pos];
+						int i = 0;
+						while (_current != null)
+						{
+							_array[i++] = _current;
+							_current = _current._nextSibling;
+						}
+						// the copied array is just a subset, so reset index
+						if (_pos != -1 && _array.Length > 0) _pos = 0; 
 
-					// tempting, but not correct. when _pos != -1, it uses _array[_pos]
-					// _current = _array[0]; 
+						// tempting, but not correct. when _pos != -1, it uses _array[_pos]
+						// _current = _array[0]; 
+					}
 				}
+
+				if (_nextIterator != null) _nextIterator.SecureCopy();
 			}
 		}
 	}

--- a/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
+++ b/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
@@ -80,8 +80,11 @@ namespace Fuse
 				}
 			}
 
+			bool _reachedEnd;
 			public bool MoveNext()
 			{
+				if (_reachedEnd) return false;
+
 				if (_pos == -1)
 				{
 					_array = _v.Children_cachedArray; // If we have a cached array, go ahead and use that
@@ -95,7 +98,9 @@ namespace Fuse
 				if (_current == null) _current = _v._firstChild;
 				else _current = _current._nextSibling;
 
-				return _current != null;
+				_reachedEnd = (_current == null);
+
+				return !_reachedEnd;
 			}
 
 			public void Dispose()
@@ -110,6 +115,7 @@ namespace Fuse
 				_pos = -1;
 				_current = null;
 				_array = null;
+				_reachedEnd = false;
 			}
 
 			void AddToIteratorList()
@@ -141,9 +147,9 @@ namespace Fuse
 			{
 				if (_array == null)
 				{
-					if (MultipleIterators)
+					if (_v.Children_cachedArray != null || MultipleIterators)
 					{
-						// If early there are multiple iterators, get reuse of the array
+						// If early there are multiple iterators or existing array, get reuse of the array
 						_array = _v.Children_GetCachedArray();
 					}
 					else
@@ -165,6 +171,9 @@ namespace Fuse
 				}
 
 				if (_nextIterator != null) _nextIterator.SecureCopy();
+
+				// We got our copy now, kthxbye
+				RemoveFromIteratorList();
 			}
 		}
 	}

--- a/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
+++ b/Source/Fuse.Nodes/Visual.Children.SafeIterator.uno
@@ -152,6 +152,9 @@ namespace Fuse
 				}
 				// the copied array is just a subset, so reset index
 				_pos = 0; 
+
+				// tempting, but not correct. when _pos != -1, it uses _array[_pos]
+				// _current = _array[0]; 
 			}
 		}
 	}

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -245,16 +245,16 @@ namespace Fuse
 		*/
 		internal void InsertNodesAfter(Node preceeder, IEnumerator<Node> items)
 		{
-			InsertNodesImpl(preceeder, items, false);
+			InsertNodesAfterImpl(preceeder, items, false);
 		}
 
-		internal void InsertOrMoveNodes(Node preceeder, IEnumerator<Node> items)
+		internal void InsertOrMoveNodesAfter(Node preceeder, IEnumerator<Node> items)
 		{
-			InsertNodesImpl(preceeder, items, true);
+			InsertNodesAfterImpl(preceeder, items, true);
 		}
 		
 		
-		void InsertNodesImpl(Node preceeder, IEnumerator<Node> items, bool allowMove)
+		void InsertNodesAfterImpl(Node preceeder, IEnumerator<Node> items, bool allowMove)
 		{
 			//cleanup all nodes first
 			while (items.MoveNext())

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -212,9 +212,17 @@ namespace Fuse
 			return false;
 		}
 
+		/** Inserts a child node after the given sibling node.
+			
+			For performance reasons, this entrypoint is recommended over using `InsertAt`.
+
+			To insert at the beginning of the list, use `null` as the first argument.
+		*/
 		public void InsertAfter(Node sibling, Node node)
 		{
+			InsertCleanup(node);
 			Children_InsertAfter(sibling, node);
+			OnAdded(node);
 		}
 
 		bool ICollection<Node>.Contains(Node item)

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -18,7 +18,7 @@ namespace Fuse
 	*/
 	public partial class Visual
 	{
-		public bool HasChildren { get { return Children_count > 0; } }
+		public bool HasChildren { get { return ChildCount > 0; } }
 
 		protected override void SubtreeToString(StringBuilder sb, int indent)
 		{
@@ -27,26 +27,50 @@ namespace Fuse
 				Children[i].SubtreeToString(sb, indent+1);
 		}
 
+		/** Returns the first child node of the given type. 
+			
+			To get the very first child node (of any type), use `FirstChild<Node>()`.
+		*/
 		public T FirstChild<T>() where T: Node
 		{
-			var c = Children_first;
+			var c = _firstChild;
 			while (c != null)
 			{
 				var v = c as T;
 				if (v != null) return v;
-				c = c.Children_next;
+				c = c._nextSibling;
 			}
 			return null;
 		}
 
-		public void RemoveAllChildren<T>() where T: Node
+		/** Returns the last child node of the given type. 
+
+			To get the very last child node (of any type), use `LastChild<Node>()`.
+		*/
+		public T LastChild<T>() where T: Node
 		{
-			var c = Children_first;
+			var c = _lastChild;
 			while (c != null)
 			{
 				var v = c as T;
+				if (v != null) return v;
+				c = c._previousSibling; 
+			}
+			return null;
+		}
+
+		/** Removes all children of the given type. 
+			
+			To remove all children (of all types), use `RemoveAllChildren<Node>()`.
+		*/
+		public void RemoveAllChildren<T>() where T: Node
+		{
+			var c = _firstChild;
+			while (c != null)
+			{
+				var v = c as T;
+				c = c._nextSibling; // important to do this before calling Remove!
 				if (v != null) Children_Remove(v);
-				c = c.Children_next;
 			}
 		}
 
@@ -198,7 +222,7 @@ namespace Fuse
 			return Children_IndexOf(item);
 		}
 
-		int ICollection<Node>.Count { get { return Children_count; } }
+		int ICollection<Node>.Count { get { return ChildCount; } }
 
 		public void Insert(int index, Node item)
 		{

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -212,6 +212,11 @@ namespace Fuse
 			return false;
 		}
 
+		public void InsertAfter(Node sibling, Node node)
+		{
+			Children_InsertAfter(sibling, node);
+		}
+
 		bool ICollection<Node>.Contains(Node item)
 		{
 			return Children_Contains(item);

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -191,7 +191,7 @@ namespace Fuse
 		{
 			for (var c = _firstChild; c != null; c = c._nextSibling)
 				OnRemoved(c);
-			Children_clear();
+			Children_Clear();
 		}
 
 		public void Add(Node item)

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -54,7 +54,7 @@ namespace Fuse
 			{
 				var v = c as T;
 				if (v != null) return v;
-				c = c._previousSibling; 
+				c = (Node)c._previousSibling;
 			}
 			return null;
 		}
@@ -65,13 +65,9 @@ namespace Fuse
 		*/
 		public void RemoveAllChildren<T>() where T: Node
 		{
-			var c = _firstChild;
-			while (c != null)
-			{
-				var v = c as T;
-				c = c._nextSibling; // important to do this before calling Remove!
-				if (v != null) Children_Remove(v);
-			}
+			// Has to use use safe iterator, ref discussion on https://github.com/fusetools/fuselibs-public/pull/260
+			foreach (var c in Children) 
+				if (c is T) Children_Remove(c);
 		}
 
 		[UXPrimary]
@@ -266,6 +262,9 @@ namespace Fuse
 		
 		void InsertNodesAfterImpl(Node preceeder, IEnumerator<Node> items, bool allowMove)
 		{
+			if (Children_Contains(preceeder)) 
+				throw new Exception("Cannot insert nodes after a node that is not a child of this parent");
+
 			//cleanup all nodes first
 			while (items.MoveNext())
 				InsertCleanup( items.Current );

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -23,8 +23,8 @@ namespace Fuse
 		protected override void SubtreeToString(StringBuilder sb, int indent)
 		{
 			base.SubtreeToString(sb, indent);
-			for (int i = 0; i < Children.Count; i++)
-				Children[i].SubtreeToString(sb, indent+1);
+			for (var c = FirstChild<Node>(); c != null; c = c.NextSibling<Node>())
+				c.SubtreeToString(sb, indent+1);
 		}
 
 		/** Returns the first child node of the given type. 
@@ -90,9 +90,8 @@ namespace Fuse
 		{
 			if (_observerCount != 0 && IsRootingStarted)
 			{
-				for (int i = 0; i < Children.Count; i++)
+				for (var n = FirstChild<Node>(); n != null; n = n.NextSibling<Node>())
 				{
-					var n = Children[i];
 					var obs = n as IParentObserver;
 					if (obs != null && n.IsRootingCompleted)
 						obs.OnChildAddedWhileRooted(elm);
@@ -106,9 +105,8 @@ namespace Fuse
 		{
 			if (_observerCount != 0 && IsRootingStarted)
 			{
-				for (int i = 0; i < Children.Count; i++)
+				for (var n = FirstChild<Node>(); n != null; n = n.NextSibling<Node>())
 				{
-					var n = Children[i];
 					var obs = n as IParentObserver;
 					if (obs != null && n.IsRootingCompleted) 
 						obs.OnChildRemovedWhileRooted(elm);
@@ -122,9 +120,8 @@ namespace Fuse
 		{
 			if (_observerCount != 0 && IsRootingStarted)
 			{
-				for (int i = 0; i < Children.Count; i++)
+				for (var n = FirstChild<Node>(); n != null; n = n.NextSibling<Node>())
 				{
-					var n = Children[i];
 					var obs = n as IParentObserver;
 					if (obs != null && n.IsRootingCompleted) 
 						obs.OnChildMovedWhileRooted(elm);

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -262,7 +262,7 @@ namespace Fuse
 		
 		void InsertNodesAfterImpl(Node preceeder, IEnumerator<Node> items, bool allowMove)
 		{
-			if (Children_Contains(preceeder)) 
+			if (!Children_Contains(preceeder)) 
 				throw new Exception("Cannot insert nodes after a node that is not a child of this parent");
 
 			//cleanup all nodes first

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -189,9 +189,9 @@ namespace Fuse
 
 		void ICollection<Node>.Clear()
 		{
-			foreach (var child in Children)
-				OnRemoved(child);
-			Children.Clear();
+			for (var c = _firstChild; c != null; c = c._nextSibling)
+				OnRemoved(c);
+			Children_clear();
 		}
 
 		public void Add(Node item)

--- a/Source/Fuse.Nodes/Visual.IsFlat.uno
+++ b/Source/Fuse.Nodes/Visual.IsFlat.uno
@@ -46,9 +46,9 @@ namespace Fuse
 		
 		internal virtual bool CalcIsLocalFlat()
 		{
-			for (int i = 0; i < Children.Count; i++)
+			for (var c = Children_first; c != null; c = c.Children_next)
 			{
-				var t = Children[i] as Transform;
+				var t = c as Transform;
 				if (t != null && !t.IsFlat) return false;
 			}
 			return true;

--- a/Source/Fuse.Nodes/Visual.IsFlat.uno
+++ b/Source/Fuse.Nodes/Visual.IsFlat.uno
@@ -46,11 +46,9 @@ namespace Fuse
 		
 		internal virtual bool CalcIsLocalFlat()
 		{
-			for (var c = Children_first; c != null; c = c.Children_next)
-			{
-				var t = c as Transform;
-				if (t != null && !t.IsFlat) return false;
-			}
+			for (var t = FirstChild<Transform>(); t != null; t = t.NextSibling<Transform>())
+				if (!t.IsFlat) return false;
+
 			return true;
 		}
 		

--- a/Source/Fuse.Nodes/Visual.Layout.uno
+++ b/Source/Fuse.Nodes/Visual.Layout.uno
@@ -385,11 +385,8 @@ namespace Fuse
 					break;
 					
 				case InvalidateLayoutReason.ChildChanged:
-					for (int i = 0; i < Children.Count; i++)
-					{
-						var v = Children[i] as Visual;
-						if (v != null) v.UpdateLayout();
-					}
+					for (var v = FirstChild<Visual>(); v != null; v = v.NextSibling<Visual>())
+						v.UpdateLayout();
 					break;
 					
 				case InvalidateLayoutReason.MarginBoxChanged:

--- a/Source/Fuse.Nodes/Visual.Layout.uno
+++ b/Source/Fuse.Nodes/Visual.Layout.uno
@@ -329,10 +329,13 @@ namespace Fuse
 			if (newValue != SnapToPixels)
 			{
 				SetBit(FastProperty1.ContextSnapToPixelsCache, newValue);
-				for (int i = 0; i < Children.Count; i++)
+
+				var c = Children_first;
+				while (c != null)
 				{
-					var v = Children[i] as Visual;
+					var v = c as Visual;
 					if (v != null) v.UpdateContextSnapToPixelsCache();
+					c = c.Children_next;
 				}	
 			}
 		}

--- a/Source/Fuse.Nodes/Visual.Layout.uno
+++ b/Source/Fuse.Nodes/Visual.Layout.uno
@@ -330,13 +330,8 @@ namespace Fuse
 			{
 				SetBit(FastProperty1.ContextSnapToPixelsCache, newValue);
 
-				var c = Children_first;
-				while (c != null)
-				{
-					var v = c as Visual;
-					if (v != null) v.UpdateContextSnapToPixelsCache();
-					c = c.Children_next;
-				}	
+				for (var v = FirstChild<Visual>(); v != null; v = v.NextSibling<Visual>())
+					v.UpdateContextSnapToPixelsCache();
 			}
 		}
 	

--- a/Source/Fuse.Nodes/Visual.Transform.uno
+++ b/Source/Fuse.Nodes/Visual.Transform.uno
@@ -242,9 +242,9 @@ namespace Fuse
 			if (HasExplicitTransforms)
 			{
 				PrependTransformOrigin(m);
-				for (int i = 0; i < Children.Count; i++)
+				for (var c = Children_first; c != null; c = c.Children_next)
 				{
-					var t = Children[i] as Transform;
+					var t = c as Transform;
 					if (t != null) 	t.PrependTo(m);
 				}
 				PrependInverseTransformOrigin(m);

--- a/Source/Fuse.Nodes/Visual.Transform.uno
+++ b/Source/Fuse.Nodes/Visual.Transform.uno
@@ -242,11 +242,10 @@ namespace Fuse
 			if (HasExplicitTransforms)
 			{
 				PrependTransformOrigin(m);
-				for (var c = Children_first; c != null; c = c.Children_next)
-				{
-					var t = c as Transform;
-					if (t != null) 	t.PrependTo(m);
-				}
+				
+				for (var t = FirstChild<Transform>(); t != null; t = t.NextSibling<Transform>())
+					t.PrependTo(m);
+					
 				PrependInverseTransformOrigin(m);
 			}
 		}

--- a/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
+++ b/Source/Fuse.Nodes/Visual.WorldTransformInvalidated.uno
@@ -43,11 +43,8 @@ namespace Fuse
 
 			if (_wtiListeners > 0) 
 			{
-				for (var i = 0; i < Children.Count; i++)
-				{
-					var v = Children[i] as Visual;
-					if (v != null) v.InvalidateWorldTransform();
-				}
+				for (var v = FirstChild<Visual>(); v != null; v = v.NextSibling<Visual>())
+					v.InvalidateWorldTransform();
 			}
 		}
 

--- a/Source/Fuse.Nodes/Visual.ZOrder.uno
+++ b/Source/Fuse.Nodes/Visual.ZOrder.uno
@@ -21,8 +21,9 @@ namespace Fuse
 
 		/** Returns the visual child with the given index. 
 		
-			For performance reasons, avoid using this function. Can be used for testing. 
+			For performance reasons, avoid using this function. 
 		*/
+		[Obsolete("Deprecated for performance reasons. Iterate over collection manually instead.")]
 		public Visual GetVisualChild(int index)
 		{
 			var c = _firstChild;

--- a/Source/Fuse.Nodes/Visual.ZOrder.uno
+++ b/Source/Fuse.Nodes/Visual.ZOrder.uno
@@ -10,50 +10,42 @@ namespace Fuse
 
 		public bool HasVisualChildren { get { return _zOrder != null && _zOrder.Count > 0; } }
 
+		[Obsolete("Use FirstChild<Visual>() instead")]
 		public Visual FirstVisualChild
 		{ 
 			get
 			{
-				var c = Children_first;
-				while (c != null)
-				{
-					var v = c as Visual;
-					if (v != null) return v;
-					c = c.Children_next;
-				}
-				return null;
+				return FirstChild<Visual>();
 			}
 		}
 
+		/** Returns the visual child with the given index. 
+		
+			For performance reasons, avoid using this function. Can be used for testing. 
+		*/
 		public Visual GetVisualChild(int index)
 		{
-			if (!HasVisualChildren) return null;
-
-			int x = 0;
-			for (int i = 0; i < Children.Count; i++)
+			var c = _firstChild;
+			int i = 0;
+			while (c != null)
 			{
-				var c = Children[i] as Visual;
-				if (c != null) 
+				var v = c as Visual;
+				if (v != null)
 				{
-					if (x == index) return c;
-					x++;
+					if (i == index) return v;
+					i++;
 				}
+				c = c._nextSibling;
 			}
 			return null;
 		}
 
+		[Obsolete("Use LastChild<Visual>() instead")]
 		public Visual LastVisualChild
 		{ 
 			get
 			{
-				if (!HasVisualChildren) return null;
-
-				for (int i = Children.Count; i --> 0;)
-				{
-					var c = Children[i] as Visual;
-					if (c != null) return c;
-				}
-				return null;
+				return LastChild<Visual>();
 			}
 		}
 
@@ -147,18 +139,12 @@ namespace Fuse
 				0  // Layer.Overlay
 			};
 
-			var c = Children_first;
-			while (c != null)
+			for (var visual = FirstChild<Visual>(); visual != null; visual = visual.NextSibling<Visual>())
 			{
-				var visual = c as Visual;
-				if (visual != null)
-				{
-					int z = (int)visual.Layer;
-					visual.ZLayer = z;
-					if (!visual.ZOffsetFixed)
-						visual.ZOffsetNatural = current[z]--;
-				}
-				c = c.Children_next;
+				int z = (int)visual.Layer;
+				visual.ZLayer = z;
+				if (!visual.ZOffsetFixed)
+					visual.ZOffsetNatural = current[z]--;
 			}
 		}
 		

--- a/Source/Fuse.Nodes/Visual.ZOrder.uno
+++ b/Source/Fuse.Nodes/Visual.ZOrder.uno
@@ -14,9 +14,14 @@ namespace Fuse
 		{ 
 			get
 			{
-				if (!HasVisualChildren) return null;
-
-				return FirstChild<Visual>();
+				var c = Children_first;
+				while (c != null)
+				{
+					var v = c as Visual;
+					if (v != null) return v;
+					c = c.Children_next;
+				}
+				return null;
 			}
 		}
 
@@ -132,7 +137,7 @@ namespace Fuse
 			return a.ZOffsetNatural - b.ZOffsetNatural;
 		}
 
-		static void AssignZOrder( IList<Node> nodes )
+		void AssignZOrder( )
 		{
 			var current = new int[]
 			{
@@ -142,15 +147,18 @@ namespace Fuse
 				0  // Layer.Overlay
 			};
 
-			for (int i = 0; i < nodes.Count; i++)
+			var c = Children_first;
+			while (c != null)
 			{
-				var visual = nodes[i] as Visual;
-				if (visual == null) continue;
-				
-				int c = (int)visual.Layer;
-				visual.ZLayer = c;
-				if (!visual.ZOffsetFixed)
-					visual.ZOffsetNatural = current[c]--;
+				var visual = c as Visual;
+				if (visual != null)
+				{
+					int z = (int)visual.Layer;
+					visual.ZLayer = z;
+					if (!visual.ZOffsetFixed)
+						visual.ZOffsetNatural = current[z]--;
+				}
+				c = c.Children_next;
 			}
 		}
 		
@@ -179,7 +187,7 @@ namespace Fuse
 		{
 			if (!_nodeZOrders)
 			{
-				AssignZOrder(Children);
+				AssignZOrder();
 				_nodeZOrders = true;
 			}
 		}

--- a/Source/Fuse.Nodes/Visual.uno
+++ b/Source/Fuse.Nodes/Visual.uno
@@ -102,11 +102,7 @@ namespace Fuse
 			{
 				// iterate over a copy of the list to prevent problems when
 				// behaviors add/remove childen during rooting
-				using (var iter = _children.GetEnumeratorVersionedStruct())
-				{
-					while (iter.MoveNext())
-						iter.Current.RootInternal(this);
-				}
+				Children_SafeForEach(_rootChild);
 			}
 
 			//this forces an invalidation now that we're rooted (ensures no old stale value is there)
@@ -117,6 +113,12 @@ namespace Fuse
 
 			_viewport = FindViewport();
 			RootResources();
+		}
+
+		static Action<Visual, Node> _rootChild = RootChild;
+		static void RootChild(Visual parent, Node child)
+		{
+			child.RootInternal(parent);
 		}
 
 		internal protected virtual void OnRootedPreChildren() { }
@@ -139,16 +141,18 @@ namespace Fuse
 			{
 				// iterate over a copy of the list to prevent problems when
 				// behaviors add/remove childen during rooting
-				using (var iter = _children.GetEnumeratorVersionedStruct())
-				{
-					while (iter.MoveNext())
-						iter.Current.UnrootInternal();
-				}
+				Children_SafeForEach(_unrootChild);
 			}
 
 			WTIUnrooted();
 
 			ConcludePendingRemove();
+		}
+
+		static Action<Visual, Node> _unrootChild = UnrootChild;
+		static void UnrootChild(Visual parent, Node child)
+		{
+			child.UnrootInternal();
 		}
 
 		public override void VisitSubtree(Action<Node> action)

--- a/Source/Fuse.Nodes/Visual.uno
+++ b/Source/Fuse.Nodes/Visual.uno
@@ -146,8 +146,8 @@ namespace Fuse
 		public override void VisitSubtree(Action<Node> action)
 		{
 			action(this);
-			for (int i = 0; i < Children.Count; i++) 
-				Children[i].VisitSubtree(action);
+			for (var n = FirstChild<Node>(); n != null; n = n.NextSibling<Node>())
+				n.VisitSubtree(action);
 		}
 
 		/**

--- a/Source/Fuse.Nodes/Visual.uno
+++ b/Source/Fuse.Nodes/Visual.uno
@@ -100,9 +100,9 @@ namespace Fuse
 
 			if (HasChildren)
 			{
-				// iterate over a copy of the list to prevent problems when
-				// behaviors add/remove childen during rooting
-				Children_SafeForEach(_rootChild);
+				// Use the IEnumerable<Node> implementation here, as this correctly deals
+				// with the list being manipulated during rooting/unrooting
+				foreach (var c in Children) c.RootInternal(this);
 			}
 
 			//this forces an invalidation now that we're rooted (ensures no old stale value is there)
@@ -113,12 +113,6 @@ namespace Fuse
 
 			_viewport = FindViewport();
 			RootResources();
-		}
-
-		static Action<Visual, Node> _rootChild = RootChild;
-		static void RootChild(Visual parent, Node child)
-		{
-			child.RootInternal(parent);
 		}
 
 		internal protected virtual void OnRootedPreChildren() { }
@@ -139,20 +133,14 @@ namespace Fuse
 
 			if (HasChildren)
 			{
-				// iterate over a copy of the list to prevent problems when
-				// behaviors add/remove childen during rooting
-				Children_SafeForEach(_unrootChild);
+				// Use the IEnumerable<Node> implementation here, as this correctly deals
+				// with the list being manipulated during rooting/unrooting
+				foreach (var c in Children) c.UnrootInternal();
 			}
 
 			WTIUnrooted();
 
 			ConcludePendingRemove();
-		}
-
-		static Action<Visual, Node> _unrootChild = UnrootChild;
-		static void UnrootChild(Visual parent, Node child)
-		{
-			child.UnrootInternal();
 		}
 
 		public override void VisitSubtree(Action<Node> action)

--- a/Source/Fuse.Physics/Draggable.uno
+++ b/Source/Fuse.Physics/Draggable.uno
@@ -134,20 +134,14 @@ namespace Fuse.Physics
 	{
 		internal static void Begin(Visual n)
 		{
-			for (int i = 0; i < n.Children.Count; i++)
-			{
-				var wd = n.Children[i] as WhileDragging;
-				if (wd != null) wd.Activate();
-			}
+			for (var v = n.FirstChild<WhileDragging>(); v != null; v = v.NextSibling<WhileDragging>())
+				v.Activate();
 		}
 
 		internal static void End(Visual n)
 		{
-			for (int i = 0; i < n.Children.Count; i++)
-			{
-				var wd = n.Children[i] as WhileDragging;
-				if (wd != null) wd.Deactivate();
-			}
+			for (var v = n.FirstChild<WhileDragging>(); v != null; v = v.NextSibling<WhileDragging>())
+				v.Deactivate();
 		}
 	}
 }

--- a/Source/Fuse.Physics/ForceFieldTriggers.uno
+++ b/Source/Fuse.Physics/ForceFieldTriggers.uno
@@ -9,15 +9,10 @@ namespace Fuse.Physics
 
 		internal static void SetForce(ForceField field, Body body, float force)
 		{
-			for (int i = 0; i < body.Visual.Children.Count; i++)
+			for (var fft = body.Visual.FirstChild<ForceFieldTrigger>(); fft != null; fft = fft.NextSibling<ForceFieldTrigger>())
 			{
-				var b = body.Visual.Children[i];
-				var fft = b as ForceFieldTrigger;
-
-				if (fft != null && fft.ForceField == field)
-				{
+				if (fft.ForceField == field)
 					fft.SetForce(body, force);
-				}
 			}
 		}
 

--- a/Source/Fuse.Reactive.Bindings/Instance.WindowItems.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.WindowItems.uno
@@ -175,7 +175,7 @@ namespace Fuse.Reactive
 			//find last node prior to where we want to introduce
 			var lastNode = GetLastNodeFromIndex(windowIndex-1);
 
-			Parent.InsertOrMoveNodes( lastNode, wi.Nodes.GetEnumerator() );
+			Parent.InsertOrMoveNodesAfter( lastNode, wi.Nodes.GetEnumerator() );
 		}
 		
 		/**

--- a/Source/Fuse.Reactive.Bindings/Instance.WindowItems.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.WindowItems.uno
@@ -175,7 +175,7 @@ namespace Fuse.Reactive
 			//find last node prior to where we want to introduce
 			var lastNode = GetLastNodeFromIndex(windowIndex-1);
 
-			Parent.InsertOrMoveNodes( Parent.Children.IndexOf(lastNode) + 1, wi.Nodes.GetEnumerator() );
+			Parent.InsertOrMoveNodes( lastNode, wi.Nodes.GetEnumerator() );
 		}
 		
 		/**

--- a/Source/Fuse.Reactive.Bindings/MatchCase.uno
+++ b/Source/Fuse.Reactive.Bindings/MatchCase.uno
@@ -240,9 +240,6 @@ namespace Fuse.Reactive
 		{
 			if (c != null)
 			{
-				//if IndexOf returns -1, for some odd reason, then we'll insert at 0
-				int childIndex = Parent.Children.IndexOf(this) + 1;
-				
 				foreach (var f in c.Factories)
 				{
 					var elm = f.New() as Node;
@@ -254,7 +251,7 @@ namespace Fuse.Reactive
 
 				}
 				
-				Parent.InsertNodes(childIndex, _elements.GetEnumerator());
+				Parent.InsertNodesAfter(this, _elements.GetEnumerator());
 			}
 			_oldCase = c;
 		}

--- a/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
@@ -8,6 +8,24 @@ using FuseTest;
 
 namespace Fuse.Reactive.Test
 {
+	// This is here because a test depends on an obsolete entrypoint
+	// Visual.GetVisualChild
+	static class VisualExtensions
+	{
+		public static Visual GetVisualChildImpl(this Visual parent, int index)
+		{
+			var c = parent.FirstChild<Visual>();
+			int i = 0;
+			while (c != null)
+			{
+				if (i == index) return v;
+				i++;
+				c = c.NextSibling<Visual>();
+			}
+			return null;
+		}
+	}
+
 	public class EachTest : TestBase
 	{
 		[Test]
@@ -41,7 +59,7 @@ namespace Fuse.Reactive.Test
 			{
 				root.StepFrameJS();
 				Assert.AreEqual(30,e.C1.ZOrderChildCount);
-				Assert.AreEqual("5", (e.C1.GetVisualChild(5) as Text).Value);
+				Assert.AreEqual("5", (e.C1.GetVisualChildImpl(5) as Text).Value);
 
 				//do in a loop to try and catch a few race conditions
 				int baseCount = 30;
@@ -51,7 +69,7 @@ namespace Fuse.Reactive.Test
 					e.CallAdd.Perform();
 					root.StepFrameJS();
 					Assert.AreEqual(baseCount+1,e.C1.ZOrderChildCount);
-					Assert.AreEqual("" + (step+5), (e.C1.GetVisualChild(5) as Text).Value);
+					Assert.AreEqual("" + (step+5), (e.C1.GetVisualChildImpl(5) as Text).Value);
 					
 					e.CallRemove.Perform();
 					root.StepFrameJS();
@@ -85,10 +103,10 @@ namespace Fuse.Reactive.Test
 				root.StepFrameJS();
 				
 				Assert.AreEqual(4,e.C1.ZOrderChildCount);
-				Assert.AreEqual(e.C2, e.C1.GetVisualChild(0));
-				Assert.AreEqual(new Selector("Q0"), e.C1.GetVisualChild(1).Name);
-				Assert.AreEqual(new Selector("Q1"), e.C1.GetVisualChild(2).Name);
-				Assert.AreEqual(e.C3, e.C1.GetVisualChild(3));
+				Assert.AreEqual(e.C2, e.C1.GetVisualChildImpl(0));
+				Assert.AreEqual(new Selector("Q0"), e.C1.GetVisualChildImpl(1).Name);
+				Assert.AreEqual(new Selector("Q1"), e.C1.GetVisualChildImpl(2).Name);
+				Assert.AreEqual(e.C3, e.C1.GetVisualChildImpl(3));
 				
 				e.CallRemove.Perform();
 				e.CallRemove.Perform();
@@ -98,9 +116,9 @@ namespace Fuse.Reactive.Test
 				e.CallAdd.Perform();
 				root.StepFrameJS();
 				Assert.AreEqual(3,e.C1.ZOrderChildCount);
-				Assert.AreEqual(e.C2, e.C1.GetVisualChild(0));
-				Assert.AreEqual(new Selector("Q2"), e.C1.GetVisualChild(1).Name);
-				Assert.AreEqual(e.C3, e.C1.GetVisualChild(2));
+				Assert.AreEqual(e.C2, e.C1.GetVisualChildImpl(0));
+				Assert.AreEqual(new Selector("Q2"), e.C1.GetVisualChildImpl(1).Name);
+				Assert.AreEqual(e.C3, e.C1.GetVisualChildImpl(2));
 			}
 		}
 		

--- a/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
@@ -18,7 +18,7 @@ namespace Fuse.Reactive.Test
 			int i = 0;
 			while (c != null)
 			{
-				if (i == index) return v;
+				if (i == index) return c;
 				i++;
 				c = c.NextSibling<Visual>();
 			}

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/ClassConstructor.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/ClassConstructor.ux
@@ -1,5 +1,6 @@
 <UX.ClassConstructorBase ux:Class="UX.ClassConstructor">
 	<Panel ux:Dependency="A" ux:Binding="A" />
 	<Panel ux:Dependency="B" /> <!--  This one is here to force this and UX.ClassConstructorBase to get different constructor signatures -->
-	<Panel ux:Name="_b" Children="B" ux:AutoBind="false" />
+	<WhileTrue ux:Name="_a" Nodes="A" ux:AutoBind="false" />
+	<WhileTrue ux:Name="_b" Nodes="B" ux:AutoBind="false" />
 </UX.ClassConstructorBase>

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/ClassConstructor.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/ClassConstructor.ux
@@ -1,6 +1,5 @@
 <UX.ClassConstructorBase ux:Class="UX.ClassConstructor">
 	<Panel ux:Dependency="A" ux:Binding="A" />
 	<Panel ux:Dependency="B" /> <!--  This one is here to force this and UX.ClassConstructorBase to get different constructor signatures -->
-	<Panel ux:Name="_a" Children="A" ux:AutoBind="false" />
 	<Panel ux:Name="_b" Children="B" ux:AutoBind="false" />
 </UX.ClassConstructorBase>

--- a/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
@@ -526,8 +526,8 @@ namespace Fuse.Reactive.Test
 			{
 				Assert.AreEqual(p1, ((UX.ClassConstructorBase)e)._a.Children[0]);
 
-				Assert.AreEqual(p1, e._a.Children[0]);
-				Assert.AreEqual(p2, e._b.Children[0]);
+				Assert.AreEqual(p1, e._a.Nodes[0]);
+				Assert.AreEqual(p2, e._b.Nodes[0]);
 			}
 		}
 

--- a/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
@@ -101,7 +101,7 @@ namespace Fuse.Reactive.Test
 			using (var root = TestRootPanel.CreateWithChild(e))
 			{
 				Assert.DoesNotThrowAny(root.StepFrameJS);
-				root.RootViewport.Children.Remove(e);
+				e.Parent.Remove(e);
 				Assert.DoesNotThrowAny(root.StepFrameJS);
 			}
 		}

--- a/Source/Fuse.Triggers/BusyTask.uno
+++ b/Source/Fuse.Triggers/BusyTask.uno
@@ -148,9 +148,9 @@ namespace Fuse.Triggers
 			var v = n as Visual;
 			if (v == null) return false;
 
-			for (int i = 0; i < v.Children.Count; i++)
+			for (var x = v.FirstChild<Node>(); x != null; x = x.NextSibling<Node>())
 			{
-				var handler = v.Children[i] as IBusyHandler;
+				var handler = x as IBusyHandler;
 				var vact = handler == null ? BusyTaskActivity.None : handler.BusyActivityHandled;
 				activity &= ~vact;
 			}

--- a/Source/Fuse.Triggers/Deferred.uno
+++ b/Source/Fuse.Triggers/Deferred.uno
@@ -182,9 +182,6 @@ namespace Fuse
 			if (_added != null)
 				Fuse.Diagnostics.InternalError( "Duplicate call to Deferred.Perform", this );
 				
-			//if IndexOf returns -1, for some odd reason, then we'll insert at 0
-			int childIndex = Parent.Children.IndexOf(this) + 1;
-
 			_added = new List<Node>();
 			for (int i=0; i < Templates.Count; ++i)
 			{
@@ -193,7 +190,7 @@ namespace Fuse
 				_added.Add(elm);
 			}
 			
-			Parent.InsertNodes(childIndex, _added.GetEnumerator());
+			Parent.InsertNodesAfter(this, _added.GetEnumerator());
 			
 			BusyTask.SetBusy(Parent, ref _busyTask, BusyTaskActivity.None);
 			return true;

--- a/Source/Fuse.Triggers/WhilePlaying.uno
+++ b/Source/Fuse.Triggers/WhilePlaying.uno
@@ -29,11 +29,8 @@ namespace Fuse.Triggers
 			if (v != playing)
 			{
 				n.Properties.Set(_whilePlayingProp, playing);
-				for (int i = 0; i < n.Children.Count; i++)
-				{
-					var wl = n.Children[i] as WhilePlaying;
-					if (wl != null) wl.SetActive(playing);
-				}
+				for (var wl = n.FirstChild<WhilePlaying>(); wl != null; wl = wl.NextSibling<WhilePlaying>())
+					wl.SetActive(playing);
 			}
 		}
 
@@ -68,11 +65,8 @@ namespace Fuse.Triggers
 			if (v != paused)
 			{
 				n.Properties.Set(_whilePausedProp, paused);
-				for (int i = 0; i < n.Children.Count; i++)
-				{
-					var wl = n.Children[i] as WhilePaused;
-					if (wl != null) wl.SetActive(paused);
-				}
+				for (var wl = n.FirstChild<WhilePaused>(); wl != null; wl = wl.NextSibling<WhilePaused>())
+					wl.SetActive(paused);
 			}
 		}
 
@@ -107,11 +101,8 @@ namespace Fuse.Triggers
 			if (v != paused)
 			{
 				n.Properties.Set(_whileCompletedProp, paused);
-				for (int i = 0; i < n.Children.Count; i++)
-				{
-					var wl = n.Children[i] as WhileCompleted;
-					if (wl != null && wl.IsRootingCompleted) wl.SetActive(paused);
-				}
+				for (var wl = n.FirstChild<WhileCompleted>(); wl != null; wl = wl.NextSibling<WhileCompleted>())
+					if (wl.IsRootingCompleted) wl.SetActive(paused);
 			}
 		}
 

--- a/Source/Fuse.UserEvents/UserEvent.uno
+++ b/Source/Fuse.UserEvents/UserEvent.uno
@@ -229,10 +229,9 @@ namespace Fuse
 				var v = at as Visual;
 				if (v != null)
 				{
-					for (int i = 0; i < v.Children.Count; i++)
+					for (var ue = v.FirstChild<UserEvent>(); ue != null; ue = ue.NextSibling<UserEvent>())
 					{
-						var ue = v.Children[i] as UserEvent;
-						if (ue != null && ue.Name == name)
+						if (ue.Name == name)
 						{
 							visual = v;
 							return ue;


### PR DESCRIPTION
This implementation avoids all memory allocation, copying and shifting in connection with manipulating the Children list, and all the list operations are now O(1), including Contains(), InsertAfter() and Remove()

Updated all relevant call sites to use this API over the IList<T> interface (which is slower).

This is a big optimization over using MiniList, shaving 2-3 seconds of a case where 5000 text elements where added to a list.

** Briefly describe changes and the motivation behind them here **

This PR contains:
- [x] Changelog
- [x] Documentation
- [-] Tests - These code paths are covered plenty by our existing tests
