### PR TITLE
GL pack/unpack alignment

### DIFF
--- a/Source/Experimental.TextureLoader/CIL/CilTextureLoader.uno
+++ b/Source/Experimental.TextureLoader/CIL/CilTextureLoader.uno
@@ -59,7 +59,6 @@ namespace Experimental.TextureLoader
 
 					var textureHandle = GL.CreateTexture();
 					GL.BindTexture(GLTextureTarget.Texture2D, textureHandle);
-					GL.PixelStore(GLPixelStoreParameter.PackAlignment, 1);
 					GL.PixelStore(GLPixelStoreParameter.UnpackAlignment, 1);
 					GL.TexImage2D(GLTextureTarget.Texture2D, 0, internalFormat, bitmap.Width, bitmap.Height, 0, pixelFormat, pixelType, new Uno.Buffer(bitmap.ReadData()));
 					var texture = new Uno.Graphics.Texture2D(textureHandle, new Uno.Int2(bitmap.Width, bitmap.Height), 1, format);

--- a/Source/Fuse.Common/Tests/FuseTest/TestFramebuffer.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestFramebuffer.uno
@@ -33,6 +33,7 @@ namespace FuseTest
 			try
 			{
 				var temp = new byte[4];
+				GL.PixelStore(GLPixelStoreParameter.PackAlignment, 1);
 				GL.ReadPixels(pos.X, Framebuffer.Size.Y - 1 - pos.Y, 1, 1, GLPixelFormat.Rgba, GLPixelType.UnsignedByte, temp);
 				return float4(temp[0] / 255.0f,
 					temp[1] / 255.0f,

--- a/Source/Fuse.Controls.Native/NativeRenderer.uno
+++ b/Source/Fuse.Controls.Native/NativeRenderer.uno
@@ -146,6 +146,7 @@ namespace Fuse.Controls.Native
 
 			[[view layer] renderInContext:context];
 
+			glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 			if (reuse)
 			{
 				glTexSubImage2D(

--- a/Source/Fuse.Controls.Video/CIL/VideoImpl.uno
+++ b/Source/Fuse.Controls.Video/CIL/VideoImpl.uno
@@ -164,6 +164,7 @@ namespace Fuse.Controls.VideoImpl.CIL
 
 			if (Fuse.Video.Graphics.CIL.VideoImpl.IsFrameAvailable(_handle))
 			{
+				GL.PixelStore(GLPixelStoreParameter.UnpackAlignment, 1);
 				Fuse.Video.Graphics.CIL.VideoImpl.UpdateTexture(_handle, _texture.GLTextureHandle);
 				_videoTexture = new VideoTexture(_texture.GLTextureHandle);
 				OnFrameAvailable();

--- a/Source/Fuse.Drawing.Surface/Android/GraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/Android/GraphicsSurface.uno
@@ -144,7 +144,7 @@ namespace Fuse.Drawing
 			int[] pixels = new int[size];
 
 			IntBuffer pixelData = IntBuffer.wrap(pixels);
-			GLES20.glPixelStorei(GLES20.GL_UNPACK_ALIGNMENT, 1);
+			GLES20.glPixelStorei(GLES20.GL_PACK_ALIGNMENT, 1);
 			GLES20.glReadPixels(0, 0, width,height, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, pixelData);
 
 			Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
@@ -247,6 +247,7 @@ namespace Fuse.Drawing
 			int size = rowSize * height;
 			auto pixelData = new UInt8[size];
 			glBindTexture(GL_TEXTURE_2D, glTexture);
+			glPixelStorei(GL_PACK_ALIGNMENT, 1);
 			glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixelData);
 			
 			//flip the image

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
@@ -144,6 +144,7 @@ namespace Fuse.Drawing
 			auto ctx = (CGLib::Context*)cp;
 			int size = width * height * 4;
 			auto pixelData = new UInt8[size];
+			glPixelStorei(GL_PACK_ALIGNMENT, 1);
 			glReadPixels(0,0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixelData);
 
 			CFDataRef data = CFDataCreate(NULL, pixelData, size);
@@ -165,6 +166,7 @@ namespace Fuse.Drawing
 			int size = rowSize * height;
 			auto pixelData = new UInt8[size];
 			glBindTexture(GL_TEXTURE_2D, glTexture);
+			glPixelStorei(GL_PACK_ALIGNMENT, 1);
 			glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixelData);
 
 			//flip the image

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
@@ -90,6 +90,7 @@ namespace Fuse.Drawing
 		@{
 			auto ctx = (CGLib::Context*)cp;
 			glBindTexture(GL_TEXTURE_2D, ctx->GLTexture);
+			glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, ctx->Width, ctx->Height, 0, GL_RGBA,
 				GL_UNSIGNED_BYTE, ctx->BitmapData);
 

--- a/Source/Fuse.Drawing.Surface/DotNetSurface.uno
+++ b/Source/Fuse.Drawing.Surface/DotNetSurface.uno
@@ -495,6 +495,7 @@ namespace Fuse.Drawing
 			int size = width * height * 4;
 			var pixelData = new byte[size];
 
+			GL.PixelStore(GLPixelStoreParameter.PackAlignment, 1);
 			GL.ReadPixels(0,0, width, height, GLPixelFormat.Rgba, GLPixelType.UnsignedByte, pixelData);
 
 			// flip r and b

--- a/Source/Fuse.Drawing.Surface/DotNetSurface.uno
+++ b/Source/Fuse.Drawing.Surface/DotNetSurface.uno
@@ -566,6 +566,7 @@ namespace Fuse.Drawing
 		public static extern void Render (float2 size, Buffer buffer, OpenGL.GLTextureHandle GLBuffer)
 		{
 			GL.BindTexture(GLTextureTarget.Texture2D, GLBuffer);
+			GL.PixelStore(GLPixelStoreParameter.UnpackAlignment, 1);
 			GL.TexImage2D(
 				GLTextureTarget.Texture2D, 0, 
 				GLPixelFormat.Rgba, (int)size.X, (int)size.Y, 0, 

--- a/Source/Fuse.iOS.TextRenderer/TextRenderer.uno
+++ b/Source/Fuse.iOS.TextRenderer/TextRenderer.uno
@@ -254,6 +254,7 @@ namespace Fuse.iOS.Bindings
 
 				var textureHandle = GL.CreateTexture();
 				GL.BindTexture(GLTextureTarget.Texture2D, textureHandle);
+				GL.PixelStore(GLPixelStoreParameter.UnpackAlignment, 1);
 				GL.TexImage2D(GLTextureTarget.Texture2D, 0, GLPixelFormat.Rgba, pixelSize.X, pixelSize.Y, 0, GLPixelFormat.Bgra, GLPixelType.UnsignedByte, textureBuffer);
 				extern(textureBuffer) "free($0)";
 				textureBuffer = IntPtr.Zero;


### PR DESCRIPTION
We need to make sure that unpack/pack alignments are set to 1 when uploading / downloading images to GL, otherwise corruption can occur.

Seems we we've been lucky and had one of the code-sites that sets these ran before every upload, but I don't think this is guaranteed.

Fixes fusetools/fuselibs#3888.
