### PR TITLE
optimize calc render bounds backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # 1.2
 
+## Optimizations
+- Optimized how bounding boxes are calculated (improves layout and rendering performance).
+- Optimized how render bounds are compounded for larger lists.
+
+
 ## 1.2.1
 
 ### Fuse.Elements

--- a/Source/Fuse.Common/FastMatrix.uno
+++ b/Source/Fuse.Common/FastMatrix.uno
@@ -7,7 +7,7 @@ namespace Fuse
 		float4x4 _matrix;
 		public float4x4 Matrix { get { return _matrix; } }
 
-		float3 Translation { get { return _matrix.M41M42M43; } }
+		internal float3 Translation { get { return _matrix.M41M42M43; } }
 
 		bool _hasNonTranslation;
 		public bool HasNonTranslation { get { return _hasNonTranslation; } }
@@ -18,6 +18,19 @@ namespace Fuse
 			 such as a failed inversion. If the matrix is not valid then the `Matrix` values are undefined.
 		*/
 		public bool IsValid { get { return _isValid; } }
+
+		public bool IsIdentity
+		{
+			get
+			{
+				if (!_hasNonTranslation)
+					return _matrix.M41M42M43 == float3(0);
+				else
+				{
+					return _matrix == float4x4.Identity;
+				}
+			}
+		}
 
 		FastMatrix()
 		{

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -139,12 +139,28 @@ namespace Fuse.Elements
 				elm.AbsoluteZoom)), CachingRectPadding);
 		}
 
+		Box GetRenderBounds(Element elm)
+		{
+			var t = elm.InternLocalTransformInternal;
+			return VisualBounds.BoxTransform((Box)elm.LocalRenderBounds, t);
+		}
+
 		VisualBounds CalcRenderBounds()
 		{
-			var rect = VisualBounds.Empty;
-			for (int i = 0; i < _elements.Count; i++)
-				rect = rect.Merge(_elements[i]._elm.CalcRenderBoundsInParentSpace());
-			return rect;
+			if (_elements.Count == 0) return VisualBounds.Empty;
+
+			var box = GetRenderBounds(_elements[0]._elm);
+			for (int i = 1; i < _elements.Count; i++)
+			{
+				var b = GetRenderBounds(_elements[i]._elm);
+				if (b.Minimum.X < box.Minimum.X) box.Minimum.X = b.Minimum.X;
+				if (b.Minimum.Y < box.Minimum.Y) box.Minimum.Y = b.Minimum.Y;
+				if (b.Minimum.Z < box.Minimum.Z) box.Minimum.Z = b.Minimum.Z;
+				if (b.Maximum.X > box.Maximum.X) box.Maximum.X = b.Maximum.X;
+				if (b.Maximum.Y > box.Maximum.Y) box.Maximum.Y = b.Maximum.Y;
+				if (b.Maximum.Z > box.Maximum.Z) box.Maximum.Z = b.Maximum.Z;
+			}
+			return VisualBounds.Box(box);
 		}
 
 		VisualBounds _renderBounds;

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -149,14 +149,14 @@ namespace Fuse.Elements
 				var lrb = elm.LocalRenderBounds;
 				if (lrb == VisualBounds.Empty) continue;
 				if (lrb == VisualBounds.Infinite) return VisualBounds.Infinite;
+				var b = VisualBounds.BoxTransform((Box)lrb, elm.InternLocalTransformInternal);
 				if (!hasAnyBounds)
 				{
-					box = lrb;
+					box = b;
 					hasAnyBounds = true;
 				}
 				else
 				{
-					var b = VisualBounds.BoxTransform((Box)lrb, elm.InternLocalTransformInternal);
 					if (b.Minimum.X < box.Minimum.X) box.Minimum.X = b.Minimum.X;
 					if (b.Minimum.Y < box.Minimum.Y) box.Minimum.Y = b.Minimum.Y;
 					if (b.Minimum.Z < box.Minimum.Z) box.Minimum.Z = b.Minimum.Z;

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -142,15 +142,16 @@ namespace Fuse.Elements
 		VisualBounds CalcRenderBounds()
 		{
 			bool hasAnyBounds = false;
-			Box box;
+			Box box = new Box(float3(0), float3(0));
 			for (var i = 0; i < _elements.Count; i++)
 			{
+				var elm = _elements[0]._elm;
 				var lrb = elm.LocalRenderBounds;
 				if (lrb == VisualBounds.Empty) continue;
 				if (lrb == VisualBounds.Infinite) return VisualBounds.Infinite;
 				if (!hasAnyBounds)
 				{
-					box = GetRenderBounds(_elements[0]._elm);
+					box = lrb;
 					hasAnyBounds = true;
 				}
 				else

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -195,7 +195,10 @@ namespace Fuse.Elements
 			_indexBufferValid = false;
 			_vertexPositionBufferValid = false;
 			_vertexTexCoordBufferValid = false;
-			_renderBounds = null;
+			if (_renderBounds != null)
+				_renderBounds = _renderBounds.Merge(elm.CalcRenderBoundsInParentSpace());
+			else
+				_renderBounds = elm.CalcRenderBoundsInParentSpace();
 		}
 
 		public void RemoveElement(Element elm)

--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -139,28 +139,34 @@ namespace Fuse.Elements
 				elm.AbsoluteZoom)), CachingRectPadding);
 		}
 
