### PR TITLE
Macos test failures

### DIFF
--- a/Source/Fuse.Common/Tests/FuseTest/TestFramebuffer.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestFramebuffer.uno
@@ -60,7 +60,7 @@ namespace FuseTest
 			{
 				for (int x = rect.Minimum.X; x < rect.Maximum.X; ++x)
 				{
-					AssertPixel(expectedColor, int2(x, y), tolerance);
+					AssertPixel(expectedColor, int2(x, y), tolerance, filePath, lineNumber, memberName);
 				}
 			}
 		}

--- a/Source/Fuse.Common/Tests/FuseTest/TestFramebuffer.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestFramebuffer.uno
@@ -50,7 +50,8 @@ namespace FuseTest
 		{
 			var color = ReadDrawPixel(pos);
 			var diff = Math.Abs(color - expectedColor);
-			if (Vector.Length(diff) > tolerance)
+			var maxError = Math.Max(Math.Max(diff.X, diff.Y), Math.Max(diff.Z, diff.W));
+			if (maxError > tolerance)
 				Assert.Fail(string.Format("Unexpected color at [{0}]. Got [{1}], expected [{2}].", pos, color, expectedColor), filePath, lineNumber, memberName);
 		}
 

--- a/Source/Fuse.Controls.Primitives/Tests/Circle.Test.uno
+++ b/Source/Fuse.Controls.Primitives/Tests/Circle.Test.uno
@@ -26,7 +26,7 @@ namespace Fuse.Controls.Primitives.Test
 						var pos = int2(x, y);
 						float distance = Vector.Distance(center, pos + float2(0.5f, 0.5f));
 						float alpha = Math.Saturate(radius - distance + 0.5f);
-						fb.AssertPixel(float4(alpha, 0, 0, alpha), pos, 1.0f / 255);
+						fb.AssertPixel(float4(alpha, 0, 0, alpha), pos, 2.0f / 255);
 					}
 				}
 			}

--- a/Source/Fuse.Elements/Tests/ElementBatcher.Test.uno
+++ b/Source/Fuse.Elements/Tests/ElementBatcher.Test.uno
@@ -119,14 +119,16 @@ namespace Fuse.Elements.Test
 			var p = new UX.ElementBatcher.ZeroSizeAfterFirstDraw();
 			using (var root = TestRootPanel.CreateWithChild(p, int2(10, 13)))
 			{
-				var edgeMargin = 1;
+				// Due to precision issues while blitting on AMD hardware, we sadly need a surprisingly
+				// large tolerance here. The test still tests what it tries too, though.
+				var tolerance = 3.0f / 255;
 
 				using (var fb = root.CaptureDraw())
 				{
-					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0,  0), int2(10,  1))); // Guard
-					fb.AssertSolidRectangle(float4(0, 1, 0, 1), new Recti(int2(0,  1), int2(10, 10)));
-					fb.AssertSolidRectangle(float4(1, 0, 0, 1), new Recti(int2(0, 11), int2(10,  1))); // Poison
-					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0, 12), int2(10,  1))); // Guard
+					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0,  0), int2(10,  1)), tolerance); // Guard
+					fb.AssertSolidRectangle(float4(0, 1, 0, 1), new Recti(int2(0,  1), int2(10, 10)), tolerance);
+					fb.AssertSolidRectangle(float4(1, 0, 0, 1), new Recti(int2(0, 11), int2(10,  1)), tolerance); // Poison
+					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0, 12), int2(10,  1)), tolerance); // Guard
 				}
 
 				p.Poison.Height = 0;
@@ -135,9 +137,9 @@ namespace Fuse.Elements.Test
 
 				using (var fb = root.CaptureDraw())
 				{
-					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0,  0), int2(10,  1))); // Guard
-					fb.AssertSolidRectangle(float4(0, 1, 0, 1), new Recti(int2(0,  1), int2(10, 10)));
-					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0, 11), int2(10,  1))); // Guard
+					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0,  0), int2(10,  1)), tolerance); // Guard
+					fb.AssertSolidRectangle(float4(0, 1, 0, 1), new Recti(int2(0,  1), int2(10, 10)), tolerance);
+					fb.AssertSolidRectangle(float4(0, 0, 1, 1), new Recti(int2(0, 11), int2(10,  1)), tolerance); // Guard
 				}
 			}
 		}


### PR DESCRIPTION
When running tests on macOS with AMD hardware, we see some failures that we don't usually see. This PR should fix those.

I also found some other nits in the testing-code while digging, so some other smaller fixes are also included.

This PR contains:
- [x] Tests
