### PR TITLE
ViewHandle.iOS: fix translation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 1.3.0
 
+### Native UI:
+- Fixed bug on iOS that could cause native views from thirdparty libraries to get an incorrect position. (Fixes issues with Firebase AdMob)
+
 ### JavaScript: Optional explicit requrie() of UX symbols
 - Symbols declared with `ux:Name`, `ux:Dependency` or `dep` are now also available to `require()` for `<JavaScript>` modules using the `ux:` prefix. This allows us to write code that plays nicer with transpilers and linters. Using require for names declared in UX is optional, but may make the code more readable and maintainable, e.g. `var router = require("ux:router")` over just using `router` with no declaration.
 

--- a/Source/Fuse.Nodes/ViewHandle.iOS.uno
+++ b/Source/Fuse.Nodes/ViewHandle.iOS.uno
@@ -259,6 +259,7 @@ namespace Fuse.Controls.Native
 			UIView* view = (UIView*)@{Fuse.Controls.Native.ViewHandle:Of(_this).NativeHandle:Get()};
 			auto t = [[view layer] transform];
 			[[view layer] setTransform:CATransform3DIdentity];
+			[view setCenter: CGPointZero];
 			[view setFrame: { { 0.0f, 0.0f }, { w, h } } ];
 
 			if ([[view superview] isKindOfClass:[UIScrollView class]])
@@ -282,6 +283,7 @@ namespace Fuse.Controls.Native
 			UIView* view = (UIView*)@{Fuse.Controls.Native.ViewHandle:Of(_this).NativeHandle:Get()};
 			auto t = [[view layer] transform];
 			[[view layer] setTransform:CATransform3DIdentity];
+			[view setCenter: CGPointZero];
 			[view setFrame: { { 0.0f, 0.0f }, { w, h } } ];
 
 			if ([[view superview] isKindOfClass:[UIScrollView class]])


### PR DESCRIPTION
The properties frame, bounds and center should all point to the same property behind the scenes. Looks like this is not the case in thirdparty libraries. For example setting a frame on Ad views from firebase has no effect on the view position.

Fixing this by always setting center to 0,0.

Fixes https://github.com/fuse-compound/Fuse.Firebase/issues/51

This PR contains:
- [x] Changelog
- [ ] ~~Documentation~~
- [ ] ~~Tests~~
