### PR TITLE
Two-way binding of Router/Model pages. GoBack support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Removed `PageControl.TransitionEasing` and `Pagecontrol.TransitionDuration`. These were deprecated over a year ago. Use a `NavigationMotion` object instead with `GotoEasing` and `GotoDuration` properties.
 - Removed `PageIndicator.DotTemplate` and `PageIndicator.DotFactor`. These were deprecated over a year ago. Use a `ux:Tempate="Dot"` child instead.
 - Removed `Navigation.PageData`. It was always meant to be internal and has no public use.
+- Allowed `GoBack` and `WhileCanGoBack` on the router to properly interact with bound observable/model `PageHistory`
 
 ## ScriptClass
 - Added ScriptPromise. This addes support for passing Promises between Uno and the scripting engine. Very useful when dealing with async stuff and JavaScript

--- a/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
@@ -1,0 +1,249 @@
+using Uno.Collections;
+
+using Fuse;
+using Fuse.Reactive;
+
+namespace FuseTest
+{
+	/**
+		An implementation of an IObservable for Uno-level data.
+		
+		NOTE: Taken from the charting in premiumlibs. Stuck in FuseTest for now since there is now use in fuselibs yet other than for testing.
+	*/
+	public abstract class ObservableData : IObservable
+	{
+		List<IObserver> _observers;
+		
+		ISubscription IObservable.Subscribe(IObserver observer)
+		{
+			if (_observers == null)
+				_observers = new List<IObserver>();
+		
+			var wasNone = _observers.Count == 0;
+			_observers.Add(observer);
+			
+			if (wasNone) //done after Add to ensure HasSubscription is true
+				OnSubscription();
+				
+			OnSubscribe(observer);
+			
+			return new Subscription{ Source = this, Observer = observer };
+		}
+		
+		void Unsubscribe(IObserver observer)
+		{
+			_observers.Remove(observer);
+			
+			if (_observers.Count == 0)
+				OnUnsubscription();
+		}
+
+		class Subscription : ISubscription
+		{
+			public ObservableData Source;
+			public IObserver Observer;
+			
+			public void Dispose()
+			{
+				Source.Unsubscribe(Observer);
+			}
+			
+			public void ClearExclusive() { Fuse.Diagnostics.InternalError( "ReadOnly array", this ); }
+			public void SetExclusive(object newValue) { Fuse.Diagnostics.InternalError( "ReadOnly array", this ); }
+			public void ReplaceAllExclusive(IArray values) { Fuse.Diagnostics.InternalError( "ReadOnly array", this ); }
+		}
+		
+		virtual protected void OnSubscription() { }
+		virtual protected void OnUnsubscription() { }
+
+		protected bool HasSubscription
+		{
+			get { return _observers != null && _observers.Count > 0; }
+		}
+		
+		virtual protected void OnSubscribe(IObserver observer)
+		{
+			observer.OnNewAll(this);
+		}
+		
+		//UNO: Workaround some problems in the interface/abstract class
+		abstract protected int GetLength();
+		abstract protected object GetItem(int index);
+		int IArray.Length { get { return GetLength();} }
+		object IArray.this[int index] { get { return GetItem(index); } }
+		
+		protected void TriggerNewAll()
+		{
+			if (_observers != null)
+			{
+				for (int i=0; i < _observers.Count; ++i)
+					_observers[i].OnNewAll(this);
+			}
+		}
+		
+		protected void TriggerClear()
+		{
+			if (_observers != null)
+			{
+				for (int i=0; i < _observers.Count; ++i)
+					_observers[i].OnClear();
+			}
+		}
+		
+		protected void TriggerSet(object value)
+		{
+			if (_observers != null)
+			{
+				for (int i=0; i < _observers.Count; ++i)
+					_observers[i].OnSet(value);
+			}
+		}
+		
+		protected void TriggerAdd(object value)
+		{
+			if (_observers != null)
+			{
+				for (int i=0; i < _observers.Count; ++i)
+					_observers[i].OnAdd(value);
+			}
+		}
+		
+		protected void TriggerRemoveAt(int index)
+		{
+			if (_observers != null)
+			{
+				for (int i=0; i < _observers.Count; ++i)
+					_observers[i].OnRemoveAt(index);
+			}
+		}
+		
+		protected void TriggerInsertAt(int index, object value)
+		{
+			if (_observers != null)
+			{
+				for (int i=0; i < _observers.Count; ++i)
+					_observers[i].OnInsertAt(index, value);
+			}
+		}
+		
+		protected void TriggerNewAt(int index, object value)
+		{
+			if (_observers != null)
+			{
+				for (int i=0; i < _observers.Count; ++i)
+					_observers[i].OnNewAt(index, value);
+			}
+		}
+		
+		protected void TriggerFail(string message)
+		{
+			if (_observers != null)
+			{
+				for (int i=0; i < _observers.Count; ++i)
+					_observers[i].OnFailed(message);
+			}
+		}
+	}
+	
+	/**
+		A typed observable list. Only the owner can modify the list, for subscribers it is readonly.
+	*/
+	public class ReadOnlyObservableList<T> : ObservableData
+	{
+		List<T> _values = new List<T>();
+		public void ReplaceAll(T[] values)
+		{
+			_values.Clear();
+			_values.AddRange(values);
+			TriggerNewAll();
+		}
+		
+		public void Clear()
+		{
+			_values.Clear();
+			TriggerClear();
+		}
+		
+		public void Add(T obj)
+		{
+			_values.Add(obj);
+			TriggerAdd(obj);
+		}
+		
+		public void RemoveAt(int index)
+		{
+			_values.RemoveAt(index);
+			TriggerRemoveAt(index);
+		}
+		
+		public void Insert(int index, T value)
+		{
+			_values.Insert(index, value);
+			TriggerInsertAt(index, value);
+		}
+		
+		public void Replace(int index, T value)
+		{
+			_values.RemoveAt(index);
+			_values.Insert(index, value);
+			TriggerNewAt(index, value);
+		}
+		
+		protected override int GetLength()
+		{
+			return _values.Count;
+		}
+		
+		protected override object GetItem(int index)
+		{
+			return _values[index];
+		}
+		
+		public int Count { get { return _values.Count; } }
+		public T this[int index] { get { return _values[index]; } }
+	}
+	
+	/**
+		A typed observable for a single data object. Only the owner can modify the value, for subscribers it is readonly.
+	*/
+	public class ReadOnlyObservableData<T> : ObservableData where T : object
+	{
+		public ReadOnlyObservableData() { }
+		
+		public ReadOnlyObservableData( T initialValue )
+		{
+			_value = initialValue;
+		}
+		
+		protected override void OnSubscribe(IObserver observer)
+		{
+			observer.OnSet(_value);
+		}
+		
+		T _value;
+		public void Set(T value)
+		{
+			_value = value;
+			TriggerSet(_value);
+		}
+		
+		public T Value { get { return _value; } }
+		
+		public void Clear()
+		{
+			_value = null;
+			TriggerClear();
+		}
+		
+		protected override int GetLength()
+		{
+			return _value == null ? 0 : 1;
+		}
+		
+		protected override object GetItem(int index)
+		{
+			return _value;
+		}
+	}
+	
+}

