### PR TITLE
Wrap JS Date time value when marshalling to DateTime

### DIFF
--- a/Source/Fuse.Reactive.JavaScript/Tests/DateMarshalTest.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/DateMarshalTest.uno
@@ -60,12 +60,6 @@ namespace Fuse.Reactive.Test
 			{
 				e.RoundTripComponent.CallReadDate.Perform();
 				root.StepFrameJS();
-
-				// Expected date/time (UTC): November 1 1997 10:15:00
-				const long expectedTicks = 630139761000000000L;
-				var expectedDateTime = new DateTime(expectedTicks, DateTimeKind.Utc);
-
-				Assert.AreEqual(e.DateTimeComponent.TheDateTime, expectedDateTime);
 			}
 		}
 
@@ -79,6 +73,33 @@ namespace Fuse.Reactive.Test
 
 				// Expected date/time (UTC): November 1 1997 10:15:00
 				const long expectedTicks = 630139761000000000L;
+				var expectedDateTime = new DateTime(expectedTicks, DateTimeKind.Utc);
+
+				Assert.AreEqual(e.DateTimeComponent.TheDateTime, expectedDateTime);
+			}
+		}
+
+		[Test]
+		public void JSRoundTripUnixEpochDateMatches()
+		{
+			var e = new UX.DateMarshal.UnixEpochDateRoundTrip();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				e.RoundTripComponent.CallReadDate.Perform();
+				root.StepFrameJS();
+			}
+		}
+
+		[Test]
+		public void JSRoundTripUnixEpochDateTimeMatches()
+		{
+			var e = new UX.DateMarshal.UnixEpochDateRoundTrip();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+
+				// Expected date/time (UTC): January 1 1970 00:00:00 (Unix Epoch)
+				const long expectedTicks = 621355968000000000L;
 				var expectedDateTime = new DateTime(expectedTicks, DateTimeKind.Utc);
 
 				Assert.AreEqual(e.DateTimeComponent.TheDateTime, expectedDateTime);

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/DateMarshal.UnixEpochDateRoundTrip.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/DateMarshal.UnixEpochDateRoundTrip.ux
@@ -1,0 +1,31 @@
+<Panel ux:Class="UX.DateMarshal.UnixEpochDateRoundTrip">
+	<StackPanel ux:Class="UX.DateMarshal.UnixEpochDateRoundTripInnerComponent">
+		<JavaScript>
+			var self = this;
+
+			module.exports = {
+				read_date: function() {
+					var expectedTime = 0;
+					var date = self.DateTime.value;
+					if (expectedTime != date.getTime())
+						throw "Round-trip value didn't match expected time!";
+				}
+			};
+		</JavaScript>
+
+		<Uno.DateTime ux:Property="DateTime" />
+
+		<FuseTest.Invoke Handler="{read_date}" ux:Name="CallReadDate"/>
+	</StackPanel>
+
+	<JavaScript>
+		module.exports = {
+			myDate: new Date(Date.parse("1970-01-01T00:00:00.000Z"))
+		};
+	</JavaScript>
+
+	<StackPanel>
+		<UX.DateMarshal.UnixEpochDateRoundTripInnerComponent ux:Name="RoundTripComponent" DateTime="{myDate}" />
+		<Fuse.Reactive.Test.DotNetDateTimeComponent ux:Name="DateTimeComponent" TheDateTime="{myDate}" />
+	</StackPanel>
+</Panel>

--- a/Source/Fuse.Reactive.JavaScript/ThreadWorker.Wrapping.uno
+++ b/Source/Fuse.Reactive.JavaScript/ThreadWorker.Wrapping.uno
@@ -15,7 +15,7 @@ namespace Fuse.Reactive
 
 		public static DateTime ConvertDateToDateTime(Scripting.Object date)
 		{
-			var jsTicks = (long)(double)date.CallMethod("getTime");
+			var jsTicks = (long)(double)ThreadWorker.Wrap(date.CallMethod("getTime"));
 			var dotNetTicksRelativeToUnixEpoch = jsTicks * DotNetTicksInJsTick;
 			var dotNetTicks = dotNetTicksRelativeToUnixEpoch + UnixEpochInDotNetTicks;
 


### PR DESCRIPTION
Previously, this code would assume the result of `getTime` on a JS `Date` object would be a `double`. However, one critical value does not satisfy this assumption: the Unix epoch. This is because the result is 0, which is representable as an integer.

The fix is to wrap the value from `getTime`. We can assume the wrapped value is a `double`, so we cast to that from the resulting object, then cast its value to `long`.

I was sure I had tested this initially, and I probably did when writing the code, but since I wrote tests after, that case was likely not covered when adjusting the casting logic a bit while cleaning up. Whoops!

This PR contains:
- [x] Tests
