### PR TITLE
ThreadWorker.ScriptClass: Add missing return

### DIFF
--- a/Source/Fuse.Reactive.JavaScript/ThreadWorker.ScriptClass.uno
+++ b/Source/Fuse.Reactive.JavaScript/ThreadWorker.ScriptClass.uno
@@ -138,7 +138,7 @@ namespace Fuse.Reactive
 				_worker = worker;
 
 				var factory = (Function)_worker.Context.Evaluate(m.Name + " (ScriptMethod)", "(function (cl, callback) { cl.prototype." + m.Name + 
-					" = function() { callback(this.external_object, Array.prototype.slice.call(arguments)); }})");
+					" = function() { return callback(this.external_object, Array.prototype.slice.call(arguments)); }})");
 				
 				factory.Call(cl, (Callback)Callback);	
 			}


### PR DESCRIPTION
Not to familiar with this code, but it seems obvious that a return is missing here? Also, this fixed my ScriptMethods that always returned undefined :)

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
