### PR TITLE
Fuse.Elements: fix a typo-bug

### DIFF
--- a/Source/Fuse.Elements/Caching/ElementBatch.uno
+++ b/Source/Fuse.Elements/Caching/ElementBatch.uno
@@ -145,7 +145,7 @@ namespace Fuse.Elements
 			Box box = new Box(float3(0), float3(0));
 			for (var i = 0; i < _elements.Count; i++)
 			{
-				var elm = _elements[0]._elm;
+				var elm = _elements[i]._elm;
 				var lrb = elm.LocalRenderBounds;
 				if (lrb == VisualBounds.Empty) continue;
 				if (lrb == VisualBounds.Infinite) return VisualBounds.Infinite;

--- a/Source/Fuse.Elements/Tests/ElementBatch.Test.uno
+++ b/Source/Fuse.Elements/Tests/ElementBatch.Test.uno
@@ -1,0 +1,69 @@
+using Uno;
+using Uno.Testing;
+using Uno.Collections;
+
+using Fuse.Elements;
+
+using FuseTest;
+
+namespace Fuse.Elements.Test
+{
+	public class ElementBatchTest : TestBase
+	{
+		[Test]
+		public void RenderBounds()
+		{
+			var batcher = new ElementBatcher();
+			var atlas = new ElementAtlas();
+
+			var batch = new ElementBatch(batcher, atlas);
+
+			MockElement parent = new MockElement();
+			var parentTranslation = new Translation() {
+				X = 10,
+				Y = 20
+			};
+			parent.Children.Add(parentTranslation);
+
+			var elements = new MockElement[]
+			{
+				new MockElement() {
+					RenderBounds = VisualBounds.Rect(float2(10, -10), float2(15, 0))
+				},
+				new MockElement() {
+					RenderBounds = VisualBounds.Rect(float2(5, 0), float2(20, 10))
+				}
+			};
+
+			var childTranslation = new Translation() {
+				X = 0,
+				Y = 10
+			};
+			elements[0].Children.Add(childTranslation);
+
+			foreach (var elm in elements)
+			{
+				parent.Children.Add(elm);
+				Assert.IsTrue(atlas.AddElement(elm));
+				batch.AddElement(elm);
+			}
+
+			Assert.AreEqual(5, batch.RenderBounds.FlatRect.Left);
+			Assert.AreEqual(20, batch.RenderBounds.FlatRect.Right);
+
+			Assert.AreEqual(0, batch.RenderBounds.FlatRect.Top);
+			Assert.AreEqual(10, batch.RenderBounds.FlatRect.Bottom);
+
+			// batch.AddElement() appends to the current rect; make
+			// we reproduce the same result when invalidating.
+
+			batch.InvalidateRenderBounds(elements[0]);
+
+			Assert.AreEqual(5, batch.RenderBounds.FlatRect.Left);
+			Assert.AreEqual(20, batch.RenderBounds.FlatRect.Right);
+
+			Assert.AreEqual(0, batch.RenderBounds.FlatRect.Top);
+			Assert.AreEqual(10, batch.RenderBounds.FlatRect.Bottom);
+		}
+	}
+}

--- a/Source/Fuse.Elements/Tests/Fuse.Elements.Test.unoproj
+++ b/Source/Fuse.Elements/Tests/Fuse.Elements.Test.unoproj
@@ -24,6 +24,7 @@
     "AspectSizing.Test.uno:Source",
     "BoxSizing.Test.uno:Source",
     "Caching.Test.uno:Source",
+    "ElementBatch.Test.uno:Source",
     "ElementBatcher.Test.uno:Source",
     "ElementEventTester.uno:Source",
     "ElementEventTests.uno:Source",


### PR DESCRIPTION
We need to actually take the union of all elements, not element
zero every time.

While we're at it, add a test-case that triggers in this case.

Fixes issue #399

This PR contains:
- [x] Tests
