### PR TITLE
Fix logical error in ThreadWorker.CheckAndThrow

### DIFF
--- a/Source/Fuse.Reactive.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Reactive.JavaScript/ThreadWorker.uno
@@ -177,7 +177,7 @@ namespace Fuse.Reactive
 			while (_exceptionQueue.TryDequeue(out next))
 			{
 				if (prev != null)
-					Fuse.Diagnostics.UnknownException("Skipped Exception", next, this);
+					Fuse.Diagnostics.UnknownException("Skipped Exception", prev, this);
 				prev = next;
 			}
 			


### PR DESCRIPTION
While debugging some other issues, I was instrumenting CheckAndThrow to be able to see an inner exception's stack trace. While in there I noticed the logic behaves a bit strangely. CheckAndThrow is supposed to check for pending JS thread exceptions and report them, if any. If there's a single exception, it should be thrown; if there are multiple, the last one will be thrown, and the rest reported. With the current logic, since we report `next`, it looks like we'll report _all_ exceptions _and_ throw the last one, rather than only reporting the first ones and throwing the last one, _if_ there are multiple exceptions. I'm guessing this was a simple mistake when writing the code originally, so let's fix that.