### PR TITLE
Fuse.Common: make assert signature consistent

### DIFF
--- a/Source/Fuse.Common/Tests/FuseTest/TestFramebuffer.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestFramebuffer.uno
@@ -53,7 +53,7 @@ namespace FuseTest
 				Assert.Fail(string.Format("Unexpected color at [{0}]. Got [{1}], expected [{2}].", pos, color, expectedColor), filePath, lineNumber, memberName);
 		}
 
-		public void AssertSolidRectangle(Recti rect, float4 expectedColor, float tolerance = Assert.ZeroTolerance, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0, [CallerMemberName] string memberName = "")
+		public void AssertSolidRectangle(float4 expectedColor, Recti rect, float tolerance = Assert.ZeroTolerance, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0, [CallerMemberName] string memberName = "")
 		{
 			for (int y = rect.Minimum.Y; y < rect.Maximum.Y; ++y)
 			{

--- a/Source/Fuse.Elements/Tests/ElementBatcher.Test.uno
+++ b/Source/Fuse.Elements/Tests/ElementBatcher.Test.uno
@@ -98,7 +98,7 @@ namespace Fuse.Elements.Test
 
 				using (var fb = root.CaptureDraw())
 				{
-					fb.AssertSolidRectangle(new Recti(int2(0 + edgeMargin, 100 + edgeMargin), int2(20 - 2 * edgeMargin, 10 - 2 * edgeMargin)), float4(1, 0, 0, 1));
+					fb.AssertSolidRectangle(float4(1, 0, 0, 1), new Recti(int2(0 + edgeMargin, 100 + edgeMargin), int2(20 - 2 * edgeMargin, 10 - 2 * edgeMargin)));
 				}
 
 				p._translation.X = 15;
@@ -106,7 +106,7 @@ namespace Fuse.Elements.Test
 
 				using (var fb = root.CaptureDraw())
 				{
-					fb.AssertSolidRectangle(new Recti(int2(15 + edgeMargin, 100 + edgeMargin), int2(20 - 2 * edgeMargin, 10 - 2 * edgeMargin)), float4(1, 0, 0, 1));
+					fb.AssertSolidRectangle(float4(1, 0, 0, 1), new Recti(int2(15 + edgeMargin, 100 + edgeMargin), int2(20 - 2 * edgeMargin, 10 - 2 * edgeMargin)));
 					fb.AssertPixel(float4(0, 0, 0, 0), int2(15 - edgeMargin, 105));
 				}
 
@@ -123,10 +123,10 @@ namespace Fuse.Elements.Test
 
 				using (var fb = root.CaptureDraw())
 				{
-					fb.AssertSolidRectangle(new Recti(int2(0,  0), int2(10,  1)), float4(0, 0, 1, 1)); // Guard
-					fb.AssertSolidRectangle(new Recti(int2(0,  1), int2(10, 10)), float4(0, 1, 0, 1));
-					fb.AssertSolidRectangle(new Recti(int2(0, 11), int2(10,  1)), float4(1, 0, 0, 1)); // Poison
-					fb.AssertSolidRectangle(new Recti(int2(0, 12), int2(10,  1)), float4(0, 0, 1, 1)); // Guard
+					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0,  0), int2(10,  1))); // Guard
+					fb.AssertSolidRectangle(float4(0, 1, 0, 1), new Recti(int2(0,  1), int2(10, 10)));
+					fb.AssertSolidRectangle(float4(1, 0, 0, 1), new Recti(int2(0, 11), int2(10,  1))); // Poison
+					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0, 12), int2(10,  1))); // Guard
 				}
 
 				p.Poison.Height = 0;
@@ -135,9 +135,9 @@ namespace Fuse.Elements.Test
 
 				using (var fb = root.CaptureDraw())
 				{
-					fb.AssertSolidRectangle(new Recti(int2(0,  0), int2(10,  1)), float4(0, 0, 1, 1)); // Guard
-					fb.AssertSolidRectangle(new Recti(int2(0,  1), int2(10, 10)), float4(0, 1, 0, 1));
-					fb.AssertSolidRectangle(new Recti(int2(0, 11), int2(10,  1)), float4(0, 0, 1, 1)); // Guard
+					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0,  0), int2(10,  1))); // Guard
+					fb.AssertSolidRectangle(float4(0, 1, 0, 1), new Recti(int2(0,  1), int2(10, 10)));
+					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0, 11), int2(10,  1))); // Guard
 				}
 			}
 		}

--- a/Source/Fuse.Elements/Tests/Rendering.Test.uno
+++ b/Source/Fuse.Elements/Tests/Rendering.Test.uno
@@ -14,13 +14,13 @@ namespace Fuse.Test
 			using (var root = TestRootPanel.CreateWithChild(p, int2(32, 32)))
 			using (var fb = root.CaptureDraw())
 			{
-				fb.AssertSolidRectangle(new Recti(0, 0, 32, 16), float4(0, 0, 0, 0));
+				fb.AssertSolidRectangle(float4(0, 0, 0, 0), new Recti(0, 0, 32, 16));
 
-				fb.AssertSolidRectangle(new Recti(0, 16, 16, 24), float4(0, 0, 0, 0));
-				fb.AssertSolidRectangle(new Recti(16, 16, 24, 24), float4(1, 0, 0, 1));
-				fb.AssertSolidRectangle(new Recti(24, 16, 32, 24), float4(0, 0, 0, 0));
+				fb.AssertSolidRectangle(float4(0, 0, 0, 0), new Recti(0, 16, 16, 24));
+				fb.AssertSolidRectangle(float4(1, 0, 0, 1), new Recti(16, 16, 24, 24));
+				fb.AssertSolidRectangle(float4(0, 0, 0, 0), new Recti(24, 16, 32, 24));
 
-				fb.AssertSolidRectangle(new Recti(0, 24, 32, 32), float4(0, 0, 0, 0));
+				fb.AssertSolidRectangle(float4(0, 0, 0, 0), new Recti(0, 24, 32, 32));
 			}
 		}
 	}


### PR DESCRIPTION
All other assert-functions take their expected value as the first
one, so let's switch around the arguments to
TestFramebuffer.AssertSolidRectangle to make it consistent.