--- a/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
@@ -8,7 +8,7 @@ namespace FuseTest
 	/**
 		An implementation of an IObservable for Uno-level data.
 		
-		NOTE: Taken from the charting in premiumlibs. Stuck in FuseTest for now since there is now use in fuselibs yet other than for testing.
+		NOTE: Taken from the charting in premiumlibs. Stuck in FuseTest for now since there is no use in fuselibs yet other than for testing.
 	*/
 	public abstract class ObservableData : IObservable
 	{

--- a/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
@@ -39,10 +39,17 @@ namespace Fuse.Controls
 			
 			if (_pageHistory == null)
 				return;
-				
+			
 			var obs = _pageHistory as IObservable;
 			if (obs != null)
+			{
 				_pageHistorySubscription = obs.Subscribe(this);
+				AncestorRouterPage.ChildRouterPages.Attach( obs );
+			}
+			else
+			{
+				Fuse.Diagnostics.UserError( "PageHistory expects an observable array. It will not work correctly otherwise", this );
+			}
 				
 			_curPageIndex = -1;
 			FullUpdatePages(UpdateFlags.ForceGoto);

--- a/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
@@ -170,4 +170,5 @@ namespace Fuse.Controls
 			return n.Properties.Get(_pageContextProperty);
 		}
 	}
+	
 }

--- a/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
@@ -47,8 +47,12 @@ namespace Fuse.Controls
 				
 			_curPageIndex = -1;
 			FullUpdatePages(UpdateFlags.ForceGoto);
-			
-			//TODO: Unroot needs to detach
+		}
+		
+		void OnPageHistoryUnrooted()
+		{
+			if (AncestorRouterPage != null)
+				AncestorRouterPage.ChildRouterPages.Detach();
 		}
 		
 		[Uno.Flags]
@@ -72,12 +76,6 @@ namespace Fuse.Controls
 			return path;
 		}
 
-		[Uno.Obsolete]
-		protected void UpdateContextData( Visual page, object data )
-		{
-			PageData.GetOrCreate(page).SetContext(data);
-		}
-		
 		void FullUpdatePages(UpdateFlags flags = UpdateFlags.None)
 		{
 			string path = null, param = null;
@@ -131,7 +129,7 @@ namespace Fuse.Controls
 			
 			(this as IRouterOutlet).Goto( rPage, trans, op, "" );
 			if (rPage.Visual != null)
-				UpdateContextData( rPage.Visual, data );
+				PageData.GetOrCreate(rPage.Visual).SetContext(data);
 			
 			_curPageIndex = pageNdx;
 		}

--- a/Source/Fuse.Controls.Navigation/NavigationControl.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.uno
@@ -207,7 +207,7 @@ namespace Fuse.Controls
 		
 		protected override void OnUnrooted()
 		{
-			base.OnUnrooted();
+			OnPageHistoryUnrooted();
 			
 			if (AncestorPage != null)
 			{
@@ -224,6 +224,8 @@ namespace Fuse.Controls
 					continue;
 				CleanupTriggers(c, pd);
 			}
+			
+			base.OnUnrooted();
 		}
 		
 		void CleanupTriggers(Element page, ControlPageData data)

