### PR TITLE
Fuse.Elements: revert ill-adviced DrawingOffset changes

### DIFF
--- a/Source/Fuse.Elements/Caching/ElementAtlas.uno
+++ b/Source/Fuse.Elements/Caching/ElementAtlas.uno
@@ -65,7 +65,6 @@ namespace Fuse.Elements
 				entry._atlas.RemoveElement(elm);
 			entry._atlas = this;
 			entry.AtlasRect = rect;
-			entry.DrawingOffset = cacheRect.Minimum;
 			_elements.Add(elm);
 
 			_invalidElements++;
@@ -108,10 +107,7 @@ namespace Fuse.Elements
 				return false;
 
 			_spilledPixels += entry.AtlasRect.Area;
-
 			entry.AtlasRect = rect;
-			entry.DrawingOffset = cacheRect.Minimum;
-
 			if (entry.IsValid)
 			{
 				_invalidElements++;
@@ -181,7 +177,8 @@ namespace Fuse.Elements
 					if (!scissorRectInClipSpace.Intersects(visibleRect))
 						continue;
 
-					var offset = (float2)(entry.AtlasRect.Minimum - entry.DrawingOffset) / density;
+					var cachingRect = ElementBatch.GetCachingRect(elm);
+					var offset = (float2)(entry.AtlasRect.Minimum - cachingRect.Minimum) / density;
 					var translation = Matrix.Translation(offset.X, offset.Y, 0);
 					var cc = new OrthographicFrustum{
 						Origin = float2(0, 0), Size = viewport,

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -65,7 +65,6 @@ namespace Fuse.Elements
 		public ElementBatch _batch;
 		public readonly Element _elm;
 		public Recti AtlasRect;
-		public int2 DrawingOffset;
 		public float _opacity;
 		public bool IsValid;
 	}
@@ -321,11 +320,12 @@ namespace Fuse.Elements
 			for (int i = 0; i < elementCount; ++i)
 			{
 				var entry = _elements[i];
+				var cachingRect = ElementBatch.GetCachingRect(entry._elm);
 				var opacity = entry._opacity;
 
 				var transform = entry._elm.LocalTransform;
 				//this calculation assumes the transform is flat (a precondition to caching the element)
-				float2 localOrigin = ((float2)entry.DrawingOffset + CachingRectPaddingAdjustment) * densityScale;
+				float2 localOrigin = ((float2)cachingRect.Minimum + CachingRectPaddingAdjustment) * densityScale;
 				float2 positionOrigin = transform[3].XY + localOrigin.X * transform[0].XY + localOrigin.Y * transform[1].XY;
 				float2 size = ((float2)entry.AtlasRect.Size - CachingRectPaddingAdjustment * 2) * densityScale;
 				float2 right = transform[0].XY * size.X;

--- a/Source/Fuse.Elements/Tests/ElementBatcher.Test.uno
+++ b/Source/Fuse.Elements/Tests/ElementBatcher.Test.uno
@@ -86,5 +86,30 @@ namespace Fuse.Elements.Test
 			foreach (var elm in elements)
 				Assert.AreNotEqual(elm.ElementBatchEntry, null);
 		}
+
+		[Test]
+		public void MoveAfterFirstDraw()
+		{
+			var p = new UX.ElementBatcher.MoveAfterFirstDraw();
+			using (var root = TestRootPanel.CreateWithChild(p, int2(40, 110)))
+			{
+				var edgeMargin = 1;
+
+				using (var fb = root.CaptureDraw())
+				{
+					fb.AssertSolidRectangle(new Recti(int2(0 + edgeMargin, 100 + edgeMargin), int2(20 - 2 * edgeMargin, 10 - 2 * edgeMargin)), float4(1, 0, 0, 1));
+				}
+
+				p._translation.X = 15;
+				root.StepFrame();
+
+				using (var fb = root.CaptureDraw())
+				{
+					fb.AssertSolidRectangle(new Recti(int2(15 + edgeMargin, 100 + edgeMargin), int2(20 - 2 * edgeMargin, 10 - 2 * edgeMargin)), float4(1, 0, 0, 1));
+					fb.AssertPixel(float4(0, 0, 0, 0), int2(15 - edgeMargin, 105));
+				}
+
+			}
+		}
 	}
 }

--- a/Source/Fuse.Elements/Tests/UX/ElementBatcher.MoveAfterFirstDraw.ux
+++ b/Source/Fuse.Elements/Tests/UX/ElementBatcher.MoveAfterFirstDraw.ux
@@ -1,0 +1,10 @@
+<StackPanel ux:Class="UX.ElementBatcher.MoveAfterFirstDraw">
+	<Each Count="10">
+		<Rectangle Width="20" Alignment="Left" Height="10" Color="#00F" />
+	</Each>
+	<Panel Alignment="Left">
+		<Rectangle Width="20" Height="10" Color="#F00">
+			<Translation ux:Name="_translation" />
+		</Rectangle>
+	</Panel>
+</StackPanel>


### PR DESCRIPTION
These changes lead to a bad situation where things ended up drawn in
the wrong location.

Fixes issue #296

This reverts parts of commit 7f89944faa3ddfa906a79ce980ba2f7742eaa3d6.

This PR contains:
- [x] Tests
