### PR TITLE
Fuse.Reactive cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## MultiDensityImageSource
 - Added native support, meaning it can be used by images inside a `NativeViewHost`.
 
+### Fuse.Reactive framework changes (Uno-level)
+- These are breaking changes, but very unlikely to affect your app:
+ * The `DataBinding`, `EventBinding` and `ExpressionBinding` class constructors no longer take a `NameTable` argument.
+ * The `Name` and `This` expression classes has been removed. The UX compiler will now compile these as `Constant` expressions that contain the actual objects instead.
+ * The `IContext` interface no longer contains the `NameTable` property.
+ * The `Fuse.IRaw` interface removed (now internal to the `Fuse.Reactive.JavaScript` package). Had no practical public use.
+ * The `Fuse.Reactive.ListMirror` class is no longer public. This was never intended to be public and has no practical public application.
+ * Added detailed docs for many of the interfaces in the `Fuse.Reactive` namespace.
+ * The `Fuse.Reactive.IWriteable` interface has changed (breaking!). The method signature is now `bool TrySetExclusive(object)` instead of `void SetExclusive(object)`. Unlikely to affect your code.
+ * `IObservable` and `IObservableArray` no longer push their initial value on `Subscribe`.
+
+
 # 1.3
 
 ## 1.3.0
@@ -98,11 +110,6 @@ which will stop push notifications registering (and potentially asking for permi
 
 ### Fuse.Drawing.Surface
 - Added support for the Surface API in native UI for iOS. Meaning that `Curve`, `VectorLayer` and charting will work inside a `NativeViewHost`.
-## Fuse.Reactive cleanup (Uno-level)
-- The `Fuse.IRaw` interface removed (now internal to the `Fuse.Reactive.JavaScript` package). Had no practical public use.
-- The `Fuse.Reactive.ListMirror` class is no longer public. This was never intended to be public and has no practical public application.
-- Added detailed docs for many of the interfaces in the `Fuse.Reactive` namespace.
-- The `Fuse.Reactive.IWriteable` interface has changed (breaking!). The method signature is now `bool TrySetExclusive(object)` instead of `void SetExclusive(object)`. Unlikely to affect your code.
 
 ### TextInput
 - Fixed issue on Android causing text to align incorrectly if being scrolled and unfocused.
@@ -126,12 +133,6 @@ which will stop push notifications registering (and potentially asking for permi
 ### UpdateManager changes (Uno-level)
 - Breaking change: Several entrypoints on UpdateManager now take a `LayoutPriority` enum instead of `int` as the `priority` argument. Very unlikely to affect user code code.
 - Fixed an issue where writes to `FuseJS/Observables` would not dispatch in the right order on the UI thread if interleaved with `ScriptClass` callbacks (slightly breaking behavior).
-
-### Fuse.Reactive framework changes (Uno-level)
-- These are breaking changes, but very unlikely to affect your app:
- * The `DataBinding`, `EventBinding` and `ExpressionBinding` class constructors no longer take a `NameTable` argument.
- * The `Name` and `This` expression classes has been removed. The UX compiler will now compile these as `Constant` expressions that contain the actual objects instead.
- * The `IContext` interface no longer contains the `NameTable` property.
 
 
 # 1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,11 @@ which will stop push notifications registering (and potentially asking for permi
 
 ### Fuse.Drawing.Surface
 - Added support for the Surface API in native UI for iOS. Meaning that `Curve`, `VectorLayer` and charting will work inside a `NativeViewHost`.
+## Fuse.Reactive cleanup (Uno-level)
+- The `Fuse.IRaw` interface removed (now internal to the `Fuse.Reactive.JavaScript` package). Had no practical public use.
+- The `Fuse.Reactive.ListMirror` class is no longer public. This was never intended to be public and has no practical public application.
+- Added detailed docs for many of the interfaces in the `Fuse.Reactive` namespace.
+- The `Fuse.Reactive.IWriteable` interface has changed (breaking!). The method signature is now `bool TrySetExclusive(object)` instead of `void SetExclusive(object)`. Unlikely to affect your code.
 
 ### TextInput
 - Fixed issue on Android causing text to align incorrectly if being scrolled and unfocused.

--- a/Source/Fuse.Common/IObject.uno
+++ b/Source/Fuse.Common/IObject.uno
@@ -1,11 +1,17 @@
 
 namespace Fuse
 {
-	public interface IRaw
-	{
-		object Raw { get; }
-	}
+	/** Represents an array-like collection.
 
+		The underlaying type is not neccessarily an Uno array or collection.
+		
+		Allthough read-only through this interface, the array is not neccessarily immutable. 
+		Changes to the array can only happen on the UI thread. This means the UI thread can safely
+		read properties from this array.
+
+		If the object also supports `Fuse.Reactive.IObservableArray, consumers can subscribe to the
+		array to receive change notifications.
+	*/
 	public interface IArray
 	{
 		int Length { get; }
@@ -14,6 +20,18 @@ namespace Fuse
 			get; 
 		}
 	}
+
+	/** Represents a key-value object, where the keys can be enumerated and looked up by string name.
+
+		The enumerable keys do not neccessarily correspond to Uno properties on the object.
+	
+		Allthough read-only through this interface, the object is not neccessarily immutable. 
+		Changes to the object can only happen on the UI thread. This means the UI thread can safely
+		read properties from this object.
+
+		If the object also supports `Fuse.Reactive.IObservableObject`, consumers can subscribe
+		to receive change notifications.
+	*/
 	public interface IObject
 	{
 		bool ContainsKey(string key);

--- a/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
@@ -25,7 +25,7 @@ namespace FuseTest
 		
 		List<IObserver> _observers;
 		
-		ISubscription IObservable.Subscribe(IObserver observer)
+		Uno.IDisposable IObservableArray.Subscribe(IObserver observer)
 		{
 			if (_observers == null)
 				_observers = new List<IObserver>();

--- a/Source/Fuse.Nodes/Node.DataContext.uno
+++ b/Source/Fuse.Nodes/Node.DataContext.uno
@@ -39,7 +39,7 @@ namespace Fuse
 			{
 				if (_key == "")
 				{
-					Resolve(data);
+					Resolve(null, data);
 					return false;
 				}
 				else
@@ -49,7 +49,7 @@ namespace Fuse
 					{
 						if (obj.ContainsKey(_key))
 						{
-							Resolve(obj[_key]);
+							Resolve(obj, obj[_key]);
 							return false;
 						}
 					}
@@ -57,7 +57,7 @@ namespace Fuse
 
 				return true; // keep looking 
 			}
-			protected abstract void Resolve(object data);
+			protected abstract void Resolve(IObject provider, object data);
 		}
 
 		public object GetFirstData()

--- a/Source/Fuse.Nodes/Node.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Node.ScriptClass.uno
@@ -69,7 +69,7 @@ namespace Fuse
 			}
 
 			object _data;
-			protected override void Resolve(object data)
+			protected override void Resolve(IObject provider, object data)
 			{
 				_data = data;
 				_context.Dispatcher.Invoke(Update);

--- a/Source/Fuse.Reactive.Bindings/DataBinding.uno
+++ b/Source/Fuse.Reactive.Bindings/DataBinding.uno
@@ -180,7 +180,11 @@ namespace Fuse.Reactive
 			{
 				if (_subscription != null)
 				{
-					if (Write) _subscription.SetExclusive(Target.GetAsObject());
+					if (Write) 
+					{
+						var sub = _subscription as ISubscription;
+						if (sub != null) sub.SetExclusive(Target.GetAsObject());
+					}
 				}
 				else if (CanWriteBack)
 				{
@@ -189,7 +193,7 @@ namespace Fuse.Reactive
 			}
 		}
 
-		ISubscription _subscription;
+		IDisposable _subscription;
 
 		internal override void NewValue(object value)
 		{
@@ -202,14 +206,16 @@ namespace Fuse.Reactive
 			if (Marshal.Is(value, Target.PropertyType))
 			{
 				// Note - this case is required in addition to the final 'else', because if the target
-				// property accepts Observable, we should not create a subscription, but pass it
+				// property accepts the observable object, we should not create a subscription, but pass it
 				// directly to the target
 
 				PushValue(value);
 			}
 			else if (Marshal.Is(value, typeof(IObservable)))
 			{
+				// Special treatment for the IObservable interface - see docs on IObservable for rationale
 				var obs = (IObservable)value;
+				if (obs.Length > 0) PushValue(obs[0]);
 				_subscription = obs.Subscribe(this);
 			}
 			else

--- a/Source/Fuse.Reactive.Bindings/Each.uno
+++ b/Source/Fuse.Reactive.Bindings/Each.uno
@@ -144,11 +144,17 @@ namespace Fuse.Reactive
 		Each(IList<Template> templates): base(templates) {}
 		public Each() {}
 
-		/** An array or observable containing the data items used to populate the collection. 
+		/** A collection containing the data items used to populate the parent. 
 
-			Can not be used together with `Count`.
-			
-			The list of items may be Observable items. Each will subscribe to these items and use the dynamic value. This however does not work in combination with the `MatchKey`, `IdentityKey` and `MatchObject` features which require an immediate value.
+			This property can not be used together with `Count`.
+
+			The provided object must implement `IArray`. To support dynamic changes to the collection, it can also implement `IObservableArray`.
+			For example, if a `FuseJS/Observable` is provided, this implements `IObservableArray`.
+	
+			Each item in the collection can in turn be an `IObservable`. If so, the Each will subscribe to these items and use the dynamic value. However,
+			this will not work in combination with the `MatchKey`, `IdentityKey` and `MatchObject` features which require an immediate value.
+
+			For legacy reasons, this property will also accept an `object[]` as the collection. This feature is deprecated.
 		*/
 		public object Items
 		{

--- a/Source/Fuse.Reactive.Bindings/ExpressionBinding.uno
+++ b/Source/Fuse.Reactive.Bindings/ExpressionBinding.uno
@@ -15,7 +15,7 @@ namespace Fuse.Reactive
 		IDisposable _expressionSub;
 
 		protected internal bool CanWriteBack { get { return _expressionSub is IWriteable; } }
-		protected internal void WriteBack(object value) { ((IWriteable)_expressionSub).SetExclusive(value); }
+		protected internal void WriteBack(object value) { ((IWriteable)_expressionSub).TrySetExclusive(value); }
 
 		protected override void OnRooted()
 		{

--- a/Source/Fuse.Reactive.Bindings/Instance.API.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.API.uno
@@ -322,21 +322,22 @@ namespace Fuse.Reactive
 		
 		protected internal void OnItemsChanged()
 		{
-			if (!IsRootingStarted) return;
+			if (!IsRootingCompleted) return;
 
+			RefreshItems();
+		}
+
+		void RefreshItems()
+		{
 			DisposeItemsSubscription();	
 
-			RemoveAll();
+			Repopulate();
 
-			var obs = _items as IObservable;
+			var obs = _items as IObservableArray;
 			if (obs != null)
 			{
 				StartListeningItems();
 				_itemsSubscription = obs.Subscribe(this);
-			}
-			else
-			{
-				Repopulate();
 			}
 		}
 		

--- a/Source/Fuse.Reactive.Bindings/Instance.WindowItems.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.WindowItems.uno
@@ -28,10 +28,16 @@ namespace Fuse.Reactive
 			return this;
 		}
 		bool _pendingNew;
+
+		// Used to test that Instance internals behaves correctly
+		// in light of https://github.com/fusetools/fuselibs-public/issues/227
+		extern (UNO_TEST) internal static int InsertCount;
 		
 		/** Inserts a new item into the _windowItems. The actual creation of the objects may be deferred. */
 		void InsertNew(int dataIndex)
 		{
+			if defined (UNO_TEST) InsertCount++; 
+
 			if (dataIndex < Offset ||
 				(HasLimit && (dataIndex - Offset) >= Limit))
 				return;

--- a/Source/Fuse.Reactive.Bindings/Instance.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.uno
@@ -82,7 +82,7 @@ namespace Fuse.Reactive
 		protected override void OnRooted()
 		{
 			base.OnRooted();
-			OnItemsChanged();
+			RefreshItems();
 			
 			if (_rootTemplates != null)
 				_rootTemplates.Subscribe(OnTemplatesChanged, OnTemplatesChanged);
@@ -95,6 +95,7 @@ namespace Fuse.Reactive
 			_isListeningItems = false;
 			if (_itemsSubscription != null)
 			{
+				_isListeningItems = false;
 				_itemsSubscription.Dispose();
 				_itemsSubscription = null;
 			}

--- a/Source/Fuse.Reactive.Bindings/MatchCase.uno
+++ b/Source/Fuse.Reactive.Bindings/MatchCase.uno
@@ -108,7 +108,7 @@ namespace Fuse.Reactive
 			throw new Exception("<Match> can not be used on lists (received OnRemoveAt)");
 		}
 
-		ISubscription _subscription;
+		IDisposable _subscription;
 
 		object _realValue;
 		object _value;
@@ -131,7 +131,9 @@ namespace Fuse.Reactive
 
 					if (_value is IObservable)
 					{
+						// Special treatment for IObservable which can be interpreted as a single value
 						var obs = (IObservable)_value;
+						if (obs.Length > 0) _realValue = obs[0];
 						_subscription = obs.Subscribe(this);
 					}
 					else

--- a/Source/Fuse.Reactive.Bindings/Tests/Each.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/Each.Test.uno
@@ -69,22 +69,30 @@ namespace Fuse.Reactive.Test
 		public void DoubleSubscribe()
 		{
 			var e = new UX.Each.DoubleSubscribe();
+			Instance.InsertCount = 0;
 			using (var root = TestRootPanel.CreateWithChild(e))
 			{
 				root.StepFrameJS();
 				Assert.AreEqual(6, e.sp.Children.Count);
+				Assert.AreEqual(3, Instance.InsertCount);
+				Instance.InsertCount = 0;
 				e.sw.Value = true;
 				root.StepFrameJS();
 				Assert.AreEqual(10, e.sp.Children.Count);
+				Assert.AreEqual(3, Instance.InsertCount);
+				Instance.InsertCount = 0;
 				e.sw.Value = false;
 				root.StepFrameJS();
 				Assert.AreEqual(6, e.sp.Children.Count);
+				Assert.AreEqual(0, Instance.InsertCount);
+				Instance.InsertCount = 0;
 
 				// Weridly, second time it failed to add the items back
 				// https://github.com/fusetools/fuselibs-public/issues/227
 				e.sw.Value = true;
 				root.StepFrameJS();
 				Assert.AreEqual(10, e.sp.Children.Count);
+				Assert.AreEqual(3, Instance.InsertCount);
 			}
 		}
 

--- a/Source/Fuse.Reactive.Bindings/WhileCount.uno
+++ b/Source/Fuse.Reactive.Bindings/WhileCount.uno
@@ -84,7 +84,7 @@ namespace Fuse.Reactive
 				
 			if (_subscription != null) _subscription.Dispose();
 			
-			var obs = _items as IObservable;
+			var obs = _items as IObservableArray;
 			if (obs != null)
 				_subscription = obs.Subscribe(this);
 			
@@ -103,7 +103,7 @@ namespace Fuse.Reactive
 				return;
 			}
 			
-			var obs = _items as IObservable;
+			var obs = _items as IObservableArray;
 			if (obs != null)
 			{
 				Assess(obs.Length);

--- a/Source/Fuse.Reactive.Bindings/With.uno
+++ b/Source/Fuse.Reactive.Bindings/With.uno
@@ -55,6 +55,7 @@ namespace Fuse.Reactive
 					var obs = value as IObservable;
 					if (obs != null) 
 					{
+						// Special case for `IObservable` which can be interpreted as a single value
 						SetSubtreeData(null);
 						_sub = new ValueForwarder(obs, this);
 					}

--- a/Source/Fuse.Reactive.Expressions/Property.uno
+++ b/Source/Fuse.Reactive.Expressions/Property.uno
@@ -41,11 +41,15 @@ namespace Fuse.Reactive
 				PushValue();
 			}
 
-			public void SetExclusive(object value)
+			public bool TrySetExclusive(object value)
 			{
 				object res;
 				if (Marshal.TryConvertTo(_accessor.PropertyType, value, out res, _object))
+				{
 					_accessor.SetAsObject(_object, res, this);
+					return true;
+				}
+				return false;
 			}
 
 			public void Dispose()

--- a/Source/Fuse.Reactive.Expressions/Subscription.uno
+++ b/Source/Fuse.Reactive.Expressions/Subscription.uno
@@ -58,6 +58,7 @@ namespace Fuse.Reactive
 			var obs = value as IObservable;
 			if (obs != null)
 			{
+				// Special case for IObservable which can be interpreted as a single value
 				if (_obsSubs == null) _obsSubs = new Dictionary<IExpression, ObservableSubscription>();
 				_obsSubs.Add(source, new ObservableSubscription(source, obs, this));
 			}

--- a/Source/Fuse.Reactive.Expressions/Tests/ObservableObjectTest.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/ObservableObjectTest.uno
@@ -1,0 +1,103 @@
+using Uno;
+using Uno.Collections;
+using Uno.UX;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Reactive.Test
+{
+	class TestData : IObservableObject
+	{
+		string _foo = "haha";
+		string _bar = "hoho";
+		TestData _other = null;
+
+		public string Foo { get { return _foo; } set { _foo = value; OnPropertyChanged("Foo", value); } }
+		public string Bar { get { return _bar; } set { _bar = value; OnPropertyChanged("Bar", value); } }
+		[UXContent]
+		public TestData Other { get { return _other; } set { _other = value; OnPropertyChanged("Other", value); } }
+
+		public object this[string key]
+		{
+			get
+			{
+				if (key == "Foo") return Foo;
+				else if (key == "Bar") return Bar;
+				else if (key == "Other") return Other;
+				else throw new Exception();
+			}
+		}
+
+		public string[] Keys
+		{
+			get { return new [] { "Foo", "Bar", "Other"}; }
+		}
+
+		public bool ContainsKey(string key)
+		{
+			for (var i = 0; i < Keys.Length; i++)
+				if (Keys[i] == key) return true;
+
+			return false;
+		}
+
+		public void OnPropertyChanged(string key, object value)
+		{
+			for (var i = 0; i < _listeners.Count; i++)
+				_listeners[i].Observer.OnPropertyChanged(_listeners[i], key, value);
+		}
+
+		public IPropertySubscription Subscribe(IPropertyObserver observer)
+		{
+			var sub = new Subscription(this, observer);
+			_listeners.Add(sub);
+			return sub;
+		}
+
+		List<Subscription> _listeners = new List<Subscription>();
+
+		class Subscription: IPropertySubscription
+		{
+			TestData _td;
+			public readonly IPropertyObserver Observer;
+			public Subscription(TestData td, IPropertyObserver observer)
+			{
+				_td = td;
+				Observer = observer;
+			}
+			public bool TrySetExclusive(string propertyName, object newValue)
+			{
+				throw new Exception();
+			}
+			public void Dispose()
+			{
+				_td._listeners.Remove(this);
+			}
+		}
+	}
+
+	class ObservableObjectTest : TestBase
+	{
+		[Test]
+		public void Basics()
+		{
+			var c = new UX.ObservableObjectTest();
+			using (var root = TestRootPanel.CreateWithChild(c))
+			{
+				root.StepFrame();
+				Assert.AreEqual("Hey there haha and hoho and Lol! and yaya!", c.t.Value);
+				c.d.Foo = "kjeks";
+				Assert.AreEqual("Hey there kjeks and hoho and Lol! and yaya!", c.t.Value);
+				c.d.Bar = "kake";
+				Assert.AreEqual("Hey there kjeks and kake and Lol! and yaya!", c.t.Value);
+				c.td.Foo = "pepperkake";
+				Assert.AreEqual("Hey there kjeks and kake and pepperkake and yaya!", c.t.Value);
+				c.d.Other = new TestData();
+				Assert.AreEqual("Hey there kjeks and kake and haha and hoho!", c.t.Value);
+				c.td.Foo = "hest";
+				Assert.AreEqual("Hey there kjeks and kake and haha and hoho!", c.t.Value);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/ObservableObjectTest.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/ObservableObjectTest.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.ObservableObjectTest">
+	<With>
+		<Fuse.Reactive.Test.TestData ux:Binding="Data" ux:Name="d">
+			<Fuse.Reactive.Test.TestData ux:Name="td" Foo="Lol!" Bar="yaya" />
+		</Fuse.Reactive.Test.TestData>
+		<Text ux:Name="t">Hey there {Foo} and {Bar} and {Other.Foo} and {Other.Bar}!</Text>
+	</With>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/VarArgFunction.uno
+++ b/Source/Fuse.Reactive.Expressions/VarArgFunction.uno
@@ -1,4 +1,5 @@
 using Uno;
+using Uno.UX;
 using Uno.Collections;
 
 namespace Fuse.Reactive

--- a/Source/Fuse.Reactive.JavaScript/ClassInstance.uno
+++ b/Source/Fuse.Reactive.JavaScript/ClassInstance.uno
@@ -13,7 +13,7 @@ namespace Fuse.Reactive
 		readonly NameTable _rootTable;
 		readonly object _obj;
 		Scripting.Object _self;
-		Dictionary<Property, ObservableProperty> _properties;
+		Dictionary<Uno.UX.Property, ObservableProperty> _properties;
 
 		internal ObservableProperty GetObservableProperty(string name)
 		{
@@ -68,7 +68,7 @@ namespace Fuse.Reactive
 
 		void EnsureHasProperties()
 		{
-			if (_properties == null) _properties = new Dictionary<Property, ObservableProperty>();
+			if (_properties == null) _properties = new Dictionary<Uno.UX.Property, ObservableProperty>();
 		}
 
 		void DispatchUnroot()
@@ -78,7 +78,7 @@ namespace Fuse.Reactive
 			_worker.Invoke(Unroot);
 		}
 
-		internal Scripting.Object GetPropertyObservable(Property p)
+		internal Scripting.Object GetPropertyObservable(Uno.UX.Property p)
 		{
 			EnsureHasProperties();
 

--- a/Source/Fuse.Reactive.JavaScript/FunctionMirror.uno
+++ b/Source/Fuse.Reactive.JavaScript/FunctionMirror.uno
@@ -11,6 +11,7 @@ namespace Fuse.Reactive
 		readonly Function _func;
 
 		public object Raw { get { return _func; } }
+		public object ReflectedRaw { get { return _func; } }
 
 		public FunctionMirror(Function func)
 		{

--- a/Source/Fuse.Reactive.JavaScript/Fuse.Reactive.JavaScript.unoproj
+++ b/Source/Fuse.Reactive.JavaScript/Fuse.Reactive.JavaScript.unoproj
@@ -17,6 +17,7 @@
     "../Fuse.Drawing/Fuse.Drawing.unoproj",
     "../Fuse.Reactive/Fuse.Reactive.unoproj",
     "../Fuse.Reactive.Bindings/Fuse.Reactive.Bindings.unoproj",
+    "../Fuse.Reactive.Expressions/Fuse.Reactive.Expressions.unoproj",
     "../Fuse.Platform/Fuse.Platform.unoproj",
     "../Fuse.Scripting.Duktape/Fuse.Scripting.Duktape.unoproj",
     "../Fuse.Scripting.JavaScriptCore/Fuse.Scripting.JavaScriptCore.unoproj",

--- a/Source/Fuse.Reactive.JavaScript/FuseJS/DiagnosticsImpl.uno
+++ b/Source/Fuse.Reactive.JavaScript/FuseJS/DiagnosticsImpl.uno
@@ -18,7 +18,7 @@ namespace Fuse.Reactive.FuseJS
 			if (_instance != null) 
 				return;
 				
-			Resource.SetGlobalKey(_instance = this, "FuseJS/DiagnosticsImpl");
+			Uno.UX.Resource.SetGlobalKey(_instance = this, "FuseJS/DiagnosticsImpl");
 			
 			AddMember(new NativeFunction("report", (NativeCallback)Report));
 		}

--- a/Source/Fuse.Reactive.JavaScript/FuseJS/Http.uno
+++ b/Source/Fuse.Reactive.JavaScript/FuseJS/Http.uno
@@ -15,7 +15,7 @@ namespace Fuse.Reactive.FuseJS
 		public Http()
 		{
 			if (_instance != null) return;
-			Resource.SetGlobalKey(_instance = this, "FuseJS/Http");
+			Uno.UX.Resource.SetGlobalKey(_instance = this, "FuseJS/Http");
 		}
 
 		public override void Evaluate(Context c, ModuleResult result)

--- a/Source/Fuse.Reactive.JavaScript/FuseJS/Timer.uno
+++ b/Source/Fuse.Reactive.JavaScript/FuseJS/Timer.uno
@@ -44,7 +44,7 @@ namespace Fuse.Reactive.FuseJS
 		{
 			if(_instance != null) return;
 
-			Resource.SetGlobalKey(_instance = this, "FuseJS/Timer");
+			Uno.UX.Resource.SetGlobalKey(_instance = this, "FuseJS/Timer");
 			
 			_tm = new TimerManager();
 			AddMember(new NativeFunction("create", (NativeCallback)Create));

--- a/Source/Fuse.Reactive.JavaScript/JavaScript.Dependencies.uno
+++ b/Source/Fuse.Reactive.JavaScript/JavaScript.Dependencies.uno
@@ -96,7 +96,7 @@ namespace Fuse.Reactive
 				for (var i = 0; i < _dependencies.Count; i++)
 					_dependencies[i].Subscribe(this);
 
-			DispatchEvaluateIfDependenciesReady();
+			if (_dependencies == null || _dependencies.Count == 0) DispatchEvaluateIfDependenciesReady();
 		}
 
 		void DisposeDependencySubscriptions()

--- a/Source/Fuse.Reactive.JavaScript/JavaScript.uno
+++ b/Source/Fuse.Reactive.JavaScript/JavaScript.uno
@@ -56,7 +56,7 @@ namespace Fuse.Reactive
 			{
 				AppInitialized.Reset();
 				// When all JavaScript nodes is unrooted, send a reset event to all global NativeModules.
-				foreach(var nm in Resource.GetGlobalsOfType<NativeModule>())
+				foreach(var nm in Uno.UX.Resource.GetGlobalsOfType<NativeModule>())
 				{
 					nm.InternalReset();
 				}

--- a/Source/Fuse.Reactive.JavaScript/ObjectMirror.uno
+++ b/Source/Fuse.Reactive.JavaScript/ObjectMirror.uno
@@ -5,15 +5,24 @@ namespace Fuse.Reactive
 {
 	class ObjectMirror : ValueMirror, IObject
 	{
-		Dictionary<string, object> _props = new Dictionary<string, object>();
+		protected Dictionary<string, object> _props = new Dictionary<string, object>();
 
-		internal ObjectMirror(ThreadWorker worker, Scripting.Object obj): base(obj)
+		/** Does not poulate the _props. This allows calling Set later with mirror == this */
+		protected ObjectMirror(Scripting.Object obj) : base(obj) {}
+
+		internal ObjectMirror(IMirror mirror, Scripting.Object obj): base(obj)
 		{
+			Set(mirror, obj);
+		}
+
+		internal virtual void Set(IMirror mirror, Scripting.Object obj)
+		{
+			_props.Clear();
 			var k = obj.Keys;
 			for (int i = 0; i < k.Length; i++)
 			{
 				var s = k[i];
-				_props.Add(s, worker.Reflect(obj[s]));
+				_props.Add(s, mirror.Reflect(obj[s]));
 			}
 		}
 

--- a/Source/Fuse.Reactive.JavaScript/Observable.uno
+++ b/Source/Fuse.Reactive.JavaScript/Observable.uno
@@ -74,8 +74,6 @@ namespace Fuse.Reactive
 				_om = om;
 				_obs = obs;
 
-				if (_om.Length == 1) obs.OnSet(_om[0]);
-				else obs.OnNewAll(_om);
 			}
 
 			public void SetExclusive(object newValue)
@@ -141,6 +139,11 @@ namespace Fuse.Reactive
 		public ISubscription Subscribe(IObserver observer)
 		{
 			return new Subscription(this, observer);
+		}
+
+		IDisposable IObservableArray.Subscribe(IObserver observer)
+		{
+			return Subscribe(observer);
 		}
 
 		readonly ThreadWorker _worker;

--- a/Source/Fuse.Reactive.JavaScript/ObservableProperty.uno
+++ b/Source/Fuse.Reactive.JavaScript/ObservableProperty.uno
@@ -6,7 +6,7 @@ namespace Fuse.Reactive
 {
 	class LazyObservableProperty: ObservableProperty
 	{
-		public LazyObservableProperty(ThreadWorker w, Scripting.Object obj, Property p): base(w, obj, p)
+		public LazyObservableProperty(ThreadWorker w, Scripting.Object obj, Uno.UX.Property p): base(w, obj, p)
 		{
 			w.Context.ObjectDefineProperty(obj, p.Name.ToString(), Get);	
 		}
@@ -26,10 +26,10 @@ namespace Fuse.Reactive
 	class ObservableProperty: IObserver, IPropertyListener
 	{
 		protected readonly ThreadWorker _worker;
-		Property _property;
+		Uno.UX.Property _property;
 		Scripting.Object _obj;
 
-		public ObservableProperty(ThreadWorker w, Scripting.Object obj, Property p)
+		public ObservableProperty(ThreadWorker w, Scripting.Object obj, Uno.UX.Property p)
 		{
 			_obj = obj;
 			_worker = w;

--- a/Source/Fuse.Reactive.JavaScript/SubscriptionSubject.uno
+++ b/Source/Fuse.Reactive.JavaScript/SubscriptionSubject.uno
@@ -1,0 +1,51 @@
+using Uno;
+
+namespace Fuse.Reactive
+{
+	/** Implements subscription subject with a fast linked list of disposable subscriptions-
+		This is intended as the base class of ValueMirro.
+	*/
+	abstract class SubscriptionSubject
+	{
+		Subscription _subscribers; // Linked list;
+
+		protected Subscription Subscribers { get { return _subscribers; } }
+
+		protected internal abstract class Subscription: IDisposable
+		{
+			Subscription _next, _prev;
+
+			protected Subscription Next { get { return _next; } }
+
+			readonly SubscriptionSubject _s;
+			protected SubscriptionSubject SubscriptionSubject { get { return _s; } }
+
+			protected Subscription(SubscriptionSubject s)
+			{
+				_s = s;
+				
+				if (s._subscribers == null) s._subscribers = this;
+				else 
+				{
+					_next = s._subscribers;
+					_next._prev = this;
+					s._subscribers = this;
+				}
+			}
+
+			public void Dispose()
+			{
+				if (_s._subscribers == this)
+				{
+					_s._subscribers = _next;
+					if (_next != null) _next._prev = null;
+				}
+				else
+				{
+					_prev._next = _next;
+					if (_next != null)	_next._prev = _prev;
+				}
+			}
+		}
+	}
+}

--- a/Source/Fuse.Reactive.JavaScript/Tests/ObservableTest.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/ObservableTest.uno
@@ -10,12 +10,49 @@ using FuseTest;
 
 namespace Fuse.Reactive.Test
 {
+	public class CreateCountPanel: Panel
+	{
+		public static int Count;
+		public CreateCountPanel() {
+			Count++;
+		}
+		public static int RootedCount;
+		protected override void OnRooted()
+		{
+			base.OnRooted();
+			RootedCount++;
+		}
+	}
+
 	/*
 		This tests the functions of the observable including the protocol used to synchronize
 		between JS and Uno. This is meant to be a more direct testing than the EachTest setup.
 	*/
 	public class ObservableTest : TestBase
 	{
+		[Test]
+		public void DoubleSubscribe()
+		{
+			CreateCountPanel.Count = 0;
+			Instance.InsertCount = 0;
+			var p = new UX.Observable.DoubleSubscribe();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				root.StepFrameJS();
+				root.StepFrameJS();
+				Assert.AreEqual(3, CreateCountPanel.Count);
+				Assert.AreEqual(3, CreateCountPanel.RootedCount);
+				Assert.AreEqual(3, Instance.InsertCount);
+				Instance.InsertCount = 0;
+				p.flip.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual(9, CreateCountPanel.Count);
+				Assert.AreEqual(9, CreateCountPanel.RootedCount);
+				Assert.AreEqual(7, Instance.InsertCount);
+			}
+		}
+
 		[Test]
 		public void BasicEmpty()
 		{

--- a/Source/Fuse.Reactive.JavaScript/Tests/UX/Observable.DoubleSubscribe.ux
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UX/Observable.DoubleSubscribe.ux
@@ -1,0 +1,30 @@
+<Panel ux:Class="UX.Observable.DoubleSubscribe">
+    <JavaScript>
+        var Observable = require("FuseJS/Observable")
+
+        exports.items = Observable(1,2,3)
+        exports.itemsMapped = exports.items.map(function(x) { return x*2; } )
+        exports.g = Observable()
+
+        exports.flip = function() {
+            exports.g.add(123)
+        }
+        
+    </JavaScript>
+    <StackPanel ux:Name="p1">
+        <Each Items="{items}">
+            <Fuse.Reactive.Test.CreateCountPanel />
+        </Each>
+    </StackPanel>
+    <Each Items="{g}">
+        <StackPanel ux:Name="p2">
+            <Each Items="{items}">
+                <Fuse.Reactive.Test.CreateCountPanel />
+            </Each>
+            <Each Items="{itemsMapped}">
+                <Fuse.Reactive.Test.CreateCountPanel />
+            </Each>
+        </StackPanel>   
+    </Each>
+    <FuseTest.Invoke Handler="{flip}" ux:Name="flip"/>
+</Panel>

--- a/Source/Fuse.Reactive.JavaScript/ThreadWorker.Wrapping.uno
+++ b/Source/Fuse.Reactive.JavaScript/ThreadWorker.Wrapping.uno
@@ -73,7 +73,7 @@ namespace Fuse.Reactive
 		{
 			if (dc == null) return null;
 			else if (dc is string) return dc;
-			else if (dc is IRaw) return ((IRaw)dc).Raw;
+			else if (dc is IRaw) return ((IRaw)dc).ReflectedRaw;
 			else if (dc is Scripting.Function) return dc;
 			else if (dc is Scripting.Object) return dc;
 			else if (dc is Scripting.Array) return dc;

--- a/Source/Fuse.Reactive.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Reactive.JavaScript/ThreadWorker.uno
@@ -7,7 +7,12 @@ using Fuse.Scripting;
 
 namespace Fuse.Reactive
 {
-	partial class ThreadWorker: IDisposable, IDispatcher, IThreadWorker
+	interface IMirror
+	{
+		object Reflect(object obj);
+	}
+
+	partial class ThreadWorker: IDisposable, IDispatcher, IThreadWorker, IMirror
 	{
 		IDispatcher IThreadWorker.Dispatcher { get { return this; } }
 		Function IThreadWorker.Observable { get { return FuseJS.Observable; } }

--- a/Source/Fuse.Reactive.JavaScript/ValueMirror.uno
+++ b/Source/Fuse.Reactive.JavaScript/ValueMirror.uno
@@ -4,12 +4,24 @@ using Uno.Threading;
 
 namespace Fuse.Reactive
 {
-	public abstract class ValueMirror: IRaw
+	/** Represents a raw JS object */
+	interface IRaw
+	{
+		object Raw { get; }
+
+		/**	The object that JavaScript will see if this object is passed
+			back into the VM. TreeObject will override this
+		*/
+		object ReflectedRaw { get; }
+	}
+
+	abstract class ValueMirror: SubscriptionSubject, IRaw
 	{
 		public abstract void Unsubscribe();
 
 		readonly object _raw;
 		public object Raw { get { return _raw; } }
+		public virtual object ReflectedRaw { get { return _raw; } }
 
 		protected ValueMirror(object raw)
 		{
@@ -23,7 +35,7 @@ namespace Fuse.Reactive
 		}
 	}
 
-	public abstract class ListMirror: ValueMirror, IArray
+	abstract class ListMirror: ValueMirror, IArray
 	{
 		public abstract int Length { get; }
 		public abstract object this[int index] { get; }

--- a/Source/Fuse.Reactive/Fuse.Reactive.unoproj
+++ b/Source/Fuse.Reactive/Fuse.Reactive.unoproj
@@ -22,6 +22,7 @@
     "Fuse.Navigation",
     "Fuse.Reactive.Bindings",
     "Fuse.Reactive.Expressions",
+    "Fuse.Expressions.Test",
     "Fuse.Reactive.JavaScript",
     "Fuse.Reactive.Test",
     "Fuse.Scripting.Test",

--- a/Source/Fuse.Reactive/IExpression.uno
+++ b/Source/Fuse.Reactive/IExpression.uno
@@ -26,10 +26,13 @@ namespace Fuse.Reactive
 		Node Node { get; }
 	}
 
-	/** Represents a subscription that supports write-back. */
+	/** Represents a subscription that might support write-back. */
 	public interface IWriteable: IDisposable
 	{
-		void SetExclusive(object value);
+		/** Attempts to write to the source. 
+			Returns whether or not the source was successfully updated.
+		*/
+		bool TrySetExclusive(object value);
 	}
 
 	public interface IExpression

--- a/Source/Fuse.Reactive/IObservable.uno
+++ b/Source/Fuse.Reactive/IObservable.uno
@@ -5,18 +5,140 @@ using Uno.Threading;
 
 namespace Fuse.Reactive
 {
-	interface IObservable: IArray
+	/** Represents an object with reactive properties.
+
+		An `IObject` that also implements this interface will emit events to observers when the
+		value of any of its properties change.
+
+		This interface can be implemented by any reactive data provider that wants to interop
+		with the `Fuse.Reactive` framework.
+	*/
+	interface IObservableObject: IObject
 	{
-		ISubscription Subscribe(IObserver observer);
+		/** Creates a new subscription to the object, which will pass change events to the given observer. */
+		IPropertySubscription Subscribe(IPropertyObserver observer);
 	}
 
+	interface IPropertySubscription: IDisposable
+	{
+		/** Attempts to write back to the property. If successful, the current subscription will not be notified. */
+		bool TrySetExclusive(string propertyName, object newValue);
+	}
+
+	interface IPropertyObserver
+	{
+		/**
+			@param subscription The subscription that corresponds to this change event. Should be used to filter events that arrived after disposal.
+			@param propertyName The name of the property that changed
+			@param newValue The new value of the property
+		*/
+		void OnPropertyChanged(IDisposable subscription, string propertyName, object newValue);
+	}
+
+	/** Represents a reactive collection. 
+
+		This interface can be implemented by any reactive data provider that wants to interop
+		with the `Fuse.Reactive` framework.
+
+		## Availability of data
+
+		As `IObservableArray` extends `IArray`, it is always safe to read synchronously from
+		the collection in the range `0..Length`. However, any meaningful data may be unavailable 
+		(and hence `Length == 0`), or out of date. 
+		
+		A subscription is needed in order to instruct the implementation to fetch the
+		underlaying data or bring the collection up to date. When subscribed to, the data 
+		may then be fetched	asynchronously. The first reliable up-to-date data is passed 
+		to the subscription	via callbacks.
+	*/
+	interface IObservableArray: IArray
+	{
+		/** Creates a new subscription to the collection, which will pass change events to the given observer. 
+
+			## Disposal of subscription
+
+			The returned object is an `IDisposable`. Calling `Dispose()` on the subscription will unsubscribe from further
+			callbacks to the subscriber. However, the subscriber cannot safely assume that no more callbacks will be made.
+			The implementation may have already queued additional callbacks	to the subscriber that cannot be cancelled.
+			The subscriber must filter out any late callback messages that arrives after disposal of the subscription.
+
+			## Write-back subscriptions
+			
+			The returned object may or may not support the `ISubscription` interface. The subscriber can test whether the
+			returned object `is ISubscription`.If so, the data source supports write-backs	to the data source, where
+			the current subscription can be excluded from callbacks.
+		*/
+		IDisposable Subscribe(IObserver observer);
+	}
+
+	/** Represents a single reactive value, or a reactive collection.
+
+		Note that `Fuse.Reactive.IObservable` has many differences from observables in other reactive
+		frameworks (such as Rx, or `Uno.IObservable`). This is to accommodate many different types of data providers.
+
+		An `IObservable` can be in several significant states:
+		 * It can be *empty*, i.e. have *no value* (`Length == 0`)
+		 * It can hold a single primary value (`Length == 1`)
+		 * It can hold multiple values (`Length > 1`). The value at index `0` is still refered to as the *primary value*.
+
+		The most significant implementation of this interface is `FuseJS/Observable`.
+
+		## Primary value usage
+
+		This interface extends the `IObservableArray` with the added contract of
+		being interpretable as a single value, called the *primary value*. The primary
+		value of the `IObservable` is the value at index `0` in the collection, if available.
+		
+		When interpreted as a single value, it is valid for the collection to be empty, 
+		which which means the primary value is not available. It is also valid for the
+		collection to have more than one value, in which case the other values will be ignored.
+		
+		The `IObservable` interface receives special treatment by the reactive operators. For 
+		example, consider the following data-binding expression:
+
+			<Text>Hello {user.name}!</Text>
+
+		If `user` is an `IObservable`, then this data binding refers to `user[0].name`, when
+		at least one element is available in the `IObservable`.
+
+		An `IObservable` also gets special treatment by `DataBinding`. If a bound expression
+		yields an `IObservable`, and the target property is not compatible with `IObservable`,
+		the data binding will create a subscription and feed the primary value to the target
+		property. Example:
+
+			<Text>{message}</Text>
+
+		If `message` yields an `IObservable`, the primary value (`message[0]`) of the observable 
+		will be displayed, if available. If there primary value is not available, the expression
+		will not yield any value (no value is written to the target property.)
+
+		Some properties accept all types (`object`), or `IObservable` explicitly. In these cases,
+		the data binding will not create a subscription, but rather pass the object directly to 
+		the target property for it to create a subscription. Examples of this is `Each.Items`,
+		`Selection.Values`, `Match.Value`, `With.Data` and `WhileCount.Items`.
+
+		## Multi-value usage
+
+		If an `IObservable` is subscribed to in a scenario where an array is expected,
+		the object behaves identically to `IObservableArray`.
+	*/
+	interface IObservable: IObservableArray
+	{
+
+	}
+
+	/** Represents a subscription to an `IObservableArray` that supports write-backs. */
 	interface ISubscription: IDisposable
 	{
+		/** Clears the contents of the `IObservableArray` without notifying this subscription of the change. */
 		void ClearExclusive();
+		/** Replaces the `IObservableArray` with a list of length 1, containting the given object, without notifying this subscription of the change. */
 		void SetExclusive(object newValue);
+		/** Replaces the `IObservableArray` with the given values, without notifying this subscription of the change. */
 		void ReplaceAllExclusive(IArray values);
 	}
 	
+	/** Represents an object that can receive change notifications for an `IObservableArray`. */
 	interface IObserver
 	{
 		/** Clear all items */

--- a/Source/Fuse.Reactive/ValueObserver.uno
+++ b/Source/Fuse.Reactive/ValueObserver.uno
@@ -3,6 +3,10 @@ using Uno;
 namespace Fuse.Reactive
 {
 	/** Utility base class that observes the first value of an `IObservable`.
+		
+		Note that this class should only be used with instances that support `IObservable`, 
+		not just `IObservableArray`. This ensures the collection is semantically inteneded
+		for single-value use.
 	*/
 	abstract class ValueObserver: IDisposable, IObserver
 	{
@@ -11,9 +15,13 @@ namespace Fuse.Reactive
 
 		public IObservable Observable { get { return _obs; } }
 
+		/** Calling this method will push the current `value[0]` if available, and then
+			subscribe to changes.
+		*/
 		protected void Subscribe(IObservable obs)
 		{
 			_obs = obs;
+			if (obs.Length > 0) PushData(obs[0]);
 			_obsSub = obs.Subscribe(this);
 		}
 

--- a/Source/Fuse.Selection/Selection.uno
+++ b/Source/Fuse.Selection/Selection.uno
@@ -355,7 +355,9 @@ namespace Fuse.Selection
 				
 			if (how == How.API && _subscription != null)
 			{
-				_subscription.ReplaceAllExclusive( new ListWrapper(_values) );
+				var sub = _subscription as ISubscription;
+				if (sub != null) sub.ReplaceAllExclusive( new ListWrapper(_values) );
+				else Diagnostics.UserWarning("Selection changed, but the bound collection is not writeable.", this);
 			}
 		}
 		
@@ -375,9 +377,9 @@ namespace Fuse.Selection
 			}
 		}
 		
-		Reactive.IObservable _observableValues;
+		Reactive.IObservableArray _observableValues;
 		/**
-			The current list of selected values. This should be bound to an `Observable` array in JavaScript in order to create a 2-way interface for the selected items.
+			The current list of selected values. This should be bound to an `IObservableArray` (e.g `FuseJS/Observable`) order to create a 2-way interface for the selected items.
 			
 			@examples Docs/example.md
 		*/
@@ -386,10 +388,10 @@ namespace Fuse.Selection
 			get { return _observableValues; }
 			set 
 			{ 
-				var q = value as Reactive.IObservable;
+				var q = value as Reactive.IObservableArray;
 				if (value != null && q == null)
 				{
-					Fuse.Diagnostics.UserError( "`Values` must be an Observable", this );
+					Fuse.Diagnostics.UserError( "`Values` must be an IObservableArray", this );
 					return;
 				}
 				
@@ -406,11 +408,13 @@ namespace Fuse.Selection
 			ClearSubscription();
 			if (_observableValues == null)
 				return;
+
+			OnNewAll(_observableValues);
 				
 			_subscription = _observableValues.Subscribe(this);
 		}
 		
-		ISubscription _subscription;
+		IDisposable _subscription;
 		void ClearSubscription()
 		{
 			if (_subscription != null)
@@ -427,6 +431,11 @@ namespace Fuse.Selection
 		}
 
 		void Reactive.IObserver.OnNewAll(IArray values)
+		{
+			OnNewAll(values);
+		}
+
+		void OnNewAll(IArray values)
 		{
 			_values.Clear();
 			for (int i=0; i < values.Length; ++i)


### PR DESCRIPTION
Large refactoring of Fuse.Reactive interfaces, implementations and related tets.

This introduces IObservableArray and IObservableObject which allows for a more general purpose interop with the datacontext. Changes the IWriteable interface slightly.

Adds a lot of documentation for those interfaces.

Fuse.Reactive.Observable no longer pushes initial value on subscribe. Consumers are fixed to cope with the new reality.

The IRaw interface gains an ReflectedRaw property to accommodate change detection engines to reflect a different object from what will be seen in JS callbacks.

Fuse.Reactive.JavaScript gains a reference to Fuse.Reactive.Expressions which requires some disambiguation of namespaces (Uno.UX also has a Property class).

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