--- a/Source/Fuse.Controls.Navigation/Navigator.uno
+++ b/Source/Fuse.Controls.Navigation/Navigator.uno
@@ -188,11 +188,13 @@ namespace Fuse.Controls
 				return RoutingResult.Change;
 				
 			routerPage.Visual = current.Visual;
-			if (routerPage.Parameter == current.Parameter)
+			if (routerPage.Parameter == current.Parameter &&
+				routerPage.Context == current.Context)
 				return RoutingResult.NoChange;
 				
-			return CompatibleParameter(routerPage.Parameter, _current.Parameter) ?
-				RoutingResult.MinorChange : RoutingResult.Change;
+			return RoutingResult.MinorChange;
+			//return CompatibleParameter(routerPage.Parameter, _current.Parameter) ?
+			//	RoutingResult.MinorChange : RoutingResult.Change;
 		}
 		
 		PrepareResult Prepare(RouterPage curPage, 
@@ -205,7 +207,8 @@ namespace Fuse.Controls
 			if (routerPage.Path == curPage.Path && curPageVisual != null)
 			{
 				//no change
-				if (routerPage.Parameter == curPage.Parameter)
+				if (routerPage.Parameter == curPage.Parameter &&
+					routerPage.Context == curPage.Context)
 					return new PrepareResult{ Page = curPage, Routing = RoutingResult.NoChange };
 					
 				// https://github.com/fusetools/fuselibs/issues/2982

--- a/Source/Fuse.Controls.Navigation/Navigator.uno
+++ b/Source/Fuse.Controls.Navigation/Navigator.uno
@@ -193,8 +193,6 @@ namespace Fuse.Controls
 				return RoutingResult.NoChange;
 				
 			return RoutingResult.MinorChange;
-			//return CompatibleParameter(routerPage.Parameter, _current.Parameter) ?
-			//	RoutingResult.MinorChange : RoutingResult.Change;
 		}
 		
 		PrepareResult Prepare(RouterPage curPage, 

--- a/Source/Fuse.Controls.Navigation/PageControl.Pages.uno
+++ b/Source/Fuse.Controls.Navigation/PageControl.Pages.uno
@@ -107,7 +107,12 @@ namespace Fuse.Controls
 					}
 					
 					var useVisual = f.New() as Visual;
-					UpdateContextData( useVisual, page );
+					if (useVisual == null)
+					{
+						Fuse.Diagnostics.UserError( "Template is not a Visual: " + path, this );
+						continue;
+					}
+					PageData.GetOrCreate(useVisual).SetContext(page);
 					toAdd.Add( useVisual );
 				}
 			}

--- a/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
@@ -613,6 +613,49 @@ namespace Fuse.Navigation.Test
 				Assert.AreEqual( null, p.router.GetHistoryRoute(9) );
 			}
 		}
+		
+		[Test]
+		public void ObservableGoBack()
+		{
+			Router.TestClearMasterRoute();
+			var p = new UX.Router.ObservableGoBack();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual( 0, p.wc.Progress );
+				Assert.AreEqual( "1", GetText(p.nav.Active) );
+				Assert.AreEqual( "1", p.history.Value );
+				
+				p.callPush.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( 1, p.wc.Progress );
+				Assert.AreEqual( "2", GetText(p.nav.Active) );
+				Assert.AreEqual( "1,2", p.history.Value );
+
+				//several calls to build up history and have navigator reuse the pages
+				p.callPush.Perform(); //3
+				root.StepFrameJS();
+				p.callPush.Perform(); //4
+				root.StepFrameJS();
+				p.callPush.Perform(); //5
+				root.StepFrameJS();
+				Assert.AreEqual( 1, p.wc.Progress );
+				Assert.AreEqual( "5", GetText(p.nav.Active) );
+				Assert.AreEqual( "1,2,3,4,5", p.history.Value );
+				
+				p.goBack.Pulse();
+				root.StepFrameJS();
+				Assert.AreEqual( 1, p.wc.Progress );
+				Assert.AreEqual( "4", GetText(p.nav.Active) );
+				Assert.AreEqual( "1,2,3,4", p.history.Value );
+				
+				p.goBack.Pulse();
+				root.StepFrameJS();
+				Assert.AreEqual( 1, p.wc.Progress );
+				Assert.AreEqual( "3", GetText(p.nav.Active) );
+				Assert.AreEqual( "1,2,3", p.history.Value );
+			}
+		}
 	}
 }
 	

--- a/Source/Fuse.Controls.Navigation/Tests/UX/Router.ObservableGoBack.ux
+++ b/Source/Fuse.Controls.Navigation/Tests/UX/Router.ObservableGoBack.ux
@@ -1,0 +1,49 @@
+<Panel ux:Class="UX.Router.ObservableGoBack">
+	<Router ux:Name="router"/>
+	<JavaScript>
+		var Observable = require("FuseJS/Observable")
+		
+		exports.pages = Observable({
+			$path: "one",
+			count: 1
+		})
+		
+		var count = 1
+		exports.push = function() {
+			exports.pages.add({
+				$path: "two",
+				count: ++count,
+			})
+		}
+		
+		exports.history = Observable( function() {
+			var text = ""
+			for (var i=0; i < exports.pages.length; ++i) {
+				if (i > 0) {
+					text += ","
+				}
+				text += exports.pages.getAt(i).count
+			}
+			return text
+		})
+	</JavaScript>
+	<Navigator PageHistory="{pages}" Transition="None" ux:Name="nav">
+		<Panel ux:Template="one">
+			<Text Value="{count}"/>
+		</Panel>
+		
+		<Panel ux:Template="two">
+			<Text Alignment="Center" Value="{count}" FontSize="48"/>
+		</Panel>
+	</Navigator>
+		
+	<Panel>
+		<WhileCanGoBack ux:Name="wc"/>
+		<Timeline ux:Name="goBack">
+			<GoBack/>
+		</Timeline>
+		<Text Value="{history}" ux:Name="history"/>
+	</Panel>
+	
+	<FuseTest.Invoke Handler="{push}" ux:Name="callPush"/>
+</Panel>

