### PR TITLE
Reduce warnings

### DIFF
--- a/Source/Fuse.Common/Tests/FuseTest/TestRootNode.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestRootNode.uno
@@ -440,10 +440,4 @@ namespace FuseTest
 			AppBase.TestSetRootViewport( null );
 		}
 	}
-	
-	[Flags]
-	public enum EventFlags
-	{
-		None = 0,
-	}
 }

--- a/Source/Fuse.Controls.Panels/Tests/Grid.Test.uno
+++ b/Source/Fuse.Controls.Panels/Tests/Grid.Test.uno
@@ -459,7 +459,7 @@ namespace Fuse.Controls.Test
 				root.Layout(int2(1000));
 				Assert.AreEqual(float2(1000,200),g.G.ActualSize);
 				
-				while(g.G.ZOrderChildCount > 0)
+				while (g.G.HasVisualChildren)
 					g.G.Children.Remove(g.G.FirstChild<Visual>());
 				root.Layout(int2(1000));
 				Assert.AreEqual(float2(1000,0),g.G.ActualSize);

--- a/Source/Fuse.Controls.ScrollView/ScrollViewPager.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollViewPager.uno
@@ -260,7 +260,6 @@ namespace Fuse.Controls
 			_lastActivitySizing = UpdateManager.FrameIndex;
 			
 			_pendingSizing = false;
-			var range = _scrollable.MaxScroll - _scrollable.MinScroll;
 			var pages = _scrollable.ContentMarginSize / _scrollable.ActualSize;
 
 			var scalarPages = _scrollable.ToScalarPosition(pages);

--- a/Source/Fuse.Controls/Tests/Panel.Test.uno
+++ b/Source/Fuse.Controls/Tests/Panel.Test.uno
@@ -304,13 +304,13 @@ namespace Fuse.Controls.Test
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
 				var order = new Panel[]{ p.B2, p.B1, p.S2, p.S1, p.S3, p.O2, p.O1 };
-				for (int i=0; i < p.ZOrderChildCount; i++)
+				for (int i=0; i < p.VisualChildCount ; i++)
 					Assert.AreEqual(order[i], p.GetZOrderChild(i));
-					
+
 				p.S1.ZOffset = 2;
 				p.O1.ZOffset = -1;
 				order = new Panel[]{ p.B2, p.B1, p.S2, p.S3, p.S1, p.O1, p.O2 };
-				for (int i=0; i < p.ZOrderChildCount; i++)
+				for (int i=0; i < p.VisualChildCount ; i++)
 					Assert.AreEqual(order[i], p.GetZOrderChild(i));
 			}
 		}

--- a/Source/Fuse.Nodes/Visual.ZOrder.Obsolete.uno
+++ b/Source/Fuse.Nodes/Visual.ZOrder.Obsolete.uno
@@ -6,9 +6,6 @@ namespace Fuse
 {
 	public partial class Visual
 	{
-        /** Whether this visual has any visual child nodes. */
-        public bool HasVisualChildren { get { return VisualChildCount > 0; } }
-
 		[Obsolete("Use FirstChild<Visual>() instead")]
 		public Visual FirstVisualChild
 		{ 

--- a/Source/Fuse.Nodes/Visual.ZOrder.Obsolete.uno
+++ b/Source/Fuse.Nodes/Visual.ZOrder.Obsolete.uno
@@ -54,11 +54,5 @@ namespace Fuse
 				return VisualChildCount;
 			}
 		}
-
-        [Obsolete("Iterate over ZOrder instead")]
-		public Visual GetZOrderChild(int index)
-		{
-			return GetCachedZOrder()[index];
-		}
-    }
+	}
 }

--- a/Source/Fuse.Nodes/Visual.ZOrder.uno
+++ b/Source/Fuse.Nodes/Visual.ZOrder.uno
@@ -135,5 +135,8 @@ namespace Fuse
 				return a.ZOffset > b.ZOffset ? 1 : -1;
 			return a._naturalZOrder - b._naturalZOrder;
 		}
+
+		/** Whether this visual has any visual child nodes. */
+		public bool HasVisualChildren { get { return VisualChildCount > 0; } }
 	}
 }

--- a/Source/Fuse.Nodes/Visual.ZOrder.uno
+++ b/Source/Fuse.Nodes/Visual.ZOrder.uno
@@ -138,5 +138,15 @@ namespace Fuse
 
 		/** Whether this visual has any visual child nodes. */
 		public bool HasVisualChildren { get { return VisualChildCount > 0; } }
