### PR TITLE
Fix TextWrapping="NoWrap" on Android TextView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## TextView
+
+- Fixed bug on Android where setting `TextWrapping="NoWrap"` would force the `TextView` to be single line. New behavior is to instead allow the view to scroll horizontally instead of automatically wrapping the text.
+
 # 1.3
 
 ## 1.3.0

--- a/Source/Fuse.Controls.Native/Android/TextView.uno
+++ b/Source/Fuse.Controls.Native/Android/TextView.uno
@@ -92,7 +92,7 @@ namespace Fuse.Controls.Native.Android
 		[Foreign(Language.Java)]
 		static void SetTextWrapping(Java.Object handle, bool wrap)
 		@{
-			((android.widget.TextView)handle).setMaxLines( (wrap) ? java.lang.Integer.MAX_VALUE : 1 );
+			((android.widget.TextView)handle).setHorizontallyScrolling( (wrap) ? false : true );
 		@}
 
 		[Foreign(Language.Java)]


### PR DESCRIPTION
The previous behavior was to set max lines to 1 in the case of
Wrapping="NoWrap". This proved to not give the right behavior, as the
TextView should still be multiline even though it shouldn't wrap
automatically. Changing this to setting horizontally scrolling to false
gives the correct behavior.

Fixes fusetools/fuselibs#4010

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