-		Box GetRenderBounds(Element elm)
-		{
-			var t = elm.InternLocalTransformInternal;
-			return VisualBounds.BoxTransform((Box)elm.LocalRenderBounds, t);
-		}
-
 		VisualBounds CalcRenderBounds()
 		{
-			if (_elements.Count == 0) return VisualBounds.Empty;
-
-			var box = GetRenderBounds(_elements[0]._elm);
-			for (int i = 1; i < _elements.Count; i++)
+			bool hasAnyBounds = false;
+			Box box;
+			for (var i = 0; i < _elements.Count; i++)
 			{
-				var b = GetRenderBounds(_elements[i]._elm);
-				if (b.Minimum.X < box.Minimum.X) box.Minimum.X = b.Minimum.X;
-				if (b.Minimum.Y < box.Minimum.Y) box.Minimum.Y = b.Minimum.Y;
-				if (b.Minimum.Z < box.Minimum.Z) box.Minimum.Z = b.Minimum.Z;
-				if (b.Maximum.X > box.Maximum.X) box.Maximum.X = b.Maximum.X;
-				if (b.Maximum.Y > box.Maximum.Y) box.Maximum.Y = b.Maximum.Y;
-				if (b.Maximum.Z > box.Maximum.Z) box.Maximum.Z = b.Maximum.Z;
+				var lrb = elm.LocalRenderBounds;
+				if (lrb == VisualBounds.Empty) continue;
+				if (lrb == VisualBounds.Infinite) return VisualBounds.Infinite;
+				if (!hasAnyBounds)
+				{
+					box = GetRenderBounds(_elements[0]._elm);
+					hasAnyBounds = true;
+				}
+				else
+				{
+					var b = VisualBounds.BoxTransform((Box)lrb, elm.InternLocalTransformInternal);
+					if (b.Minimum.X < box.Minimum.X) box.Minimum.X = b.Minimum.X;
+					if (b.Minimum.Y < box.Minimum.Y) box.Minimum.Y = b.Minimum.Y;
+					if (b.Minimum.Z < box.Minimum.Z) box.Minimum.Z = b.Minimum.Z;
+					if (b.Maximum.X > box.Maximum.X) box.Maximum.X = b.Maximum.X;
+					if (b.Maximum.Y > box.Maximum.Y) box.Maximum.Y = b.Maximum.Y;
+					if (b.Maximum.Z > box.Maximum.Z) box.Maximum.Z = b.Maximum.Z;
+				}
 			}
-			return VisualBounds.Box(box);
+			
+			if (!hasAnyBounds) return VisualBounds.Empty;
+			else return VisualBounds.Box(box);
 		}
 
 		VisualBounds _renderBounds;

--- a/Source/Fuse.Nodes/VisualBounds.uno
+++ b/Source/Fuse.Nodes/VisualBounds.uno
@@ -41,6 +41,11 @@ namespace Fuse
 			nb._box.Maximum = pt;
 			return nb;
 		}
+
+		public static implicit operator Box(VisualBounds vb)
+		{
+			return vb._box;
+		}
 		
 		/**
 			Create a VisualBounds of the rect with two corner points.
@@ -292,6 +297,9 @@ namespace Fuse
 		//uses the W paramete runlike Box.Transform (which may be a defect there)
 		public static Box BoxTransform(Box box, FastMatrix matrix)
 		{
+			if (!matrix.HasNonTranslation)
+				return new Box(box.Minimum + matrix.Translation, box.Maximum + matrix.Translation);
+
 			float3 A = matrix.TransformVector(float3(box.Minimum.X, box.Minimum.Y, box.Minimum.Z));
 			float3 B = matrix.TransformVector(float3(box.Maximum.X, box.Minimum.Y, box.Minimum.Z));
 			float3 C = matrix.TransformVector(float3(box.Maximum.X, box.Maximum.Y, box.Minimum.Z));


### PR DESCRIPTION
This is a back-port of @Duckers's render bounds optimisations for the ElementBatcher. This targets release-1.2 instead of master.

This contains the changes in #280 as well as #289

This PR contains:
- [x] Changelog
- [ ] Tests