### PR TITLE
Make the auto test app work in preview on macOS

### DIFF
--- a/Source/FuseJS/Environment.uno
+++ b/Source/FuseJS/Environment.uno
@@ -62,6 +62,7 @@ namespace FuseJS
 			AddMember(new NativeProperty<bool, bool>("desktop", defined(!MOBILE)));
 			AddMember(new NativeProperty<bool, bool>("preview", defined(DESIGNMODE)));
 			AddMember(new NativeProperty<bool, bool>("dotnet", defined(DOTNET))); // Undocumented for testing use only
+			AddMember(new NativeProperty<bool, bool>("host_mac", defined(HOST_MAC))); // Undocumented for testing use only
 			AddMember(new NativeProperty<string, string>("mobileOSVersion", GetMobileOSVersion));
 		}
 		

--- a/Tests/AutomaticTestApp/App/Parts/WebSocket.ux
+++ b/Tests/AutomaticTestApp/App/Parts/WebSocket.ux
@@ -5,7 +5,8 @@
 		fw.testStarted("WebSocket");
 
 		var env = require('FuseJS/Environment');
-		if (env.ios || env.android || env.dotnet) {
+		//  `&& !(env.preview && env.host_mac)` can be removed when #467 is fixed
+		if (env.ios || env.android || env.dotnet && !(env.preview && env.host_mac)) {
 			var ws = new WebSocket("wss://echo.websocket.org/");
 
 			ws.addEventListener('open', function() {


### PR DESCRIPTION
Workaround for #467, fixes #485

This makes the auto test app work in preview on macOS, by disabling the `WebSocket` test.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
