### PR TITLE
ScriptClass: implement ScriptReadonlyProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@
 - Allowed `GoBack` and `WhileCanGoBack` on the router to properly interact with bound observable/model `PageHistory`
 
 ## ScriptClass
-- Added ScriptPromise. This addes support for passing Promises between Uno and the scripting engine. Very useful when dealing with async stuff and JavaScript
+- Added ScriptPromise. This adds support for passing Promises between Uno and the scripting engine. Very useful when dealing with async stuff and JavaScript
+- Added ScriptReadonlyProperty. This feature lets you expose readonly data in JavaScript. Useful for exposing constants for example
 
 ## WebView
 Fixed issue where custom URI schemes were matched too greedily in URLs, making for erroneously intercepted URL requests.

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -22,6 +22,16 @@ namespace Fuse.Scripting
 		}
 	}
 
+	public class ScriptReadonlyProperty: ScriptMember
+	{
+		public readonly object Value;
+
+		public ScriptReadonlyProperty(string name, object value): base(name)
+		{
+			Value = value;
+		}
+	}
+
 	public abstract class ScriptProperty: ScriptMember
 	{
 		public readonly string Modifier;

--- a/Source/Fuse.Scripting/Tests/ScriptClass/ScriptReadonlyProperty.Test.uno
+++ b/Source/Fuse.Scripting/Tests/ScriptClass/ScriptReadonlyProperty.Test.uno
@@ -1,0 +1,48 @@
+using Uno;
+using Uno.Threading;
+using Uno.Testing;
+using Uno.Collections;
+
+using Fuse.Reactive;
+using Fuse.Scripting;
+using Fuse.Controls;
+using FuseTest;
+
+namespace Fuse.Scripting.Test
+{
+	public class ReadonlyPropertyPanel : Panel
+	{
+		static ReadonlyPropertyPanel()
+		{
+			ScriptClass.Register(
+				typeof(ReadonlyPropertyPanel),
+				new ScriptReadonlyProperty("stringProperty", "fusetools"),
+				new ScriptReadonlyProperty("numberProperty", 13.37));
+		}
+	}
+
+	public class ScriptReadonlyPropertyTest : TestBase
+	{
+		[Test]
+		public void StringTest()
+		{
+			var child = new UX.ScriptReadonlyPropertyTest();
+			using (var root = TestRootPanel.CreateWithChild(child))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("fusetools", child.Properties.StringProperty);
+			}
+		}
+
+		[Test]
+		public void NumberTest()
+		{
+			var child = new UX.ScriptReadonlyPropertyTest();
+			using (var root = TestRootPanel.CreateWithChild(child))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual(13.37, child.Properties.NumberProperty);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Scripting/Tests/ScriptClass/UX/ScriptReadonlyPropertyTest.ux
+++ b/Source/Fuse.Scripting/Tests/ScriptClass/UX/ScriptReadonlyPropertyTest.ux
@@ -1,0 +1,22 @@
+<Panel ux:Class="UX.ScriptReadonlyPropertyTest">
+	<Fuse.Scripting.Test.ReadonlyPropertyPanel ux:Name="testPanel" >
+
+		<JavaScript>
+			module.exports = {
+				stringProperty: testPanel.stringProperty,
+				numberProperty: testPanel.numberProperty,
+			};
+		</JavaScript>
+
+		<Properties2
+			ux:Name="Properties"
+			StringProperty="{stringProperty}"
+			NumberProperty="{numberProperty}" />
+
+		<Panel ux:Class="Properties2">
+			<string ux:Property="StringProperty" />
+			<double ux:Property="NumberProperty" />
+		</Panel>
+
+	</Fuse.Scripting.Test.ReadonlyPropertyPanel>
+</Panel>


### PR DESCRIPTION
This feature enables users to expose readonly data from a scriptclass

This PR contains:
- [x] Changelog
- [ ] Documentation
- [x] Tests