+
+		/**  Get the Visual for a given z-order
+
+			This method might have a surprisingly high performance impact; avoid calling it in
+			performance sensitive code-paths.
+		*/
+		public Visual GetZOrderChild(int index)
+		{
+			return GetCachedZOrder()[index];
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/EachTest.uno
@@ -95,7 +95,7 @@ namespace Fuse.Reactive.Test
 			using (var root = TestRootPanel.CreateWithChild(e))
 			{
 				root.StepFrameJS();
-				Assert.AreEqual(30,e.C1.ZOrderChildCount);
+				Assert.AreEqual(30,e.C1.VisualChildCount);
 				Assert.AreEqual("5", (e.C1.GetVisualChildImpl(5) as Text).Value);
 
 				//do in a loop to try and catch a few race conditions
@@ -105,16 +105,16 @@ namespace Fuse.Reactive.Test
 				{
 					e.CallAdd.Perform();
 					root.StepFrameJS();
-					Assert.AreEqual(baseCount+1,e.C1.ZOrderChildCount);
+					Assert.AreEqual(baseCount+1,e.C1.VisualChildCount);
 					Assert.AreEqual("" + (step+5), (e.C1.GetVisualChildImpl(5) as Text).Value);
 					
 					e.CallRemove.Perform();
 					root.StepFrameJS();
-					Assert.AreEqual(baseCount,e.C1.ZOrderChildCount);
+					Assert.AreEqual(baseCount,e.C1.VisualChildCount);
 					
 					e.CallRemoveAt.Perform();
 					root.StepFrameJS();
-					Assert.AreEqual(baseCount-1,e.C1.ZOrderChildCount);
+					Assert.AreEqual(baseCount-1,e.C1.VisualChildCount);
 					
 					//two removal + one addiiton
 					baseCount--;
@@ -124,7 +124,7 @@ namespace Fuse.Reactive.Test
 				
 				e.CallClear.Perform();
 				root.StepFrameJS();
-				Assert.AreEqual(0,e.C1.ZOrderChildCount);
+				Assert.AreEqual(0,e.C1.VisualChildCount);
 			}
 		}
 		
@@ -139,7 +139,7 @@ namespace Fuse.Reactive.Test
 			{
 				root.StepFrameJS();
 				
-				Assert.AreEqual(4,e.C1.ZOrderChildCount);
+				Assert.AreEqual(4,e.C1.VisualChildCount);
 				Assert.AreEqual(e.C2, e.C1.GetVisualChildImpl(0));
 				Assert.AreEqual(new Selector("Q0"), e.C1.GetVisualChildImpl(1).Name);
 				Assert.AreEqual(new Selector("Q1"), e.C1.GetVisualChildImpl(2).Name);
@@ -148,11 +148,11 @@ namespace Fuse.Reactive.Test
 				e.CallRemove.Perform();
 				e.CallRemove.Perform();
 				root.StepFrameJS();
-				Assert.AreEqual(2,e.C1.ZOrderChildCount);
+				Assert.AreEqual(2,e.C1.VisualChildCount);
 				
 				e.CallAdd.Perform();
 				root.StepFrameJS();
-				Assert.AreEqual(3,e.C1.ZOrderChildCount);
+				Assert.AreEqual(3,e.C1.VisualChildCount);
 				Assert.AreEqual(e.C2, e.C1.GetVisualChildImpl(0));
 				Assert.AreEqual(new Selector("Q2"), e.C1.GetVisualChildImpl(1).Name);
 				Assert.AreEqual(e.C3, e.C1.GetVisualChildImpl(2));
@@ -492,8 +492,8 @@ namespace Fuse.Reactive.Test
 
 		static Visual[] GetZChildren(Visual root)
 		{
-			var list = new Visual[root.ZOrderChildCount];
-			for (int i=0; i < root.ZOrderChildCount; ++i)
+			var list = new Visual[root.VisualChildCount];
+			for (int i=0; i < root.VisualChildCount; ++i)
 				list[i] = root.GetZOrderChild(i);
 			return list;
 		}

--- a/Source/Fuse.Reactive.Bindings/Tests/MatchCaseTest.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/MatchCaseTest.uno
@@ -16,7 +16,7 @@ namespace Fuse.Reactive.Test
 			using (var root = TestRootPanel.CreateWithChild(e))
 			{
 				root.StepFrameJS();
-				Assert.AreEqual(2, e.Container.ZOrderChildCount);
+				Assert.AreEqual(2, e.Container.VisualChildCount);
 				Assert.AreEqual("OneTwo", GetText(e.Container));
 			}
 		}

--- a/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/Various.uno
@@ -294,7 +294,7 @@ namespace Fuse.Reactive.Test
 			{
 				root.StepFrameJS();
 
-				Assert.IsTrue(e.items.ZOrderChildCount > 0);
+				Assert.IsTrue(e.items.VisualChildCount > 0);
 				AssertTextCorrect(e.items);
 			}
 		}
@@ -382,7 +382,7 @@ namespace Fuse.Reactive.Test
 			{
 				root.StepFrameJS();
 				Assert.AreEqual(true, e.Container.HasVisualChildren);
-				Assert.AreEqual(1, e.Container.ZOrderChildCount);
+				Assert.AreEqual(1, e.Container.VisualChildCount);
 
 				var text = e.Container.GetZOrderChild(0) as Text;
 				Assert.AreNotEqual(null, text);
@@ -441,7 +441,7 @@ namespace Fuse.Reactive.Test
 			using (var root = TestRootPanel.CreateWithChild(e))
 			{
 				root.StepFrameJS();
-				Assert.AreEqual(10001, e.ZOrderChildCount);
+				Assert.AreEqual(10001, e.VisualChildCount);
 			}
 		}
 


### PR DESCRIPTION
Here's a few patches to reduce warnings when building tests.

This also un-obsolete Visual.GetZOrderChild, because it's needed sometimes, and there's non-internal replacement.