### PR TITLE
Fuse.Nodes: unroot binding when removing

### DIFF
--- a/Source/Fuse.Nodes/Node.Bindings.uno
+++ b/Source/Fuse.Nodes/Node.Bindings.uno
@@ -129,6 +129,7 @@ namespace Fuse
 			}
 			else
 			{
+				Unroot(BindingList[index]);
 				BindingList.RemoveAt(index);
 			}
 		}

--- a/Source/Fuse.Nodes/Tests/Fuse.Nodes.Test/Node.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Fuse.Nodes.Test/Node.Test.uno
@@ -1,0 +1,35 @@
+using Uno;
+using Uno.Testing;
+
+using Fuse;
+using FuseTest;
+
+namespace Fuse.Test
+{
+	public class NodeTest : TestBase
+	{
+		class MockNode : Node { }
+		class MockBinding : Binding { }
+
+		[Test]
+		public void UnrootAtRemoval()
+		{
+			var p = new MockNode();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				var b1 = new MockBinding();
+				var b2 = new MockBinding();
+
+				p.Add(b1);
+				p.Add(b2);
+				Assert.AreNotEqual(null, b1.Parent);
+				Assert.AreNotEqual(null, b2.Parent);
+
+				p.Bindings.RemoveAt(1);
+				p.Bindings.RemoveAt(0);
+				Assert.AreEqual(null, b1.Parent);
+				Assert.AreEqual(null, b2.Parent);
+			}
+		}
+	}
+}


### PR DESCRIPTION
We unroot if there's only one, so it would be reasonable to expect
that we unroot if there's more.

This was found by code-inspection, and seems to have been like this
for a long time.

I also can't find a call-site for this, so it's probably never triggered
in practice. This is why I decided not to include a changelog-entry.

This PR contains:
- [ ] Changelog
- [x] Tests
