### PR TITLE
test.sh: remove .exe to call x-platform wrapper, fixes issue on macOS

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,6 @@ set -e
 
 ROOT=`dirname $0`
 
-"$ROOT/Stuff/uno.exe" test "$ROOT/Source"
+"$ROOT/Stuff/uno" test "$ROOT/Source"
 
 "$ROOT/Tests/package-compilation.sh"


### PR DESCRIPTION
This fixes the script on macOS after it broke in 952a37ba33c939f7bae29a2b3e1dd148ece1f78f.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
