### PR TITLE
ThreadWorker: Add missing if tests in Unwrap

### DIFF
--- a/Source/Fuse.Reactive.JavaScript/ThreadWorker.Wrapping.uno
+++ b/Source/Fuse.Reactive.JavaScript/ThreadWorker.Wrapping.uno
@@ -75,6 +75,8 @@ namespace Fuse.Reactive
 			else if (dc is string) return dc;
 			else if (dc is IRaw) return ((IRaw)dc).Raw;
 			else if (dc is Scripting.Function) return dc;
+			else if (dc is Scripting.Object) return dc;
+			else if (dc is Scripting.Array) return dc;
 			else if (dc is float2) return ToArray((float2)dc);
 			else if (dc is float3) return ToArray((float3)dc);
 			else if (dc is float4) return ToArray((float4)dc);


### PR DESCRIPTION
Came up while writing tests for Fuse.Scripting that Scripting.Object's and Scripting.Array's gets wrapped as external objects

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
