### PR TITLE
Travis: use Mono 4.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ env:
     - XCODE_XCCONFIG_FILE=$TRAVIS_BUILD_DIR/.travis.xcconfig
 
 install:
-  - brew update
-  - brew install mono
   - pip install six
+  - wget https://download.mono-project.com/archive/4.4.2/macos-10-universal/MonoFramework-MDK-4.4.2.macos10.xamarin.universal.pkg -O mono.pkg &&
+    sudo installer -pkg mono.pkg -target / &&
+    export PATH=$PATH:/Library/Frameworks/Mono.framework/Versions/Current/Commands
   - Stuff/stuff install Stuff
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: cpp
 
 compiler: clang
 
-cache: ccache
-
 env:
   global:
     - XCODE_XCCONFIG_FILE=$TRAVIS_BUILD_DIR/.travis.xcconfig
@@ -13,13 +11,10 @@ env:
 install:
   - brew update
   - brew install mono
-  - brew install ccache
   - pip install six
   - Stuff/stuff install Stuff
 
 before_script:
-  - export CC="ccache clang"
-  - export CXX="ccache clang++"
   - ulimit -c unlimited -S
   - rm -rf /cores/core.*
 


### PR DESCRIPTION
We need to use Mono 4.4.2 to build ManualTestingApp for iOS. The only reason
why this seemed to work when the PR was pulled, was that there was a uno-bug
that prevented the build-error from being reported.

This PR also gets rid of ccache, as it's no longer needed (and cause issues).

Sadly, it makes the build a bit slower. I'll experiment a bit more with the caching
later to try to mitigate this a bit. But for now, I'd prefer a master that actually
builds.