### PR TITLE
 JavaScript: optional explicit require() of UX symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## JavaScript: Optional explicit requrie() of UX symbols
+- Symbols declared with `ux:Name`, `ux:Dependency` or `dep` are now also available to `require()` for `<JavaScript>` modules using the `ux:` prefix. This allows us to write code that plays nicer with transpilers and linters. Using require for names declared in UX is optional, but may make the code more readable and maintainable, e.g. `var router = require("ux:router")` over just using `router` with no declaration.
+
 ## Fonts
 - Fixed bug where the default font on Android could end up being null.
 

--- a/Source/Fuse.Reactive.JavaScript/JavaScript.uno
+++ b/Source/Fuse.Reactive.JavaScript/JavaScript.uno
@@ -24,7 +24,7 @@ namespace Fuse.Reactive
 		static ThreadWorker _worker;
 		internal static ThreadWorker Worker { get { return _worker; } }
 
-		readonly NameTable _nameTable;
+		internal readonly NameTable _nameTable;
 		RootableScriptModule _scriptModule;
 		internal RootableScriptModule ScriptModule { get { return _scriptModule; } }
 

--- a/Source/Fuse.Reactive.JavaScript/ModuleInstance.uno
+++ b/Source/Fuse.Reactive.JavaScript/ModuleInstance.uno
@@ -24,6 +24,14 @@ namespace Fuse.Reactive
 		// JS thread
 		void Evaluate()
 		{
+			var nt = _js._nameTable;
+			while (nt != null)
+			{
+				for (int i = 0; i < nt.Entries.Length; ++i)
+					_deps.Add(nt.Entries[i], _worker.Unwrap(nt.Objects[i]));
+				nt = nt.ParentTable;
+			}
+
 			_js.ScriptModule.Dependencies = _deps;
 			_dc = _worker.Reflect(EvaluateExports());
 			UpdateManager.PostAction(SetDataContext);

--- a/Source/Fuse.Reactive.JavaScript/RootableScriptModule.uno
+++ b/Source/Fuse.Reactive.JavaScript/RootableScriptModule.uno
@@ -33,6 +33,11 @@ namespace Fuse.Reactive
 
 		internal Dictionary<string, object> Dependencies;
 
+		protected override Dictionary<string, object> GenerateRequireTable(Context c)
+		{
+			return Dependencies;
+		}
+
 		protected override string GenerateArgs(Context c, ModuleResult result, List<object> args)
 		{
 			var argsString = base.GenerateArgs(c, result, args);
@@ -41,17 +46,6 @@ namespace Fuse.Reactive
 			{
 				argsString += ", " + dep.Key;
 				args.Add(dep.Value);
-			}
-
-			var nt = _names;
-			while (nt != null)
-			{
-				for (int i = 0; i < nt.Entries.Length; ++i)
-				{
-					argsString += ", " + nt.Entries[i];
-					args.Add(_worker.Unwrap(nt.Objects[i]));
-				}
-				nt = nt.ParentTable;
 			}
 
 			return argsString;

--- a/Source/Fuse.Reactive.JavaScript/Tests/Fuse.Reactive.JavaScript.Test.unoproj
+++ b/Source/Fuse.Reactive.JavaScript/Tests/Fuse.Reactive.JavaScript.Test.unoproj
@@ -27,6 +27,7 @@
   ],
   "Includes": [
     "*",
+    "OptionalExplicit.js:Bundle",
     "Assets/hello.txt:Bundle",
     "Assets/test.png:Bundle",
   ],

--- a/Source/Fuse.Reactive.JavaScript/Tests/OptionalExplicit.js
+++ b/Source/Fuse.Reactive.JavaScript/Tests/OptionalExplicit.js
@@ -1,0 +1,4 @@
+
+// This file is here to test that OptionalExplicit.ux takes this file as
+// precedence over a dependency with the same name.
+exports.haha = 1337;

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/OptionalExplicit.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/OptionalExplicit.ux
@@ -1,0 +1,33 @@
+<Panel ux:Class="UX.OptionalExplicit">
+	<Router ux:Name="router" />
+	<JavaScript>
+		exports.foo = 123
+		// should not be reached below, as there is a bundled file that matches
+		// this path
+		exports.OptionalExplicit = 777 
+	</JavaScript>
+	<JavaScript dep:bar="{foo}">
+		var OptionalExplicit = require("OptionalExplicit")
+		var foo = require("ux:router")
+		var maa = require("ux:bar")
+		if (!(foo.goBack instanceof Function)) { throw new Error(); }
+		if (maa !== 123) { throw new Error() }
+
+		// would crash if wrong symbol is resolved
+		if (OptionalExplicit.haha !== 1337) { throw new Error() }
+		exports.success = 1
+	</JavaScript>
+	<Text ux:Name="t" Value="{success}" />
+	
+	<Panel ux:Class="OESub">
+		<Router ux:Dependency="quirk"/>
+		<JavaScript>
+			var qfoo = require("ux:quirk")
+			if (!(qfoo.goBack instanceof Function)) { throw new Error(); }
+			exports.success = 1
+		</JavaScript>
+		<Text ux:Name="t" Value="{success}" />
+	</Panel>
+	<OESub quirk="router" ux:Name="q"/>
+	
+</Panel>

--- a/Source/Fuse.Reactive.JavaScript/Tests/Various.Test.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/Various.Test.uno
@@ -541,5 +541,15 @@ namespace Fuse.Reactive.Test
 				Assert.AreEqual("Bar", e.Text.Value);
 			}
 		}
