### PR TITLE
ManualTestingApp: use ZonedDateTime.Now instead of DateTime.Now

### DIFF
--- a/Tests/ManualTests/ManualTestingApp/Clock/Clock.ux.uno
+++ b/Tests/ManualTests/ManualTestingApp/Clock/Clock.ux.uno
@@ -1,4 +1,5 @@
 using Uno;
+using Uno.Time;
 
 public partial class ClockPage
 {
@@ -13,7 +14,7 @@ public partial class ClockPage
 		if (!IsVisible)
 			return;
 			
-		var t = DateTime.Now;
+		var t = ZonedDateTime.Now;
 		float h = t.Hour;
 		float m = t.Minute;
 		float s = t.Second;


### PR DESCRIPTION
We've changed the Uno API for DateTime.Now from returning a
ZonedDateTime to returning a struct DateTime, which is severely
limited. This is so we can add DateTime to our public UX-visible
API without pulling in a lot of timezone-stuff for all future.

So, until DateTime is a bit more capable, we need to use
ZonedDateTime instead.

In the great future, this will probably have to get reverted.