### PR TITLE
FuseTest: do not use non-existent base-constructor

### DIFF
--- a/Source/Fuse.Common/Tests/FuseTest/TestRootNode.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestRootNode.uno
@@ -12,12 +12,19 @@ namespace FuseTest
 	 /* TODO: Missing bootstrapper */
 	public class TestRootViewport : RootViewport, IRenderViewport
 	{
+		extern(!Android && !iOS)
 		public TestRootViewport(Uno.Platform.Window window, float pixelsPerPoint = 0)
 			: base(window, pixelsPerPoint)
 		{ 
 			OverrideSize( float2(100), pixelsPerPoint, pixelsPerPoint );
 		}
-		
+
+		extern(Android || iOS)
+		public TestRootViewport(Uno.Platform.Window window, float pixelsPerPoint = 0)
+		{
+			OverrideSize( float2(100), pixelsPerPoint, pixelsPerPoint );
+		}
+
 		public void Resize(float2 size)
 		{
 			OverrideSize(size, PixelsPerPoint, PixelsPerOSPoint);


### PR DESCRIPTION
Android / iOS testing was broken, this fix is analogous to
17faa1cb183d9746b2555a64a181d786bee2bbfa.