### PR TITLE
Handle AndroidSystemFont Default being null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Fonts
+- Fixed bug where the default font on Android could end up being null.
+
 ## ViewHandle
 - Fixed issue where Images with Mask could end up not displaying. This happend due to unnecessary invalidation of the implicit native GraphicsView in the app root. This invalidation was introduced when the Surface API was implemented for native. Invalidation is now opt-in on ViewHandle
 

--- a/Source/Fuse.Common/Internal/AndroidSystemFont.uno
+++ b/Source/Fuse.Common/Internal/AndroidSystemFont.uno
@@ -88,7 +88,13 @@ namespace Fuse.Internal
 		{
 			var result = new List<FontFaceDescriptor>();
 			result.Add(new FontFaceDescriptor(file, 0));
-			result.AddRange(Get(null, Fuse.SystemFont.Style.Normal, Fuse.SystemFont.Weight.Normal));
+
+			var normal = Get(null, Fuse.SystemFont.Style.Normal, Fuse.SystemFont.Weight.Normal);
+			if (normal != null)
+			{
+				result.AddRange(normal);
+			}
+
 			return result;
 		}
 


### PR DESCRIPTION
`Default` returns null when `_families.Count == 0`, however
`GetFallback` always passed the result of `Default` straight to
`AddRange` which on some devices (Android Oreo in this case) caused
the app to crash.

Havent added a changelog as this as a bugfix. However it may be worth one as it fixes Fuse builds for android 8
