### PR TITLE
Feature ImageFill uv offset and zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## ImageFill
+- Added ScaleOrigin and ScaleFactor for zooming effects
+- Added Offset for scrolling effects
+
 ## Trigger
 - Fixed an issue where certain triggers would not skip their animation/actions as part of the Bypass phase. This will not likely affect many projects, but may resolve some spurious issues where animations did not bypass under certain conditions.
 - Fixed an issue where `WhileVisibleInScrollView` did not respect the Bypass phase for element layout.

--- a/Source/Fuse.Elements/Drawing/ImageFill.uno
+++ b/Source/Fuse.Elements/Drawing/ImageFill.uno
@@ -117,6 +117,46 @@ namespace Fuse.Drawing
 				}
 			}
 		}
+		
+		static Selector _scaleOriginName = "ScaleOrigin";
+		float2 _scaleOrigin;
+		/**
+			A normalized offset used to adjust the position on which ScaleFactor is based.
+			
+			Default is 0.5,0.5 (center of the image)
+		*/
+		public float2 ScaleOrigin
+		{
+			get { return _scaleOrigin; }
+			set
+			{
+				if(_scaleOrigin != value)
+				{
+					_scaleOrigin = value;
+					OnPropertyChanged(_scaleOriginName);
+				}
+			}
+		}
+		
+		static Selector _scaleFactorName = "ScaleFactor";
+		float _scaleFactor = 1.0f;
+		/**
+			A nor
+
+			Useful for animating scrolling effects. 
+		*/
+		public float ScaleFactor
+		{
+			get { return _scaleFactor; }
+			set
+			{
+				if(_scaleFactor != value)
+				{
+					_scaleFactor = value;
+					OnPropertyChanged(_scaleFactorName);
+				}
+			}
+		}
 
 		float2 GetSize()
 		{
@@ -130,7 +170,8 @@ namespace Fuse.Drawing
 			public float2 Origin, Size;
 			public float4 UVClip;
 			public Texture2D Texture;
-			public float2 TexCoordBias1, TexCoordBias2, TexCoordScale1, TexCoordScale2, TexCoordOffset;
+			public float2 TexCoordBias1, TexCoordBias2, TexCoordScale1, TexCoordScale2, TexCoordOffset, ScaleOrigin;
+			public float ScaleFactor;
 			public SamplerState SamplerState;
 			public bool NeedFract;
 		}
@@ -201,6 +242,8 @@ namespace Fuse.Drawing
 				dp.NeedFract = false;
 			}
 			dp.TexCoordOffset = _uvOffset;
+			dp.ScaleFactor = _scaleFactor;
+			dp.ScaleOrigin = _scaleOrigin;
 			
 			_drawParams = dp;
 			_lastUsed = Time.FrameTime;
@@ -214,8 +257,12 @@ namespace Fuse.Drawing
 		//translate to/from element position to get the correct UV coordinates based on _container.Sizing
 		float2 ElementPosition: req(TexCoord as float2)
 			CanvasSize * TexCoord;
+		
+		//Apply offset, then scale
 		float2 OurTC: 
-			(ElementPosition - DP.Origin)/DP.Size *(DP.UVClip.ZW - DP.UVClip.XY) + DP.UVClip.XY + DP.TexCoordOffset;
+			((ElementPosition - DP.Origin) / DP.Size * (DP.UVClip.ZW - DP.UVClip.XY) 
+			+ DP.UVClip.XY 
+			+ DP.TexCoordOffset - DP.ScaleOrigin) * DP.ScaleFactor + DP.ScaleOrigin;
 			
 		DrawContext DrawContext: prev, null;
 		DrawParams DP: 


### PR DESCRIPTION
Looking at some of the fun squishy UI in games like Splatoon last night I started thinking about how I would replicate some of the effects in Fuse, and it seems to me we lack features for doing pretty simple stuff like infinitely scrolling images (even though our imagefills are repeating textures by default) or doing image scaling within a mask like circle/rect with rounded corners.  This PR adds ScaleFactor and ScaleOrigin for zooming on an imagefill, as well as Offset for translating UVs. I don't think the added complexity to the shader should hurt, as it adds an add, a subtract and a multiply. 

UV offset is applied, then scaling around an origin. 

This PR contains:
- [x] Changelog
- [x] Documentation