--- a/Source/Fuse.Navigation/Fuse.Navigation.unoproj
+++ b/Source/Fuse.Navigation/Fuse.Navigation.unoproj
@@ -23,6 +23,7 @@
     "../Fuse.Marshal/Fuse.Marshal.unoproj",
     "../Fuse.Reactive.Expressions/Fuse.Reactive.Expressions.unoproj",
     "../Fuse.Reactive.Bindings/Fuse.Reactive.Bindings.unoproj",
+    "../Fuse.Reactive/Fuse.Reactive.unoproj",
     "../Fuse.Common/Fuse.Common.unoproj",
     "../Fuse.Scripting/Fuse.Scripting.unoproj",
     "../Fuse.Nodes/Fuse.Nodes.unoproj",

--- a/Source/Fuse.Navigation/IRouterOutlet.uno
+++ b/Source/Fuse.Navigation/IRouterOutlet.uno
@@ -1,6 +1,8 @@
 using Uno;
 using Uno.Collections;
 
+using Fuse.Reactive;
+
 namespace Fuse.Navigation
 {
 	enum RoutingOperation
@@ -40,18 +42,19 @@ namespace Fuse.Navigation
 	{
 		public string Path;
 		public string Parameter;
+		public object Context;
 		[WeakReference]
 		public Visual Visual;
 		
 		//if there is an Outlet descendent of this page it should use this to track it's pages. This will
 		//keep the pages hierarchy/history during navigation.
-		List<RouterPage> _childRouterPages;
-		public List<RouterPage> ChildRouterPages
+		ObserverMap<RouterPage> _childRouterPages;
+		public ObserverMap<RouterPage> ChildRouterPages
 		{
 			get 
 			{
 				if (_childRouterPages == null)
-					_childRouterPages = new List<RouterPage>();
+					_childRouterPages = new PagesMap();
 				return _childRouterPages;
 			}
 		}
@@ -78,6 +81,20 @@ namespace Fuse.Navigation
 				router.OnHistoryChanged();
 		}
 	}
+	
+	class PagesMap : ObserverMap<RouterPage>
+	{
+		protected override RouterPage Map(object v)
+		{
+			return new RouterPage{ Context = v };
+		}
+		
+		protected override object Unmap(RouterPage mv)
+		{
+			return mv.Context;
+		}
+	}
+	
 	
 	/**	Represents an object that handle navigation to one @Route path element. */
 	interface IRouterOutlet

--- a/Source/Fuse.Navigation/IRouterOutlet.uno
+++ b/Source/Fuse.Navigation/IRouterOutlet.uno
@@ -76,7 +76,8 @@ namespace Fuse.Navigation
 		
 		public override string ToString() 
 		{
-			return Path + "?" + Parameter + " " + Visual;
+			return Path + "?" + Parameter + " " + Visual + " " + 
+				(Context == null ? "no-ctx" : ("@" + Context.GetHashCode()));
 		}
 
 		internal static void BubbleHistoryChanged( Node at )

--- a/Source/Fuse.Navigation/IRouterOutlet.uno
+++ b/Source/Fuse.Navigation/IRouterOutlet.uno
@@ -44,7 +44,13 @@ namespace Fuse.Navigation
 		public string Parameter;
 		public object Context;
 		[WeakReference]
-		public Visual Visual;
+		public Node Node;
+		
+		public Visual Visual 
+		{ 	
+			get { return Node as Visual; } 
+			set { Node = value; }
+		}
 		
 		//if there is an Outlet descendent of this page it should use this to track it's pages. This will
 		//keep the pages hierarchy/history during navigation.
@@ -54,7 +60,7 @@ namespace Fuse.Navigation
 			get 
 			{
 				if (_childRouterPages == null)
-					_childRouterPages = new PagesMap();
+					_childRouterPages = new PagesMap(this);
 				return _childRouterPages;
 			}
 		}
@@ -64,7 +70,7 @@ namespace Fuse.Navigation
 			var np = new RouterPage();
 			np.Path = Path;
 			np.Parameter = Parameter;
-			np.Visual = Visual;
+			np.Node = Node;
 			return np;
 		}
 		
