### PR TITLE
Documentation: add point about spaces around operators

### DIFF
--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -47,6 +47,17 @@ but we also have a few additional guidelines:
    }
    ```
 * *Do not* use egyptian braces
+* Use spaces around operators and keywords, but not inside parentheses and
+  not around function calls. So, like this:
+  ```Uno
+  if (condition)
+        foo(bar + 1);
+  ```
+  ...and not like this:
+  ```Uno
+  if( condition )
+        foo( bar+1 );
+  ```
 
 ## JavaScript
 


### PR DESCRIPTION
We're far from consistent in how we're writing things like this, but
there's already a pretty clear presedence set:

```
$ git grep "[a-zA-Z0-9_]\+ + [a-zA-Z0-9_]\+" -- *.uno | wc -l
675

$ git grep "[a-zA-Z0-9_]\++[a-zA-Z0-9_]\+" -- *.uno | wc -l
147

$ git grep "if ([^ ]" -- *.uno | wc -l
5855

$ git grep "if([^ ]" -- *.uno | wc -l
273

$ git grep "if( [^ ]" -- *.uno | wc -l
35

$ git grep "if ( [^ ]" -- *.uno | wc -l
28
```

So, the 'a + b' pattern is more than 4 times as popular as the 'a+b'
pattern, and the 'if (foo)'-pattern is more than 20 times(!) as popular
as the second most popular alternative.

The same patterns repeats itself as the by-far more popular for other
operators (at least for '*', see notice below) and keywords (like
'while', 'for' and 'switch') as well. So this pretty much just
documents what's currently the situation.

The reason I didn't measure the '-' and '/' operators, is that they
produce too many false-positives to produce reliable data. But visual
inspection seems to indicate that they follow the same pattern.

This PR contains:
- [x] Documentation
