### PR TITLE
iOS: Remove SetActionStyle on MultiLineTextEdit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## TextView
+- Fixed iOS issue where the return key would display "next" instead of "return".
+
 ## Navigation
 - `Navigator` blocks input to pages while trasitioning to new pages. To get the old behaviour, where input is not blocked, set `<Navigator BlockInput="Never">`.
 

--- a/Source/Fuse.Controls.Native/iOS/TextEdit.uno
+++ b/Source/Fuse.Controls.Native/iOS/TextEdit.uno
@@ -652,18 +652,7 @@ namespace Fuse.Controls.Native.iOS
 
 		TextInputActionStyle ITextEdit.ActionStyle
 		{
-			set
-			{
-				switch(value)
-				{
-					case TextInputActionStyle.Default: SetActionStyle(Handle, extern<int>"UIReturnKeyDefault"); break;
-					case TextInputActionStyle.Done: SetActionStyle(Handle, extern<int>"UIReturnKeyDone"); break;
-					case TextInputActionStyle.Next: SetActionStyle(Handle, extern<int>"UIReturnKeyNext"); break;
-					case TextInputActionStyle.Go: SetActionStyle(Handle, extern<int>"UIReturnKeyGo"); break;
-					case TextInputActionStyle.Search: SetActionStyle(Handle, extern<int>"UIReturnKeySearch"); break;
-					case TextInputActionStyle.Send: SetActionStyle(Handle, extern<int>"UIReturnKeySend"); break;
-				}
-			}
+			set { /* Does not apply to MultilineTextEdit */ }
 		}
 
 		AutoCorrectHint ITextEdit.AutoCorrectHint
@@ -750,13 +739,6 @@ namespace Fuse.Controls.Native.iOS
 		@{
 			::UITextView* textView = (::UITextView*)handle;
 			[textView setKeyboardType:(UIKeyboardType)hint];
-		@}
-
-		[Foreign(Language.ObjC)]
-		static void SetActionStyle(ObjC.Object handle, int style)
-		@{
-			::UITextView* textView = (::UITextView*)handle;
-			[textView setReturnKeyType: (UIReturnKeyType)style];
 		@}
 
 		[Foreign(Language.ObjC)]


### PR DESCRIPTION
ActionStyle is not a part of the TextView public API. This was here due to legacy code before the split into TextInput and TextView

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
