### PR TITLE
Add note about DateTime/Date conversion

### DIFF
--- a/Source/Fuse.Reactive.JavaScript/ThreadWorker.Wrapping.uno
+++ b/Source/Fuse.Reactive.JavaScript/ThreadWorker.Wrapping.uno
@@ -24,6 +24,9 @@ namespace Fuse.Reactive
 
 		public static object ConvertDateTimeToJSDate(DateTime dt, Scripting.Function dateCtor)
 		{
+			// TODO: This assumes dt's `Kind` is set to `Utc`. The `Ticks` value may have to be adjusted if `Kind` is `Local` or `Unspecified`.
+			//  Currently we don't support other `Kind`'s than `Utc`, but when we do, this code should be updated accordingly.
+			//  Something like: `if (dt.Kind != DateTimeKind.Utc) { dt = dt.ToUniversalTime(); }`
 			var dotNetTicks = dt.Ticks;
 			var dotNetTicksRelativeToUnixEpoch = dotNetTicks - UnixEpochInDotNetTicks;
 			var jsTicks = dotNetTicksRelativeToUnixEpoch / DotNetTicksInJsTick;


### PR DESCRIPTION
Currently we're trying to keep our DateTime API surface as minimal as possible, which means not exposing ways of dealing with/converting times/dates that aren't in UTC. While assuming UTC makes some of our impl's simpler, we should try to at least document where fuselibs code should change if/when the API gets filled in more to ensure correctness, and since I'm in the area while working on similar features, I thought I'd add this here.