### PR TITLE
Fix incorrect check for mono

### DIFF
--- a/Source/Fuse.Reactive.JavaScript/FuseJS/Http.uno
+++ b/Source/Fuse.Reactive.JavaScript/FuseJS/Http.uno
@@ -321,7 +321,7 @@ namespace Fuse.Reactive.FuseJS
 			{
 				if (args.Length > 0)
 				{
-					if defined(!DesignMode) // NOTE: Hack to disable cache for mono. They don't have support for it :(
+					if defined(!(HOST_OSX && DOTNET)) // NOTE: Hack to disable cache for mono. They don't have support for it :(
 					{
 						_req.EnableCache((bool)args[0]);
 					}


### PR DESCRIPTION
Due to mono throwing a NotImplentedException when trying to set cache behavior, the FuseJS/Http module disables caching for mono targets.

However, it only checks if we're running in preview, resulting in a crash when running dotnet build on osx, as well as disabling cache on non-mono platforms that actually support it.

This PR replaces the check for preview with a check for `HOST_OSX && DOTNET`, which should only trigger when running in mono on OSX.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
