### PR TITLE
ManualTestingApp: do not randomize with time

### DIFF
--- a/Tests/ManualTests/ManualTestingApp/PointerAndMouse/PointerAndMouse.ux.uno
+++ b/Tests/ManualTests/ManualTestingApp/PointerAndMouse/PointerAndMouse.ux.uno
@@ -11,7 +11,7 @@ public partial class PointerAndMouse
     {
         InitializeUX();
         this.Title = "Pointer & Mouse";
-        _random = new Random(DateTime.Now.Millisecond);
+        _random = new Random(1337);
     }
 
 
@@ -53,4 +53,3 @@ public partial class PointerAndMouse
         return result;
     }
 }
-


### PR DESCRIPTION
`DateTime.Now` now returns a DateTime-struct, not a ZonedDateTime as
it did before. And our DateTime-struct doesn't (yet) support the
`Milliseconds`-property.

Having this test randomize based on time serves no real purpose, we
can just randomize with some constant instead. Having different
colors per run isn't a big plus.

Another alternative would be to use the LocalDateTime-class, but the
plan is to make that one obsolete at some later point. So it doesn't
feel like it's worth the hassle just for a rather useless feature.