### PR TITLE
Fuse.Reactive.Expressions: do not crash on null-input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 1.2
 
+## Reactive Expressions
+- Fixed a bug where `toUpper` and `toLower` would crash on null-input.
+
+
 ## 1.2.1
 
 ### Fuse.Elements

--- a/Source/Fuse.Reactive.Expressions/StringFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/StringFunctions.uno
@@ -9,6 +9,9 @@ namespace Fuse.Reactive
 		public ToUpper([UXParameter("Value")] Expression value): base(value) {}
 		protected override object Compute(object s)
 		{
+			if (s == null)
+				return null;
+
 			return s.ToString().ToUpper();
 		}
 
@@ -25,6 +28,9 @@ namespace Fuse.Reactive
 		public ToLower([UXParameter("Value")] Expression value): base(value) {}
 		protected override object Compute(object s)
 		{
+			if (s == null)
+				return null;
+
 			return s.ToString().ToLower();
 		}
 

--- a/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
@@ -1,0 +1,35 @@
+using Uno;
+using Uno.UX;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Reactive.Test
+{
+	public class StringFunctionsTest : TestBase
+	{
+		[Test]
+		public void Simple()
+		{
+			var p = new UX.StringFunctions.Simple();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				p.Input = "Test";
+				Assert.AreEqual("TEST", p.ToUpper.Value);
+				Assert.AreEqual("test", p.ToLower.Value);
+			}
+		}
+
+		[Test]
+		public void NullInput()
+		{
+			var p = new UX.StringFunctions.Simple();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				p.Input = null;
+				Assert.AreEqual("", p.ToUpper.Value);
+				Assert.AreEqual("", p.ToLower.Value);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.Simple.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.Simple.ux
@@ -1,0 +1,5 @@
+<Panel ux:Class="UX.StringFunctions.Simple">
+	<string ux:Property="Input" />
+	<Text Value="{= toUpper(Property Input)}" ux:Name="ToUpper" />
+	<Text Value="{= toLower(Property Input)}" ux:Name="ToLower" />
+</Panel>


### PR DESCRIPTION
toUpper and toLower UX-expression functions would crash if they were
given null-input. Other UX-expressions seems to generally return null
on null-input, rather than crashing. So let's follow that example.

This fixes issue #367.

This PR contains:
- [x] Changelog
- [x] Tests
