### PR TITLE
Fix filesystem docs: copy

### DIFF
--- a/Source/Fuse.FileSystem/FileSystemModule.uno
+++ b/Source/Fuse.FileSystem/FileSystemModule.uno
@@ -656,7 +656,7 @@ namespace Fuse.FileSystem
 
 
 		/**
-			@scriptmethod move(source, destination)
+			@scriptmethod copy(source, destination)
 			@param source (String) Source path
 			@param destination (String) Destination path
 			@return Promise of nothing


### PR DESCRIPTION
The `copy` method had mistakenly be called `move` in the comments section, so it never appeared on the docs. Fixed that.

This PR contains:
- [ ] Changelog
- [x] Documentation
- [ ] Tests
