### PR TITLE
ScriptPromise: add Context as argument on FutureFactory

### DIFF
--- a/Source/Fuse.Scripting/Tests/ScriptClass/ScriptPromise.Test.uno
+++ b/Source/Fuse.Scripting/Tests/ScriptClass/ScriptPromise.Test.uno
@@ -35,17 +35,17 @@ namespace Fuse.Scripting.Test
 				new ScriptPromise<CustomPanel,TestObject,External>("getObject", ExecutionThread.MainThread, getObject, new ResultConverter().Convert));
 		}
 
-		static Future<string> getString(CustomPanel self, object[] args)
+		static Future<string> getString(Context context, CustomPanel self, object[] args)
 		{
 			return self.StringFuture;
 		}
 
-		static Future<double> getNumber(CustomPanel self, object[] args)
+		static Future<double> getNumber(Context context, CustomPanel self, object[] args)
 		{
 			return self.NumberFuture;
 		}
 
-		static Future<TestObject> getObject(CustomPanel self, object[] args)
+		static Future<TestObject> getObject(Context context, CustomPanel self, object[] args)
 		{
 			return self.ObjectFuture;
 		}


### PR DESCRIPTION
This should have been there in the firstplace. Its needed for Wrapping/Unwrapping incoming arguments from JS.

`ScriptPromise` is not released yet, so we are not breaking any APIs

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