+		
+		[Test]
+		public void OptionalExplicitTest()
+		{
+			var e = new UX.OptionalExplicit();
+			var root = TestRootPanel.CreateWithChild(e);
+			root.StepFrameJS();
+			Assert.AreEqual("1", e.t.Value);
+			Assert.AreEqual("1", e.q.t.Value);
+		}
 	}
 }

--- a/Source/Fuse.Scripting/ScriptModule.Evaluate.uno
+++ b/Source/Fuse.Scripting/ScriptModule.Evaluate.uno
@@ -57,13 +57,20 @@ namespace Fuse.Scripting
 			CallModuleFunc(moduleFunc, args.ToArray());
 		}
 
+		protected virtual Dictionary<string, object> GenerateRequireTable(Context c)
+		{
+			return null;
+		}
+
 		protected virtual string GenerateArgs(Context c, ModuleResult result, List<object> args)
 		{
 			var module = result.Object;
 
+			var rt = GenerateRequireTable(c);
+
 			args.Add(module);
 			args.Add(module["exports"]);
-			args.Add((Callback)new RequireContext(c, this, result).Require);
+			args.Add((Callback)new RequireContext(c, this, result, rt).Require);
 
 			return "module, exports, require";
 		}

--- a/Source/Fuse.Scripting/ScriptModule.Require.uno
+++ b/Source/Fuse.Scripting/ScriptModule.Require.uno
@@ -16,12 +16,14 @@ namespace Fuse.Scripting
 			readonly Context _c;
 			readonly ModuleResult _dependant;
 			readonly ScriptModule _m;
+			readonly Dictionary<string, object> _rt;
 
-			public RequireContext(Context c, ScriptModule m, ModuleResult dependant)
+			public RequireContext(Context c, ScriptModule m, ModuleResult dependant, Dictionary<string, object> rt)
 			{
 				_c = c;
 				_m = m;
 				_dependant = dependant;
+				_rt = rt;
 			}
 
 			public object Require(object[] args)
@@ -45,8 +47,19 @@ namespace Fuse.Scripting
 
 				if (module == null)
 				{
+					const string uxPrefix = "ux:";
+					if (id.StartsWith(uxPrefix))
+					{
+						if (_rt == null)
+							throw new Error( "require(): unable to resolve ux: prefixes: " + id );
+							
+						object res;
+						if (_rt.TryGetValue(id.Substring(uxPrefix.Length), out res)) return res;
+						
+						throw new Error("require(): ux name not found: " + id);
+					}
+					
 					var mod = _m.TryResolve(path, isFile);
-
 					if (mod == null)
 						throw new Error("require(): module not found: " + id);
 


### PR DESCRIPTION
Symbols declared with ux:Name, ux:Dependency or dep are in this PR also available to require() for <JavaScript> modules using a `ux:` prefix.

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
