### PR TITLE
travis: build manual testing app

### DIFF
--- a/.travis.xcconfig
+++ b/.travis.xcconfig
@@ -1,0 +1,1 @@
+SDKROOT = iphonesimulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ compiler: clang
 
 cache: ccache
 
+env:
+  global:
+    - XCODE_XCCONFIG_FILE=$TRAVIS_BUILD_DIR/.travis.xcconfig
+
 install:
   - brew update
   - brew install mono
@@ -21,6 +25,7 @@ before_script:
 
 script:
   - Stuff/uno --trace doctor
+  - Stuff/uno --trace build -tios Tests/ManualTests/ManualTestingApp/ManualTestingApp.unoproj
   - Stuff/uno --trace test -tnative --timeout=30 Source/AllTests.unoproj
 
 after_failure:


### PR DESCRIPTION
So far, we haven't been building manual testing app on pull-requests, because we had issues with too long build times. Now that this has been solved, we should be able to do this.

Note that building ManualTestingApp doesn't actually work right now, due to a uno-bug. But another uno-bug cancels that one out, so uno doesn't report an error. Both of these bugs are in the process of being fixed in uno master.

This PR contains:
- [x] Tests
