### PR TITLE
Cope with Uno.Time being internal, using Uno.DateTime instead

### DIFF
--- a/Source/Fuse.FileSystem/FileSystemModule.uno
+++ b/Source/Fuse.FileSystem/FileSystemModule.uno
@@ -950,9 +950,9 @@ namespace Fuse.FileSystem
 		}
 
 
-		private static object ToScriptingDate(Context context, ZonedDateTime time)
+		private static object ToScriptingDate(Context context, DateTime time)
 		{
-			var msSinceUnixEpoch = ((time.ToInstant() - Uno.Time.Constants.UnixEpoch).Ticks)
+			var msSinceUnixEpoch = ((time._time.ToInstant() - Uno.Time.Constants.UnixEpoch).Ticks)
 										/ Uno.Time.Constants.TicksPerMillisecond;
 			return context.Evaluate("(Date Converter)", string.Format("new Date({0})", msSinceUnixEpoch));
 		}

--- a/Source/Fuse.FileSystem/Uno/IO/FileStatus.uno
+++ b/Source/Fuse.FileSystem/Uno/IO/FileStatus.uno
@@ -1,18 +1,15 @@
 using Uno;
-using Uno.Time;
 
 namespace Fuse.FileSystem
 {
     internal class FileStatus
     {
-        internal static readonly Instant FileTimeEpoch = Instant.FromUtc(1601, 1, 1, 0, 0);
-
         readonly bool _exists;
         readonly long _length;
         readonly FileAttributes _attributes;
-        readonly ZonedDateTime _creationTimeUtc;
-        readonly ZonedDateTime _lastAccessTimeUtc;
-        readonly ZonedDateTime _lastWriteTimeUtc;
+        readonly DateTime _creationTimeUtc;
+        readonly DateTime _lastAccessTimeUtc;
+        readonly DateTime _lastWriteTimeUtc;
 
 
         public FileStatus()
@@ -20,7 +17,7 @@ namespace Fuse.FileSystem
             // When file does not exists the timestamps will be
             //  12:00 midnight, January 1, 1601 A.D. (C.E.) Coordinated Universal Time (UTC).
             // This is because we want to follow the .NET API behavior
-            var defaultTime = new ZonedDateTime(FileTimeEpoch, DateTimeZone.Utc);
+            var defaultTime = DateTime.FromFileTimeUtc(0);
             _creationTimeUtc = defaultTime;
             _lastWriteTimeUtc = defaultTime;
             _lastAccessTimeUtc = defaultTime;
@@ -33,9 +30,9 @@ namespace Fuse.FileSystem
 
         public FileStatus(long length,
                           FileAttributes attributes,
-                          ZonedDateTime creationTimeUtc,
-                          ZonedDateTime lastAccessTimeUtc,
-                          ZonedDateTime lastWriteTimeUtc)
+                          DateTime creationTimeUtc,
+                          DateTime lastAccessTimeUtc,
+                          DateTime lastWriteTimeUtc)
         {
             _length = length;
             _attributes = attributes;
@@ -48,15 +45,15 @@ namespace Fuse.FileSystem
 
         // This is not currently exposed on FileSystemInfo, as there's no simple way
         // to get file creation timestamp on Linux.
-        public ZonedDateTime CreationTimeUtc { get { return _creationTimeUtc; } }
+        public DateTime CreationTimeUtc { get { return _creationTimeUtc; } }
 
         public bool Exists { get { return _exists; } }
 
         public FileAttributes Attributes { get { return _attributes; } }
 
-        public ZonedDateTime LastAccessTimeUtc { get { return _lastAccessTimeUtc; } }
+        public DateTime LastAccessTimeUtc { get { return _lastAccessTimeUtc; } }
 
-        public ZonedDateTime LastWriteTimeUtc { get { return _lastWriteTimeUtc; } }
+        public DateTime LastWriteTimeUtc { get { return _lastWriteTimeUtc; } }
 
         public long Length { get { return _length; } }
     }

--- a/Source/Fuse.FileSystem/Uno/IO/FileStatusHelpers.Windows.uno
+++ b/Source/Fuse.FileSystem/Uno/IO/FileStatusHelpers.Windows.uno
@@ -1,6 +1,5 @@
 using Uno;
 using Uno.Compiler.ExportTargetInterop;
-using Uno.Time;
 
 namespace Fuse.FileSystem
 {
@@ -18,11 +17,10 @@ namespace Fuse.FileSystem
     [Require("Source.Include", "Uno/Support.h")]
     extern(MSVC) internal static class FileStatusHelpers
     {
-        extern(MSVC) private static ZonedDateTime FileTimeToZoned(uint fileTimeHigh, uint fileTimeLow)
+        extern(MSVC) private static DateTime FileTimeToZoned(uint fileTimeHigh, uint fileTimeLow)
         {
-            var fileTime = ((ulong)fileTimeHigh << 32) | fileTimeLow;
-            var instant = FileStatus.FileTimeEpoch.PlusTicks((long)fileTime);
-            return new ZonedDateTime(instant, DateTimeZone.Utc);
+            var fileTime = ((long)fileTimeHigh << 32) | fileTimeLow;
+            return DateTime.FromFileTimeUtc(fileTime);
         }
 
 
@@ -51,7 +49,7 @@ namespace Fuse.FileSystem
             if (data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
                 attributes |= @{FileAttributes.ReparsePoint};
 
-            return @{FileStatus(long, FileAttributes, ZonedDateTime, ZonedDateTime, ZonedDateTime):New(
+            return @{FileStatus(long, FileAttributes, DateTime, DateTime, DateTime):New(
                 size,
                 attributes,
                 // CreationTime

--- a/Source/Fuse.FileSystem/Uno/IO/FileSystemInfo.uno
+++ b/Source/Fuse.FileSystem/Uno/IO/FileSystemInfo.uno
@@ -31,28 +31,15 @@ namespace Fuse.FileSystem
         }
 
 
-        private static ZonedDateTime ConvertTime(object time)
-        {
-            if defined(DOTNET)
-            {
-                var dt = (BclDateTime)time;
-                var instant = Constants.BclEpoch.PlusTicks(dt.Ticks);
-                return new ZonedDateTime(instant, DateTimeZone.Utc);
-            }
-            else
-                return (ZonedDateTime)time;
-        }
-
-
         public FileAttributes Attributes { get { return (FileAttributes)Status.Attributes; } }
 
         public bool Exists { get { return Status.Exists; } }
 
         public string FullName { get { return _fullPath; } }
 
-        public ZonedDateTime LastAccessTimeUtc { get { return ConvertTime(Status.LastAccessTimeUtc); } }
+        public DateTime LastAccessTimeUtc { get { return Status.LastAccessTimeUtc; } }
 
-        public ZonedDateTime LastWriteTimeUtc { get { return ConvertTime(Status.LastWriteTimeUtc); } }
+        public DateTime LastWriteTimeUtc { get { return Status.LastWriteTimeUtc; } }
 
 
         extern(!DOTNET) private FileStatus _status;


### PR DESCRIPTION
Needed when we take new stuff from https://github.com/fusetools/uno/pull/1258



This PR contains:
- [-] Changelog - The Uno repo has the changelog for this
- [-] Documentation - No *public* fuselibs APIs changed
- [-] Tests - No fuselibs behavior changed
