### PR TITLE
Fixed #427 iOS GeoLocation Authorization Popup added

### DIFF
--- a/Source/Fuse.GeoLocation/iOS/IOSLocationProvider.uno
+++ b/Source/Fuse.GeoLocation/iOS/IOSLocationProvider.uno
@@ -34,7 +34,7 @@ namespace Fuse.GeoLocation
 			{
 				@{IOSLocationProvider:Of(_this).OnError(string):Call(err.localizedDescription)};
 			}
-      changeAuthorizationStatus: ^void (int status)
+			changeAuthorizationStatus: ^void (int status)
 			{
 				@{IOSLocationProvider:Of(_this).OnChangeAuthorizationStatus(int):Call(status)};
 			}
@@ -187,7 +187,7 @@ namespace Fuse.GeoLocation
 			}
 		}
 
-	  void OnChangeAuthorizationStatus(int clAuthorizationStatus)
+		void OnChangeAuthorizationStatus(int clAuthorizationStatus)
 		{
 			if (clAuthorizationStatus == AuthorizedWhenInUse && _currentWaitingPromise != null)
 			{

--- a/Source/Fuse.GeoLocation/iOS/IOSLocationProvider.uno
+++ b/Source/Fuse.GeoLocation/iOS/IOSLocationProvider.uno
@@ -10,11 +10,15 @@ namespace Fuse.GeoLocation
 	[ForeignInclude(Language.ObjC, "iOS/LocationManagerDelegate.h")]
 	extern(iOS) class IOSLocationProvider : ILocationTracker
 	{
+		private const int AuthorizedWhenInUse = 4;
+
 		ObjC.Object _lm; // CLLocationManager*
 		ObjC.Object _lmDelegate; // LocationManagerDelegate*
 		Action<Location> _continuousLocationListener;
 		Action<Exception> _continuousErrorListener;
 		Queue<Promise<Location>> _waitingPromises = new Queue<Promise<Location>>();
+		Promise<Location> _currentWaitingPromise;
+		double _promiseTimeout;
 		double _desiredAccuracyInMeters;
 
 		[Foreign(Language.ObjC)]
@@ -29,7 +33,12 @@ namespace Fuse.GeoLocation
 			error: ^void (NSError* err)
 			{
 				@{IOSLocationProvider:Of(_this).OnError(string):Call(err.localizedDescription)};
-			}];
+			}
+      changeAuthorizationStatus: ^void (int status)
+			{
+				@{IOSLocationProvider:Of(_this).OnChangeAuthorizationStatus(int):Call(status)};
+			}
+			];
 
 			lm.delegate = lmDelegate;
 
@@ -162,13 +171,41 @@ namespace Fuse.GeoLocation
 
 		public void GetLocation(Promise<Location> promise, double timeout)
 		{
-			Timer.Wait(timeout / 1000, new The(promise).TimedOut);
-			_waitingPromises.Enqueue(promise);
 			SetCLLocationManagerParams(_lm, 0);
 			// Stopping and starting triggers a new callback
 			StopUpdatingLocation(_lm);
 			StartUpdatingLocation(_lm);
+			if (IsLocationPermitted())
+			{
+				PublishLocationPromise(promise, timeout);
+			}
+			else
+			{
+				RequestAuthorization(GeoLocationAuthorizationType.WhenInUse);
+				_currentWaitingPromise = promise;
+				_promiseTimeout = timeout;
+			}
 		}
+
+	  void OnChangeAuthorizationStatus(int clAuthorizationStatus)
+		{
+			if (clAuthorizationStatus == AuthorizedWhenInUse && _currentWaitingPromise != null)
+			{
+				PublishLocationPromise(_currentWaitingPromise, _promiseTimeout);
+			}
+		}
+
+		private void PublishLocationPromise(Promise<Location> promise, double timeout)
+		{
+			Timer.Wait(timeout / 1000, new The(promise).TimedOut);
+			_waitingPromises.Enqueue(promise);
+		}
+
+		[Foreign(Language.ObjC)]
+		private bool IsLocationPermitted()
+		@{
+			return [CLLocationManager authorizationStatus]==kCLAuthorizationStatusAuthorizedWhenInUse;
+		@}
 
 		class The
 		{
@@ -221,7 +258,7 @@ namespace Fuse.GeoLocation
 			*altitude = location.altitude;
 			*speed = location.speed;
 		@}
-		
+
 		public void Init(Action onReady)
 		{
 			onReady();

--- a/Source/Fuse.GeoLocation/iOS/LocationManagerDelegate.h
+++ b/Source/Fuse.GeoLocation/iOS/LocationManagerDelegate.h
@@ -3,5 +3,7 @@
 @interface LocationManagerDelegate : NSObject<CLLocationManagerDelegate>
 @property (nonatomic, copy) void (^_onLocationChanged)(CLLocation* location);
 @property (nonatomic, copy) void (^_onError)(NSError* location);
-- (id)initWithBlock:(void (^)(CLLocation* location))onLocationChanged error:(void (^)(NSError* err))onError;
+@property (nonatomic, copy) void (^_onChangeAuthorizationStatus)(int status);
+- (id)initWithBlock:(void (^)(CLLocation* location))onLocationChanged error:(void (^)(NSError* err))onError
+                     changeAuthorizationStatus:(void (^)(int status))onChangeAuthorizationStatus;
 @end

--- a/Source/Fuse.GeoLocation/iOS/LocationManagerDelegate.h
+++ b/Source/Fuse.GeoLocation/iOS/LocationManagerDelegate.h
@@ -5,5 +5,5 @@
 @property (nonatomic, copy) void (^_onError)(NSError* location);
 @property (nonatomic, copy) void (^_onChangeAuthorizationStatus)(int status);
 - (id)initWithBlock:(void (^)(CLLocation* location))onLocationChanged error:(void (^)(NSError* err))onError
-                     changeAuthorizationStatus:(void (^)(int status))onChangeAuthorizationStatus;
+										 changeAuthorizationStatus:(void (^)(int status))onChangeAuthorizationStatus;
 @end

--- a/Source/Fuse.GeoLocation/iOS/LocationManagerDelegate.mm
+++ b/Source/Fuse.GeoLocation/iOS/LocationManagerDelegate.mm
@@ -4,10 +4,13 @@
 
 @synthesize _onLocationChanged;
 @synthesize _onError;
+@synthesize _onChangeAuthorizationStatus;
 
-- (id)initWithBlock:(void (^)(CLLocation* location))onLocationChanged error:(void (^)(NSError* err))onError {
+- (id)initWithBlock:(void (^)(CLLocation* location))onLocationChanged error:(void (^)(NSError* err))onError
+										 changeAuthorizationStatus:(void (^)(int status))onChangeAuthorizationStatus {
 	self = [super init];
 	if (self) {
+		self._onChangeAuthorizationStatus = onChangeAuthorizationStatus;
 		self._onLocationChanged = onLocationChanged;
 		self._onError = onError;
 	}
@@ -26,6 +29,10 @@
 
 - (void)locationManager:(CLLocationManager*)manager didFailWithError:(NSError*)error {
 	_onError(error);
+}
+
+- (void)locationManager:(CLLocationManager*)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+	_onChangeAuthorizationStatus((int)status);
 }
 
 @end


### PR DESCRIPTION
2 problems were addressed in the fix.
- Authorization Popup was not triggered by `GetLocation.getLocation` JS call in iOS
- Provided timeout for `GetLocation.getLocation` was starting before user clicks `Allow` button on popup