### PR TITLE
Revert "appveyor: temporarily direct azure CDN to europe"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
 version: '{build}'
 
-init:
-  - ps: '[System.IO.File]::AppendAllText("C:\Windows\System32\drivers\etc\hosts", "`n93.184.221.200  az664292.vo.msecnd.net")'
-
 install:
   - Stuff\stuff install Stuff
   - ps: Invoke-WebRequest http://downloads.fdossena.com/geth.php?r=mesa-latest -OutFile mesa.zip


### PR DESCRIPTION
The azure CDN-problem has been fixed a while back, so let's
remove this horrible hack ;)

This reverts commit 31748b90c4e11389d8f446dc592f144090d94d37.