### PR TITLE
Fix axis-aligned lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## JavaScript: Optional explicit requrie() of UX symbols
 - Symbols declared with `ux:Name`, `ux:Dependency` or `dep` are now also available to `require()` for `<JavaScript>` modules using the `ux:` prefix. This allows us to write code that plays nicer with transpilers and linters. Using require for names declared in UX is optional, but may make the code more readable and maintainable, e.g. `var router = require("ux:router")` over just using `router` with no declaration.
 
+## Fuse.Drawing.Surface
+- Fixed a problem where horizontal or vertical lines would not draw in the .NET backend.
+
 ## Attract
 - Fixed an issue with `attract` not updating when using a data binding as the source value
 

--- a/Source/Fuse.Controls.Primitives/Tests/Curve.Test.uno
+++ b/Source/Fuse.Controls.Primitives/Tests/Curve.Test.uno
@@ -51,5 +51,24 @@ namespace Fuse.Controls.Primitives.Test
 				Assert.AreEqual(0, p.C.TestLineSegments.Count);
 			}
 		}
+
+		[Test]
+		[extern(MSVC) Ignore("no surface backend")]
+		public void LineRendering()
+		{
+			var p = new UX.Curve.LineRendering();
+			using (var root = TestRootPanel.CreateWithChild(p, int2(100, 100)))
+			using (var fb = root.CaptureDraw())
+			{
+				// left background
+				fb.AssertSolidRectangle(float4(0, 0, 0, 0), new Recti(int2(0,  0), int2(50 - 6, 100)));
+
+				// line
+				fb.AssertSolidRectangle(float4(1, 0, 0, 1), new Recti(int2(50 - 4,  0), int2(8, 100)));
+
+				// right background
+				fb.AssertSolidRectangle(float4(0, 0, 0, 0), new Recti(int2(50 + 6,  0), int2(50 - 6, 100)));
+			}
+		}
 	}
 }

--- a/Source/Fuse.Controls.Primitives/Tests/UX/Curve.LineRendering.ux
+++ b/Source/Fuse.Controls.Primitives/Tests/UX/Curve.LineRendering.ux
@@ -1,0 +1,7 @@
+<Panel ux:Class="UX.Curve.LineRendering">
+	<Curve Width="100" Height="100" Style="Straight">
+		<Stroke Alignment="Center" LineCap="Round" Width="10" Color="Red" />
+		<CurvePoint At="0.5,0" />
+		<CurvePoint At="0.5,1" />
+	</Curve>
+</Panel>

--- a/Source/Fuse.Drawing.Surface/DotNetSurface.uno
+++ b/Source/Fuse.Drawing.Surface/DotNetSurface.uno
@@ -741,6 +741,8 @@ namespace Fuse.Drawing
 		{
 			var bounds = path.GetBounds();
 			bounds.Inflate(width, width);
+			if (bounds.IsEmpty)
+				return;
 
 			SolidBrush brush = new SolidBrush(color);
 			Pen pen = new Pen(brush, width);
@@ -766,6 +768,8 @@ namespace Fuse.Drawing
 		{
 			var bounds = path.GetBounds();
 			bounds.Inflate(width, width);
+			if (bounds.IsEmpty)
+				return;
 
 			var brush = new TextureBrush(image, DotNetWrapMode.Tile);
 			
@@ -798,12 +802,12 @@ namespace Fuse.Drawing
 			LineJoin lineJoin, LineCap lineCap
 		)
 		{
-			var state = graphics.Save();
 			var bounds = path.GetBounds();
-
-			// make the clipping path wider to componesate for the stroke width
 			bounds.Inflate(width, width);
+			if (bounds.IsEmpty)
+				return;
 
+			var state = graphics.Save();
 			ColorBlend blend = CreateColorBlend(lg, bounds, startX, startY, endX, endY);
 
 			var brush = new LinearGradientBrush(
@@ -848,6 +852,9 @@ namespace Fuse.Drawing
 		)
 		{
 			var bounds = path.GetBounds();
+			if (bounds.IsEmpty)
+				return;
+
 			var blend = CreateColorBlend(lg, bounds, startX, startY, endX, endY);
 
 			var startPoint = new PointF(bounds.X, bounds.Y);
@@ -893,13 +900,15 @@ namespace Fuse.Drawing
 			float width, float height
 			)
 		{
+			var bounds = path.GetBounds();
+			if (bounds.IsEmpty)
+				return;
+
 			var newImage = new Bitmap(image, (int)tileSizeX, (int)tileSizeY);
 
 			var brush = new TextureBrush(newImage, DotNetWrapMode.Tile);
 			brush.ScaleTransform(1, -1);
 			brush.TranslateTransform(originX, originY);
-			
-			var bounds = path.GetBounds();
 
 			graphics.SetClip(bounds, CombineMode.Replace);
 			graphics.FillPath(brush, path);
@@ -1271,6 +1280,7 @@ namespace Fuse.Drawing
 			public extern float X { get; set; }
 			public extern float Y { get; set; }
 			public extern void Inflate(float x,float y);
+			public extern bool IsEmpty { get; }
 		}
 
 		[DotNetType("System.Drawing.Rectangle")]

--- a/Source/Fuse.Drawing.Surface/DotNetSurface.uno
+++ b/Source/Fuse.Drawing.Surface/DotNetSurface.uno
@@ -157,9 +157,6 @@ namespace Fuse.Drawing
 
 			var graphicsPath = actualPath.Path.GetGraphicsPath();
 
-			// if the path has no size, return
-			if (DotNetHelpers.IsEmptyPath(graphicsPath)) return;
-			
 			bool eoFill = actualPath.FillRule == FillRule.EvenOdd;
 			// set the path filling mode
 			DotNetHelpers.SetEOFill(graphicsPath, eoFill);
@@ -230,9 +227,6 @@ namespace Fuse.Drawing
 			var actualPath = (DotNetCanvasPath)path;
 
 			var graphicsPath = actualPath.Path.GetGraphicsPath();
-
-			// if the path has no size, return
-			if (DotNetHelpers.IsEmptyPath(graphicsPath)) return;
 
 			bool eoFill = actualPath.FillRule == FillRule.EvenOdd;
 			// set the path filling mode
@@ -575,11 +569,6 @@ namespace Fuse.Drawing
 			);
 			return;
 		}
-
-		public static extern bool IsEmptyPath(GraphicsPath path)
-		{
-			return path.GetBounds().Width == 0 || path.GetBounds().Height == 0;
-		} 
 
 		public static extern void SetEOFill(GraphicsPath path, bool eoFill)
 		{


### PR DESCRIPTION
This is an alternative to #470 to fix issue #270. I believe this takes the bull by its horns a bit more than the original fix, as it avoids the specific thing that cause a crash under Mono instead of caring about zero-bounds paths before expanding.

This PR contains:
- [x] Changelog
- [ ] ~Documentation~ no API changes
- [x] Tests
