### PR TITLE
add benchmark application

### DIFF
--- a/Tests/Benchmark/Benchmark.unoproj
+++ b/Tests/Benchmark/Benchmark.unoproj
@@ -1,0 +1,12 @@
+{
+  "Packages": [
+    "Fuse",
+    "FuseJS",
+  ],
+  "Includes": [
+    "Utils/FrameIndex.uno",
+    "Utils/ProfilePanel.uno",
+    "Utils/TestRunner.uno",
+    "MainView.ux"
+  ]
+}

--- a/Tests/Benchmark/MainView.ux
+++ b/Tests/Benchmark/MainView.ux
@@ -1,0 +1,12 @@
+<App>
+	<TestRunner>
+
+		<ProfilePanel ux:Template="Text Rendering" FrameCount="100">
+			<Text ux:Name="_text" Value="Frame: {frameIndex()}" />
+			<WhileTrue Value="true">
+				<Cycle Target="_text.Color" Offset="0, 0, 0, 1" Base="1, 0, 0, 0" Low="0" High="1" Frequency="0.5"/>
+			</WhileTrue>
+		</ProfilePanel>
+
+	</TestRunner>
+</App>

--- a/Tests/Benchmark/Utils/FrameIndex.uno
+++ b/Tests/Benchmark/Utils/FrameIndex.uno
@@ -1,0 +1,28 @@
+using Uno;
+using Uno.UX;
+
+using Fuse;
+using Fuse.Reactive;
+using Fuse.Triggers;
+
+[UXFunction("frameIndex")]
+public class FrameIndex: Fuse.Reactive.Expression, IDisposable
+{
+	IListener _listener;
+	public override IDisposable Subscribe(IContext context, IListener listener)
+	{
+		_listener = listener;
+		UpdateManager.AddAction(OnUpdate);
+		return this;
+	}
+
+	public void Dispose()
+	{
+		UpdateManager.RemoveAction(OnUpdate);
+	}
+
+	void OnUpdate()
+	{
+		_listener.OnNewData(this, UpdateManager.FrameIndex);
+	}
+}

--- a/Tests/Benchmark/Utils/ProfilePanel.uno
+++ b/Tests/Benchmark/Utils/ProfilePanel.uno
@@ -1,0 +1,79 @@
+using Fuse;
+using Fuse.Controls;
+using Fuse.Elements;
+
+using Uno;
+using Uno.Diagnostics;
+
+class ProfilePanel : LayoutControl
+{
+	public ProfilePanel()
+	{
+		CachingMode = CachingMode.Never;
+	}
+
+	public int FrameCount
+	{
+		get { return _frameCount; }
+		set
+		{
+			_frameCount = Math.Max(value, 1);
+		}
+	}
+
+	int _frames;
+	int _frameCount = 100;
+	double _drawMinTime, _drawMaxTime, _drawTotalTime;
+
+	protected override void OnRooted()
+	{
+		base.OnRooted();
+
+		_drawMinTime = float.MaxValue;
+		_drawMaxTime = 0;
+		_drawTotalTime = 0;
+
+		UpdateManager.AddAction(Update);
+	}
+
+	protected override void OnUnrooted()
+	{
+		base.OnUnrooted();
+		UpdateManager.RemoveAction(Update);
+	}
+
+	void Report()
+	{
+		var name = Name != null ? Name.ToString() : "<Unnamed>";
+		Debug.Log(string.Format("Results for \"{0}\", {1} frames:", name, _frames));
+		Debug.Log(string.Format("\tDraw MinTime: {1} ms", name, _drawMinTime * 1000.0));
+		Debug.Log(string.Format("\tDraw MaxTime: {1} ms", name, _drawMaxTime * 1000.0));
+		Debug.Log(string.Format("\tDraw AvgTime: {1} ms", name, (_drawTotalTime / _frames) * 1000.0));
+	}
+
+	void Update()
+	{
+		if (_frames == _frameCount)
+		{
+			Report();
+
+			var testRunner = GetNearestAncestorOfType<TestRunner>();
+			if (testRunner != null)
+				testRunner.OnTestFinished();
+		}
+
+		_frames++;
+	}
+
+	protected override void DrawWithChildren(DrawContext dc)
+	{
+		var startTime = Uno.Diagnostics.Clock.GetSeconds();
+		base.DrawWithChildren(dc);
+		var endTime = Uno.Diagnostics.Clock.GetSeconds();
+
+		var time = endTime - startTime;
+		_drawMinTime = Math.Min(_drawMinTime, time);
+		_drawMaxTime = Math.Max(_drawMaxTime, time);
+		_drawTotalTime += time;
+	}
+}

--- a/Tests/Benchmark/Utils/TestRunner.uno
+++ b/Tests/Benchmark/Utils/TestRunner.uno
@@ -1,0 +1,47 @@
+using Fuse;
+using Fuse.Controls;
+using Fuse.Elements;
+
+using Uno.Diagnostics;
+
+class TestRunner : ContentControl
+{
+	int _testIndex;
+
+	void StartTest(int testIndex)
+	{
+		var template = Templates[testIndex];
+		_testIndex = testIndex;
+
+		var test = (Element)template.New();
+		var testName = test.Name != null ? test.Name.ToString() : "<Unnamed>";
+		Debug.Log("Starting test: " + testName);
+		Content = test;
+	}
+
+	void StopTest()
+	{
+		Content = null;
+		Uno.Runtime.Implementation.Internal.Unsafe.Quit();
+	}
+
+	protected override void OnRooted()
+	{
+		base.OnRooted();
+		if (Templates.Count > 0)
+			StartTest(0);
+	}
+
+	protected override void OnUnrooted()
+	{
+		base.OnUnrooted();
+	}
+
+	public void OnTestFinished()
+	{
+		if (Templates.Count > _testIndex + 1)
+			StartTest(_testIndex + 1);
+		else
+			StopTest();
+	}
+}


### PR DESCRIPTION
It's often useful to keep track of some performance cases over time,
so let's add a framework where it's easy to add cases and run them.

This is a pretty basic app, and we should probably need to both add
counters and tweak current functionality before this is very useful.
But at least it's a start.