### PR TITLE
Fuse.Elements: revert bad change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 1.2
 
+## Fuse.Elements
+- Fixed an issue where the ElementBatcher ended up throwing an Exception complaining about the element not having a caching rect.
+
+
 ## 1.2.0
 
 ### Fuse.Text

--- a/Source/Fuse.Elements/Caching/ElementAtlas.uno
+++ b/Source/Fuse.Elements/Caching/ElementAtlas.uno
@@ -100,7 +100,9 @@ namespace Fuse.Elements
 			if (entry._atlas != this)
 				throw new Exception("wrong atlas again, dummy!");
 
-			Recti cacheRect = ElementBatch.GetCachingRect(elm);
+			Recti cacheRect;
+			if (!Cache.GetCachingRect(elm, out cacheRect))
+				return false;
 
 			Recti rect;
 			if (!_rectPacker.TryAdd(cacheRect.Size, out rect))

--- a/Source/Fuse.Elements/Tests/ElementBatcher.Test.uno
+++ b/Source/Fuse.Elements/Tests/ElementBatcher.Test.uno
@@ -111,5 +111,34 @@ namespace Fuse.Elements.Test
 
 			}
 		}
+
+		[Test]
+		public void ZeroSizeAfterFirstDraw()
+		{
+			var p = new UX.ElementBatcher.ZeroSizeAfterFirstDraw();
+			using (var root = TestRootPanel.CreateWithChild(p, int2(10, 13)))
+			{
+				var edgeMargin = 1;
+
+				using (var fb = root.CaptureDraw())
+				{
+					fb.AssertSolidRectangle(new Recti(int2(0,  0), int2(10,  1)), float4(0, 0, 1, 1)); // Guard
+					fb.AssertSolidRectangle(new Recti(int2(0,  1), int2(10, 10)), float4(0, 1, 0, 1));
+					fb.AssertSolidRectangle(new Recti(int2(0, 11), int2(10,  1)), float4(1, 0, 0, 1)); // Poison
+					fb.AssertSolidRectangle(new Recti(int2(0, 12), int2(10,  1)), float4(0, 0, 1, 1)); // Guard
+				}
+
+				p.Poison.Height = 0;
+				p.Poison.Background = null;
+				root.StepFrame();
+
+				using (var fb = root.CaptureDraw())
+				{
+					fb.AssertSolidRectangle(new Recti(int2(0,  0), int2(10,  1)), float4(0, 0, 1, 1)); // Guard
+					fb.AssertSolidRectangle(new Recti(int2(0,  1), int2(10, 10)), float4(0, 1, 0, 1));
+					fb.AssertSolidRectangle(new Recti(int2(0, 11), int2(10,  1)), float4(0, 0, 1, 1)); // Guard
+				}
+			}
+		}
 	}
 }

--- a/Source/Fuse.Elements/Tests/UX/ElementBatcher.ZeroSizeAfterFirstDraw.ux
+++ b/Source/Fuse.Elements/Tests/UX/ElementBatcher.ZeroSizeAfterFirstDraw.ux
@@ -1,0 +1,8 @@
+<StackPanel ux:Class="UX.ElementBatcher.ZeroSizeAfterFirstDraw">
+	<Rectangle Width="100%" Alignment="Left" Height="1px" Color="#00F" />
+	<Each Count="10">
+		<Rectangle Width="100%" Alignment="Left" Height="1px" Color="#0F0" />
+	</Each>
+	<Panel ux:Name="Poison" Width="100%" Height="1px" Color="#F00" />
+	<Rectangle Width="100%" Height="1px" Color="#00F" />
+</StackPanel>


### PR DESCRIPTION
In 7f89944, we incorrectly assumed that this could never happen.
If you look at the callsite, you can see that this exact behavior
is expected.

This is not ideal behavior, but let's restore the old behavior for
now. We can rework this mechanism later for master.

While we're at it, add a test that picks up this breakage.

Fixes issue #375

This PR contains:
- [x] Changelog
- [x] Tests