@@ -84,6 +90,14 @@ namespace Fuse.Navigation
 	
 	class PagesMap : ObserverMap<RouterPage>
 	{
+		[WeakReference]
+		RouterPage _owner;
+		
+		public PagesMap( RouterPage owner )
+		{
+			_owner = owner;
+		}
+		
 		protected override RouterPage Map(object v)
 		{
 			return new RouterPage{ Context = v };
@@ -93,6 +107,15 @@ namespace Fuse.Navigation
 		{
 			return mv.Context;
 		}
+	
+		protected override void OnUpdated()
+		{
+			if (_owner == null || _owner.Node == null)
+				return;
+				
+			RouterPage.BubbleHistoryChanged(_owner.Node);
+		}
+
 	}
 	
 	

--- a/Source/Fuse.Navigation/PageData.uno
+++ b/Source/Fuse.Navigation/PageData.uno
@@ -42,12 +42,12 @@ namespace Fuse.Navigation
 				return;
 			}
 			
-			if (rp.Visual != null && visual != rp.Visual)
+			if (rp.Node != null && visual != rp.Node)
 			{
 				Fuse.Diagnostics.InternalError( "Mismatched page visual", this );
 				return;
 			}
-			rp.Visual = visual;
+			rp.Node = visual;
 			
 			this.RouterPage = rp;
 			visual.Prepare(rp.Parameter);

--- a/Source/Fuse.Navigation/PageData.uno
+++ b/Source/Fuse.Navigation/PageData.uno
@@ -27,6 +27,8 @@ namespace Fuse.Navigation
 		public RouterPage RouterPage { get; private set; }
 	
 		public event RouterPageChangedHandler RouterPageChanged;
+
+		public object Context { get; private set; }
 		
 		public PageData( Visual visual ) 
 		{
@@ -51,9 +53,23 @@ namespace Fuse.Navigation
 			
 			this.RouterPage = rp;
 			visual.Prepare(rp.Parameter);
+			UpdateContextData( visual, rp.Context );
 			
 			if (RouterPageChanged != null)
 				RouterPageChanged( this, rp );
+		}
+		
+		void UpdateContextData( Visual page, object data )
+		{
+			var oldData = Context;
+			Context = data;
+			page.BroadcastDataChange(oldData, data);
+		}
+		
+		//TODO: temporary  until PageControl is migrated better
+		public void SetContext( object data )
+		{
+			UpdateContextData( Visual, data );
 		}
 		
 		static PropertyHandle _propPageData = Properties.CreateHandle();

--- a/Source/Fuse.Navigation/Router.uno
+++ b/Source/Fuse.Navigation/Router.uno
@@ -111,6 +111,10 @@ namespace Fuse.Navigation
 						_masterRootPage = _rootPage;
 				}
 			}
+			
+			_rootPage.Node = Parent;
+			if (_rootPage.Node == null)
+				Fuse.Diagnostics.UserError( "No visual routing outlet was found",this );
 		}
 
 		protected override void OnUnrooted()

--- a/Source/Fuse.Nodes/Node.DataContext.uno
+++ b/Source/Fuse.Nodes/Node.DataContext.uno
@@ -102,7 +102,7 @@ namespace Fuse
 			}
 		}
 
