### PR TITLE
use 64-bit mono in scripts

### DIFF
--- a/Tests/auto-test-app.sh
+++ b/Tests/auto-test-app.sh
@@ -15,7 +15,11 @@ if [ $# == 2 ]; then
 fi
 
 if [ "$OSTYPE" != "msys" ]; then
-    UNO="mono $UNO"
+    if which mono64 > /dev/null 2>&1; then
+        UNO="mono64 $UNO"
+    else
+        UNO="mono $UNO"
+    fi
 fi
 
 shopt -s nocasematch

--- a/Tests/build_test_apps.sh
+++ b/Tests/build_test_apps.sh
@@ -22,11 +22,11 @@ echo "Setting version to $VERSION in manual test app"
 ./set_version.sh $VERSION
 
 echo "Building manual test app for Android"
-mono ../../../Stuff/uno.exe build ManualTestingApp.unoproj -v --target=android --output-dir=.build/Android-Debug
+../../../Stuff/uno build ManualTestingApp.unoproj -v --target=android --output-dir=.build/Android-Debug
 
 echo "Building manual test app for iOS"
 echo "Note that this requires the keychain to be unlocked, build servers might need a separate step for this"
-mono ../../../Stuff/uno.exe build ManualTestingApp.unoproj -v --target=ios --output-dir=.build/iOS-Debug
+../../../Stuff/uno build ManualTestingApp.unoproj -v --target=ios --output-dir=.build/iOS-Debug
 xcodebuild -project .build/iOS-Debug/*.xcodeproj -configuration Release
 /usr/bin/xcrun -sdk iphoneos PackageApplication -v .build/iOS-Debug/build/Release-iphoneos/*.app -o "$PWD/ManualTestingApp.ipa" --embed /Users/outracks/Library/MobileDevice/Provisioning\ Profiles/Adhoc.mobileprovision
 
@@ -37,11 +37,11 @@ popd
 pushd ManualTests/NativeTestingApp
 
 echo "Building native test app for Android"
-mono ../../../Stuff/uno.exe build -v --target=android --output-dir=.build/Android-Debug
+../../../Stuff/uno build -v --target=android --output-dir=.build/Android-Debug
 
 echo "Building native test app for iOS"
 echo "Note that this requires the keychain to be unlocked, build servers might need a separate step for this"
-mono ../../../Stuff/uno.exe build -v --target=ios --output-dir=.build/iOS-Debug
+../../../Stuff/uno build -v --target=ios --output-dir=.build/iOS-Debug
 xcodebuild -project .build/iOS-Debug/*.xcodeproj -configuration Release
 /usr/bin/xcrun -sdk iphoneos PackageApplication -v .build/iOS-Debug/build/Release-iphoneos/*.app -o "$PWD/NativeTestingApp.ipa" --embed /Users/outracks/Library/MobileDevice/Provisioning\ Profiles/Adhoc.mobileprovision
 

--- a/Tests/compile-packages.sh
+++ b/Tests/compile-packages.sh
@@ -29,6 +29,16 @@ function usage {
     echo "    -a, --argument <uno argument>        extra argument to uno.exe (use -a <arg1> -a <arg2> ... to add more arguments)"
 }
 
+function monow {
+    if [ "$OSTYPE" = msys ]; then
+        "$@"
+    elif which mono64 > /dev/null 2>&1; then
+        mono64 "$@"
+    else
+        mono "$@"
+    fi
+}
+
 if [[ "$1" == "-h" || "$1" == "--help" ]]
 then
     usage
@@ -87,16 +97,8 @@ fi
 
 echo "Generating project..."
 echo
-if [ "$OSTYPE" = msys ]; then
-    $UNO test-gen $PACKAGES $OUTPUT_DIR
-else
-    mono $UNO test-gen $PACKAGES $OUTPUT_DIR
-fi
+monow $UNO test-gen $PACKAGES $OUTPUT_DIR
 
 echo "Building project..."
 echo
-if [ "$OSTYPE" = msys ]; then
-    $UNO build -v --target=$TARGET --no-strip --clean $ARGUMENTS $OUTPUT_DIR
-else
-    mono $UNO build -v --target=$TARGET --no-strip --clean $ARGUMENTS $OUTPUT_DIR
-fi
+monow $UNO build -v --target=$TARGET --no-strip --clean $ARGUMENTS $OUTPUT_DIR

--- a/performance.sh
+++ b/performance.sh
@@ -2,4 +2,4 @@
 set -e
 cd "`dirname "$0"`"
 
-mono "$ROOT/Stuff/uno.exe" perf-test -logdirectory=PerfLogs Source
+"$ROOT/Stuff/uno" perf-test -logdirectory=PerfLogs Source

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,6 @@ set -e
 
 ROOT=`dirname $0`
 
-mono "$ROOT/Stuff/uno.exe" test "$ROOT/Source"
+"$ROOT/Stuff/uno.exe" test "$ROOT/Source"
 
-$ROOT/Tests/package-compilation.sh
+"$ROOT/Tests/package-compilation.sh"


### PR DESCRIPTION
The "Create Manual Testing Apps" build step in TeamCity stopped working when we switched to using Xamarin.Mac in Uno. Running 64-bit mono makes this work again.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
