### PR TITLE
Fuse.Text: fix problem with ICU-clashing symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # 1.2
 
+## Fuse.Text
+- Fixed an issue where the combination of `-DUSE_HARFBUZZ`, `-DCOCOAPODS` *and* certain Pods (in particular Firebase.Database has been identified) caused an app to link to symbols that the AppStore disallows.
+
 ## Each
 - Fixed an issue where removing an element would not actually remove the element
 

--- a/Source/Fuse.Text/icu/i18n/unicode/uconfig.h
+++ b/Source/Fuse.Text/icu/i18n/unicode/uconfig.h
@@ -87,7 +87,11 @@
  * @internal
  */
 #ifndef U_DISABLE_RENAMING
+#if defined(__APPLE__) && !TARGET_OS_IPHONE
 #define U_DISABLE_RENAMING 1
+#else
+#define U_DISABLE_RENAMING 0
+#endif
 #endif
 
 /**

--- a/Source/Fuse.Text/icu/iOS.stuff
+++ b/Source/Fuse.Text/icu/iOS.stuff
@@ -1,3 +1,3 @@
 if iOS {
-/* 12.81MB */ iOS: "https://az664292.vo.msecnd.net/files/8SDulYmfA3TA32mz-iOS.zip"
+/* 12.79MB */ iOS: "https://az664292.vo.msecnd.net/files/ybMpO7kdxn1NkoFr-iOS.zip"
 }


### PR DESCRIPTION
When using both -DUSE_HARFBUZZ and -DCOCOAPODS and some particular
pods, we end up linking to the wrong, AppStore banned symbols
instead of our bundled copy of ICU.

The approach of providing multiple copies of the same symbols, is
fragile, and some Cocoapods project re-writing ends up biting us
here. So let's get out of the "same symbols"-business, and use
ICUs built-in symbol-renaming mechanism instead.

Since we're using the system-provided copy of ICU on macOS, we
need to only do this for iPhone-builds.

The scripts to build and package ICU can be found here (sorry in
advance to people outside the fusetools organization, this repo
is currently private):

https://github.com/fusetools/uno-base/tree/build-icu

This PR contains:
- [x] Changelog