-		protected void BroadcastDataChange(object oldData, object newData)
+		internal protected void BroadcastDataChange(object oldData, object newData)
 		{
 			string[] newKeys = null;
 			var newObj = newData as IObject;

--- a/Source/Fuse.Reactive/Fuse.Reactive.unoproj
+++ b/Source/Fuse.Reactive/Fuse.Reactive.unoproj
@@ -23,6 +23,7 @@
     "Fuse.Reactive.Bindings",
     "Fuse.Reactive.Expressions",
     "Fuse.Reactive.JavaScript",
+    "Fuse.Reactive.Test",
     "Fuse.Scripting.Test",
     "Fuse.Selection",
     "Fuse.Common.Test.Helpers",

--- a/Source/Fuse.Reactive/ObserverMap.uno
+++ b/Source/Fuse.Reactive/ObserverMap.uno
@@ -20,7 +20,7 @@ namespace Fuse.Reactive
 		A two-way mapped observable list. This serves as the outermost list: the list functions here will update the backing
 		Observable.
 	*/
-	abstract class ObserverMap<T> : IObserver, IArray where T : class
+	abstract class ObserverMap<T> : IObserver where T : class
 	{
 		internal List<T> _list = new List<T>();
 		
@@ -29,10 +29,13 @@ namespace Fuse.Reactive
 	
 		internal object UVUnmap(T mv) { return Unmap(mv); }
 		
-		public int Length { get { return _list.Count; } }
-		object IArray.this[int index] {  get { return _list[index]; } }		
-		//UNO: can't have a second indexer returning T
-		public T Get(int index) {  return _list[index]; }
+		public int Count { get { return _list.Count; } }
+		public T this[int index]
+		{
+			get { return _list[index]; }
+			set { _list[index] = value; }
+		}
+			
 		
 		IObservable _observable;
 		ISubscription _subscription;

--- a/Source/Fuse.Reactive/ObserverMap.uno
+++ b/Source/Fuse.Reactive/ObserverMap.uno
@@ -1,0 +1,82 @@
+using Uno;
+using Uno.Collections;
+
+namespace Fuse.Reactive
+{
+	abstract class ObserverMap<T> : IObserver, IArray where T : class
+	{
+		List<T> _list = new List<T>();
+		
+		protected abstract T Map(object v);
+		protected abstract object Unmap(T mv);
+		
+		public int Length { get { return _list.Count; } }
+		object IArray.this[int index] {  get { return _list[index]; } }		
+		//UNO: can't have a second indexer returning T
+		public T Get(int index) {  return _list[index]; }
+		
+		IObservable _observable;
+		ISubscription _subscription;
+		public void Attach( IObservable obs ) 
+		{
+			_observable = obs;
+			_subscription = _observable.Subscribe(this);
+			((IObserver)this).OnNewAll(obs);
+		}
+		
+		public void Detach()
+		{
+			_list.Clear();
+			if (_subscription != null)
+			{
+				_subscription.Dispose();
+				_subscription = null;
+			}
+			_observable = null;
+		}
+		
+		void IObserver.OnClear()
+		{
+			_list.Clear();
+		}
+		
+		void IObserver.OnNewAll(IArray values)
+		{
+			_list.Clear();
+			for (int i=0; i < values.Length;  ++i)
+				_list.Add( Map(values[i]) );
+		}
+		
+		void IObserver.OnNewAt(int index, object newValue)
+		{
+			_list[index] = Map(newValue);
+		}
+		
+		void IObserver.OnSet(object newValue)
+		{
+			_list.Clear();
+			_list.Add( Map(newValue) );
+		}
+		
+		void IObserver.OnAdd(object addedValue)
+		{
+			_list.Add( Map(addedValue) );
+		}
+		
+		void IObserver.OnRemoveAt(int index)
+		{
+			_list.RemoveAt(index);
+		}
+		
+		void IObserver.OnInsertAt(int index, object value)
+		{
+			_list.Insert(index, Map(value));
+		}
+		
+		void IObserver.OnFailed(string message)
+		{
+			_list.Clear();
+		}
+	}
+}
+	

--- a/Source/Fuse.Reactive/ObserverMap.uno
+++ b/Source/Fuse.Reactive/ObserverMap.uno
@@ -3,12 +3,31 @@ using Uno.Collections;
 
 namespace Fuse.Reactive
 {
+	//UNO: Cast to IArray was failing if this class is declared inside ObserverMap
+	class UnmappedView<T> : IArray where T : class
+	{
+		ObserverMap<T> _source;
+		public UnmappedView( ObserverMap<T> source )
+		{
+			_source = source;
+		}
+		
+		public int Length { get { return _source._list.Count; } } 
+		public object this[int index] { get { return _source.UVUnmap(_source._list[index]); } }
+	}
+	
+	/**
+		A two-way mapped observable list. This serves as the outermost list: the list functions here will update the backing
+		Observable.
+	*/
 	abstract class ObserverMap<T> : IObserver, IArray where T : class
 	{
-		List<T> _list = new List<T>();
+		internal List<T> _list = new List<T>();
 		
 		protected abstract T Map(object v);
 		protected abstract object Unmap(T mv);
+	
+		internal object UVUnmap(T mv) { return Unmap(mv); }
 		
 		public int Length { get { return _list.Count; } }
 		object IArray.this[int index] {  get { return _list[index]; } }		
@@ -33,6 +52,39 @@ namespace Fuse.Reactive
 				_subscription = null;
 			}
 			_observable = null;
+		}
+		
+		public void Add( T value )
+		{
+			_list.Add(value);
+			UpdateBacking();
+		}
+		
+		public void RemoveAt( int index )
+		{
+			_list.RemoveAt(index);
+			UpdateBacking();
+		}
+		
+		public void Insert( int index, T value )
+		{
+			_list.Insert(index, value);
+			UpdateBacking();
+		}
+		
+		public void Clear()
+		{
+			_list.Clear();
+			UpdateBacking();
+		}
+		
+		void UpdateBacking()
+		{
+			if (_subscription == null)
+				return;
+	
+			IArray uv = 	new UnmappedView<T>(this);
+			_subscription.ReplaceAllExclusive( uv );	
 		}
 		
 		void IObserver.OnClear()

--- a/Source/Fuse.Reactive/ObserverMap.uno
+++ b/Source/Fuse.Reactive/ObserverMap.uno
@@ -26,6 +26,7 @@ namespace Fuse.Reactive
 		
 		protected abstract T Map(object v);
 		protected abstract object Unmap(T mv);
+		protected virtual void OnUpdated() { }
 	
 		internal object UVUnmap(T mv) { return Unmap(mv); }
 		
@@ -41,6 +42,7 @@ namespace Fuse.Reactive
 		ISubscription _subscription;
 		public void Attach( IObservable obs ) 
 		{
+			Detach();
 			_observable = obs;
 			_subscription = _observable.Subscribe(this);
 			((IObserver)this).OnNewAll(obs);
@@ -93,6 +95,7 @@ namespace Fuse.Reactive
 		void IObserver.OnClear()
 		{
 			_list.Clear();
+			OnUpdated();
 		}
 		
 		void IObserver.OnNewAll(IArray values)
@@ -100,37 +103,44 @@ namespace Fuse.Reactive
 			_list.Clear();
 			for (int i=0; i < values.Length;  ++i)
 				_list.Add( Map(values[i]) );
+			OnUpdated();
 		}
 		
 		void IObserver.OnNewAt(int index, object newValue)
 		{
 			_list[index] = Map(newValue);
+			OnUpdated();
 		}
 		
 		void IObserver.OnSet(object newValue)
 		{
 			_list.Clear();
 			_list.Add( Map(newValue) );
+			OnUpdated();
 		}
 		
 		void IObserver.OnAdd(object addedValue)
 		{
 			_list.Add( Map(addedValue) );
+			OnUpdated();
 		}
 		
 		void IObserver.OnRemoveAt(int index)
 		{
 			_list.RemoveAt(index);
+			OnUpdated();
 		}
 		
 		void IObserver.OnInsertAt(int index, object value)
 		{
 			_list.Insert(index, Map(value));
+			OnUpdated();
 		}
 		
 		void IObserver.OnFailed(string message)
 		{
 			_list.Clear();
+			OnUpdated();
 		}
 	}
 }

--- a/Source/Fuse.Reactive/ObserverMap.uno
+++ b/Source/Fuse.Reactive/ObserverMap.uno
@@ -4,6 +4,7 @@ using Uno.Collections;
 namespace Fuse.Reactive
 {
 	//UNO: Cast to IArray was failing if this class is declared inside ObserverMap
+	//https://github.com/fusetools/uno/issues/1321
 	class UnmappedView<T> : IArray where T : class
 	{
 		ObserverMap<T> _source;
@@ -17,8 +18,7 @@ namespace Fuse.Reactive
 	}
 	
 	/**
-		A two-way mapped observable list. This serves as the outermost list: the list functions here will update the backing
-		Observable.
+		A two-way mapped observable list. This serves as the outermost list: the list functions here will update the backing Observable.
 	*/
 	abstract class ObserverMap<T> : IObserver where T : class
 	{

--- a/Source/Fuse.Reactive/Tests/Fuse.Reactive.Test.unoproj
+++ b/Source/Fuse.Reactive/Tests/Fuse.Reactive.Test.unoproj
@@ -1,0 +1,13 @@
+{
+  "Packages": [
+    "Fuse",
+    "FuseJS",
+    "Uno.Threading"
+  ],
+  "Projects": [
+    "../../Fuse.Common/Tests/FuseTest/FuseTest.unoproj"
+  ],
+  "Includes": [
+    "*",
+  ],
+}

--- a/Source/Fuse.Reactive/Tests/ObserverMap.Test.uno
+++ b/Source/Fuse.Reactive/Tests/ObserverMap.Test.uno
@@ -15,17 +15,17 @@ namespace Fuse.Reactive.Test
 			
 			rl.Add( new Source(5) );
 			rl.Insert(0, new Source(3) );
-			Assert.AreEqual( 2, tm.Length );
-			Assert.AreEqual( 5, tm.Get(1).InitValue );
-			Assert.AreEqual( 3, tm.Get(0).InitValue );
+			Assert.AreEqual( 2, tm.Count );
+			Assert.AreEqual( 5, tm[1].InitValue );
+			Assert.AreEqual( 3, tm[0].InitValue );
 			
 			rl.Replace(1, new Source(7));
 			rl.RemoveAt(0);
-			Assert.AreEqual( 1, tm.Length );
-			Assert.AreEqual( 7, tm.Get(0).InitValue );
+			Assert.AreEqual( 1, tm.Count );
+			Assert.AreEqual( 7, tm[0].InitValue );
 			
 			rl.Clear();
-			Assert.AreEqual( 0, tm.Length );
+			Assert.AreEqual( 0, tm.Count );
 			
 			tm.Detach();
 		}
@@ -66,11 +66,11 @@ namespace Fuse.Reactive.Test
 			rl.Insert( 1, new Source(3) ); //1,3,2
 			tm.Insert( 1, new Mapped { InitValue = 4 } ); //1,4,3,2
 			Assert.AreEqual( 4, rl.Count );
-			Assert.AreEqual( 4, tm.Length );
+			Assert.AreEqual( 4, tm.Count );
 			var expect = new[]{ 1, 4, 3, 2 };
 			for (int i=0; i < expect.Length; ++i)
 			{
-				Assert.AreEqual( expect[i], tm.Get(i).InitValue );
+				Assert.AreEqual( expect[i], tm[i].InitValue );
 				Assert.AreEqual( expect[i], rl[i].Value );
 			}
 			

--- a/Source/Fuse.Reactive/Tests/ObserverMap.Test.uno
+++ b/Source/Fuse.Reactive/Tests/ObserverMap.Test.uno
@@ -11,7 +11,7 @@ namespace Fuse.Reactive.Test
 		{
 			var rl = new ObservableList<Source>();
 			var tm = new TestMap();
-			tm.Attach(rl);
+			tm.Attach(rl, null);
 			
 			rl.Add( new Source(5) );
 			rl.Insert(0, new Source(3) );
@@ -35,7 +35,7 @@ namespace Fuse.Reactive.Test
 		{
 			var rl = new ObservableList<Source>();
 			var tm = new TestMap();
-			tm.Attach(rl);
+			tm.Attach(rl, null);
 			
 			tm.Add( new Mapped{ InitValue = 4 } );
 			Assert.AreEqual( 1, rl.Count );
@@ -59,7 +59,7 @@ namespace Fuse.Reactive.Test
 		{
 			var rl = new ObservableList<Source>();
 			var tm = new TestMap();
-			tm.Attach(rl);
+			tm.Attach(rl, null);
 			
 			rl.Add( new Source(1) ); // 1
 			tm.Add( new Mapped{ InitValue = 2 } ); //1,2

--- a/Source/Fuse.Reactive/Tests/ObserverMap.Test.uno
+++ b/Source/Fuse.Reactive/Tests/ObserverMap.Test.uno
@@ -9,7 +9,7 @@ namespace Fuse.Reactive.Test
 		[Test]
 		public void Forward()
 		{
-			var rl = new ReadOnlyObservableList<Source>();
+			var rl = new ObservableList<Source>();
 			var tm = new TestMap();
 			tm.Attach(rl);
 			
@@ -23,8 +23,59 @@ namespace Fuse.Reactive.Test
 			rl.RemoveAt(0);
 			Assert.AreEqual( 1, tm.Length );
 			Assert.AreEqual( 7, tm.Get(0).InitValue );
+			
+			rl.Clear();
+			Assert.AreEqual( 0, tm.Length );
+			
+			tm.Detach();
 		}
 		
+		[Test]
+		public void Backward()
+		{
+			var rl = new ObservableList<Source>();
+			var tm = new TestMap();
+			tm.Attach(rl);
+			
+			tm.Add( new Mapped{ InitValue = 4 } );
+			Assert.AreEqual( 1, rl.Count );
+			Assert.AreEqual( 4, rl[0].Value );
+			
+			tm.Insert( 0, new Mapped{ InitValue = 5 } );
+			tm.Insert( 2, new Mapped{ InitValue = 2 } );
+			tm.RemoveAt( 1 );
+			Assert.AreEqual( 2, rl.Count );
+			Assert.AreEqual( 5, rl[0].Value );
+			Assert.AreEqual( 2, rl[1].Value );
+			
+			tm.Clear();
+			Assert.AreEqual( 0, rl.Count );
+			
+			tm.Detach();
+		}
+		
+		[Test]
+		public void Both()
+		{
+			var rl = new ObservableList<Source>();
+			var tm = new TestMap();
+			tm.Attach(rl);
+			
+			rl.Add( new Source(1) ); // 1
+			tm.Add( new Mapped{ InitValue = 2 } ); //1,2
+			rl.Insert( 1, new Source(3) ); //1,3,2
+			tm.Insert( 1, new Mapped { InitValue = 4 } ); //1,4,3,2
+			Assert.AreEqual( 4, rl.Count );
+			Assert.AreEqual( 4, tm.Length );
+			var expect = new[]{ 1, 4, 3, 2 };
+			for (int i=0; i < expect.Length; ++i)
+			{
+				Assert.AreEqual( expect[i], tm.Get(i).InitValue );
+				Assert.AreEqual( expect[i], rl[i].Value );
+			}
+			
+			tm.Detach();
+		}
 	}
 	
 	class TestMap : ObserverMap<Mapped>
@@ -36,6 +87,8 @@ namespace Fuse.Reactive.Test
 		
 		protected override object Unmap(Mapped mv)
 		{
+			if (mv.Backing == null)
+				mv.Backing = new Source(mv.InitValue);
 			return mv.Backing;
 		}
 	}

--- a/Source/Fuse.Reactive/Tests/ObserverMap.Test.uno
+++ b/Source/Fuse.Reactive/Tests/ObserverMap.Test.uno
@@ -1,0 +1,58 @@
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Reactive.Test
+{
+	public class ObserverMapTest : TestBase
+	{
+		[Test]
+		public void Forward()
+		{
+			var rl = new ReadOnlyObservableList<Source>();
+			var tm = new TestMap();
+			tm.Attach(rl);
+			
+			rl.Add( new Source(5) );
+			rl.Insert(0, new Source(3) );
+			Assert.AreEqual( 2, tm.Length );
+			Assert.AreEqual( 5, tm.Get(1).InitValue );
+			Assert.AreEqual( 3, tm.Get(0).InitValue );
+			
+			rl.Replace(1, new Source(7));
+			rl.RemoveAt(0);
+			Assert.AreEqual( 1, tm.Length );
+			Assert.AreEqual( 7, tm.Get(0).InitValue );
+		}
+		
+	}
+	
+	class TestMap : ObserverMap<Mapped>
+	{
+		protected override Mapped Map(object v)
+		{
+			return new Mapped{ Backing = v, InitValue = ((Source)v).Value };
+		}
+		
+		protected override object Unmap(Mapped mv)
+		{
+			return mv.Backing;
+		}
+	}
+	
+	class Source
+	{
+		public int Value;
+		
+		public Source( int value )
+		{
+			Value = value;
+		}
+	}
+	
+	class Mapped
+	{
+		public object Backing;
+		public int InitValue;
+	}
+}


### PR DESCRIPTION
This allows GoBack and WhileCanGoBack to work with a model bound to `NavigationControl.PageHistory`. The full functionality is incomplete, but this represents a useful first step and makes the most invasive parts of the changes.

This PR contains:
- [x] Changelog
- [-] Documentation -  no visible API changes. This will require extensive documentation once the Model stuff is released.
- [x] Tests
