### PR TITLE
State migration for Preview

### DIFF
--- a/Source/Fuse.Controls.Navigation/Tests/Navigator.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Navigator.Test.uno
@@ -30,7 +30,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Reuse()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.Reuse();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -53,7 +52,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void ReuseNoneRemove()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.ReuseNoneRemove();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -88,7 +86,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void ReuseInactive()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.ReuseInactive();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -128,7 +125,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void ReuseRemoved()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.ReuseRemoved();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -164,7 +160,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Remove()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.Remove();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -208,7 +203,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void DeferredActivation()
 		{	
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.DeferredActivation();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -227,7 +221,6 @@ namespace Fuse.Navigation.Test
 		//https://github.com/fusetools/fuselibs/issues/2982
 		public void EmptyParameter()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.EmptyParameter();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -261,7 +254,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void PageBinding()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.Page();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -279,7 +271,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void NonTemplates()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.NonTemplate();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -310,7 +301,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void JsInterface()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.JsInterface();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -334,7 +324,6 @@ namespace Fuse.Navigation.Test
 		// https://github.com/fusetools/fuselibs/issues/4256
 		public void RootingCache1()
 		{
-			Router.TestClearMasterRoute();
 			var p =  new UX.Navigator.RootingCache();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -363,7 +352,6 @@ namespace Fuse.Navigation.Test
 		//variant of RootingCache that uses non-template pages
 		public void RootingCache2()
 		{
-			Router.TestClearMasterRoute();
 			var p =  new UX.Navigator.RootingCache2();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -390,7 +378,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void SwipeBack()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.SwipeBack();
 			using (var root = TestRootPanel.CreateWithChild(p,int2(1000)))
 			{
@@ -430,7 +417,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void SwipeBackDirection()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.SwipeBackDirection();
 			using (var root = TestRootPanel.CreateWithChild(p,int2(1000)))
 			{
@@ -462,7 +448,6 @@ namespace Fuse.Navigation.Test
 		//tests null paths and swiping back to them
 		public void SwipeBackNull()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.SwipeBackNull();
 			using (var root = TestRootPanel.CreateWithChild(p,int2(1000)))
 			{
@@ -501,7 +486,6 @@ namespace Fuse.Navigation.Test
 		//an explicit NavigatorSwipe to work with bookmarks
 		public void SwipeBookmark()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.SwipeBookmark();
 			using (var root = TestRootPanel.CreateWithChild(p,int2(1000)))
 			{
@@ -523,7 +507,6 @@ namespace Fuse.Navigation.Test
 		//constructs the swiping logic at the UX level
 		public void SwipeBits()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.SwipeBits();
 			using (var root = TestRootPanel.CreateWithChild(p,int2(10000)))
 			{
@@ -550,7 +533,6 @@ namespace Fuse.Navigation.Test
 		//tests the Busy waiting mechanism used to defer page transitions
 		public void DeferPageSwitch()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.DeferPageSwitch();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -579,7 +561,6 @@ namespace Fuse.Navigation.Test
 		//ensures a busy deferred page transition is forced if a new route request comes in
 		public void ForceDefer()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.ForceDefer();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -598,7 +579,6 @@ namespace Fuse.Navigation.Test
 		//checks some cleanup and caching conditions in the navigator
 		public void PreparedCleanup()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.PreparedCleanup();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -632,7 +612,6 @@ namespace Fuse.Navigation.Test
 		//checks the removing items aren't transition triggered as well
 		public void Removing()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Navigator.Removing();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{

--- a/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
@@ -20,7 +20,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Basic()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.RouterTest();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -62,7 +61,6 @@ namespace Fuse.Navigation.Test
 		//extracted from a failure in Basic
 		public void Scenario1()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.Scenario1();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -74,7 +72,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void SelfChange()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.RouterTest();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -103,7 +100,6 @@ namespace Fuse.Navigation.Test
 		/* kind of a clunky feature, but it should be tested nonetheless */
 		public void MasterState()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.MasterRoute();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -113,8 +109,11 @@ namespace Fuse.Navigation.Test
 				root.PumpDeferred();
 
 				//Route survives destruction
+				var store = root.RootViewport.PreviewSaveState();
 				root.Children.Remove(p);
+				
 				p = new UX.MasterRoute();
+				root.RootViewport.PreviewRestoreState(store);
 				root.Children.Add(p);
 				root.IncrementFrame();
 				
@@ -130,7 +129,6 @@ namespace Fuse.Navigation.Test
 		/* checks a router that is inside the routing path of another router */
 		public void Embedded()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.RouterEmbed();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -160,7 +158,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Relative()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.Relative();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -192,7 +189,6 @@ namespace Fuse.Navigation.Test
 		//https://github.com/fusetools/fuselibs/issues/3689
 		public void RelativeNonCurrent()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.RelativeNonCurrent();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -219,7 +215,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Modify()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.Modify();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -246,7 +241,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void RelativeNest()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.RelativeNest();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -290,7 +284,6 @@ namespace Fuse.Navigation.Test
 		//variant of RelativeNest to ensure modify does the same thing
 		public void RelativeNestModify()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.RelativeNestModify();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -323,7 +316,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void HistoryBasic()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.HistoryBasic();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -354,7 +346,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void HistoryMulti()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.HistoryMulti();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -400,7 +391,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void NavigatorHistoryBasic()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.NavigatorHistoryBasic();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -429,7 +419,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void NavigatorHistoryMulti()
 		{
-				Router.TestClearMasterRoute();
 			var p = new UX.Router.NavigatorHistoryMulti();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{	
@@ -476,7 +465,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void HistoryActiveIndex()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.HistoryActiveIndex();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -497,7 +485,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void HistoryParameter()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.HistoryParameter();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -533,7 +520,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void NavigatorHistoryParameter()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.NavigatorHistoryParameter();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -573,7 +559,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void HistorySame()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.HistorySame();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -617,7 +602,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void ObservableGoBack()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Router.ObservableGoBack();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{

--- a/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
@@ -109,11 +109,11 @@ namespace Fuse.Navigation.Test
 				root.PumpDeferred();
 
 				//Route survives destruction
-				var store = root.RootViewport.PreviewSaveState();
+				var store = root.RootViewport.SavePreviewState();
 				root.Children.Remove(p);
 				
 				p = new UX.MasterRoute();
-				root.RootViewport.PreviewRestoreState(store);
+				root.RootViewport.RestorePreviewState(store);
 				root.Children.Add(p);
 				root.IncrementFrame();
 				

--- a/Source/Fuse.Controls.Navigation/Tests/Transition.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Transition.Test.uno
@@ -17,7 +17,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Basic()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Transition.Basic();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -78,7 +77,6 @@ namespace Fuse.Navigation.Test
 		//checks some basic with non-template pages and with Bypass mode
 		public void BasicNonTemplate()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Transition.BasicNonTemplate();
 			using(var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -131,7 +129,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void FrontBack()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Transition.FrontBack();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -160,7 +157,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void InFrontBehind()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Transition.InFrontBehind();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -213,7 +209,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Release()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Transition.Release();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -239,7 +234,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Interactive()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Transition.Interactive();
 			using (var root = TestRootPanel.CreateWithChild(p,int2(1000)))
 			{
@@ -272,7 +266,6 @@ namespace Fuse.Navigation.Test
 		//tests operation style matching
 		public void Style()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Transition.Style();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{

--- a/Source/Fuse.Navigation/Tests/Activated.Test.uno
+++ b/Source/Fuse.Navigation/Tests/Activated.Test.uno
@@ -14,7 +14,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Deep()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.Activated.Deep();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -76,7 +75,6 @@ namespace Fuse.Navigation.Test
 		/** Testing of De/Activated events via a Router using a Navigator */
 		public void RouterNavigatorActivated()
 		{
-			Router.TestClearMasterRoute();
 			var p  = new UX.Activated.RouterNavigator();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{

--- a/Source/Fuse.Navigation/Tests/FindRouter.Test.uno
+++ b/Source/Fuse.Navigation/Tests/FindRouter.Test.uno
@@ -11,7 +11,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Basic()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.FindRouter.Basic();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{

--- a/Source/Fuse.Navigation/Tests/Navigation.Test.uno
+++ b/Source/Fuse.Navigation/Tests/Navigation.Test.uno
@@ -100,7 +100,6 @@ namespace Fuse.Navigation.Test
 			
 			npp.Dispose();
 			Assert.IsFalse(_navReady);
-			Router.TestClearMasterRoute();
 		}
 		
 		bool _navReady;

--- a/Source/Fuse.Navigation/Tests/RouterModify.Test.uno
+++ b/Source/Fuse.Navigation/Tests/RouterModify.Test.uno
@@ -14,7 +14,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Bookmark()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.RouterModify.Bookmark();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -30,7 +29,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void Path()
 		{
-			Router.TestClearMasterRoute();
 			var p =new UX.RouterModify.Path();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -58,7 +56,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void DynamicPath()
 		{
-			Router.TestClearMasterRoute();
 			var p =new UX.RouterModify.DynamicPath();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -82,7 +79,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void GotoPush()
 		{
-			Router.TestClearMasterRoute();
 			var p =new UX.RouterModify.GotoPush();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{

--- a/Source/Fuse.Navigation/Tests/WhileHistory.Test.uno
+++ b/Source/Fuse.Navigation/Tests/WhileHistory.Test.uno
@@ -14,7 +14,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void GoBackBehavior()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.WhileHistory.GoBackBehavior();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
@@ -33,7 +32,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void GoBackRouter()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.WhileHistory.GoBackRouter();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{

--- a/Source/Fuse.Navigation/Tests/WhileNavigation.Test.uno
+++ b/Source/Fuse.Navigation/Tests/WhileNavigation.Test.uno
@@ -14,7 +14,6 @@ namespace Fuse.Navigation.Test
 		[Test]
 		public void WhileNavigationDeep()
 		{
-			Router.TestClearMasterRoute();
 			var p = new UX.WhileNavigation.Deep();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{

--- a/Source/Fuse.Nodes/PreviewState.uno
+++ b/Source/Fuse.Nodes/PreviewState.uno
@@ -4,8 +4,6 @@ namespace Fuse
 {
 	/** 
 		State management in Preview for reloading/reifying. This has not use other than when running in preview.
-		
-		TODO: Reduce as much as possible if not defined(DESIGNMODE)
 	*/
 	class PreviewState
 	{
@@ -101,15 +99,9 @@ namespace Fuse
 			return null;
 		}
 	}
-	
 
 	interface IPreviewStateSaver
 	{
 		void Save( PreviewStateData data );
-	}
-	
-	interface IStateSource
-	{
-		
 	}
 }

--- a/Source/Fuse.Nodes/PreviewState.uno
+++ b/Source/Fuse.Nodes/PreviewState.uno
@@ -1,0 +1,85 @@
+using Uno.Collections;
+
+namespace Fuse
+{
+	/** 
+		State management in Preview for reloading/reifying. This has not use other than when running in preview.
+		
+		TODO: Reduce as much as possible if not defined(DESIGNMODE)
+	*/
+	class PreviewState
+	{
+		public PreviewStateData Save()
+		{
+			var psd = new PreviewStateData();
+			for (int i=0; i < _savers.Count; ++i)
+				_savers[i].Save( psd );
+			return psd;
+		}
+		
+		public void SetState(PreviewStateData data)
+		{
+			_current = data;
+		}
+		
+		PreviewStateData _current;
+		public PreviewStateData Current
+		{
+			get { return _current; }
+		}
+		
+		List<IPreviewStateSaver> _savers = new List<IPreviewStateSaver>();
+		
+		public void AddSaver( IPreviewStateSaver saver )
+		{
+			_savers.Add( saver );
+		}
+		
+		public void RemoveSaver( IPreviewStateSaver saver )
+		{
+			_savers.Remove( saver );
+		}
+		
+		/** Finds the appropriate PreviewState for a given node. May return null */
+		static public PreviewState Find( Node n )
+		{
+			while (n != null)
+			{
+				var rv = n as RootViewport; //the only thing that provides a PreviewState
+				if (rv != null)
+					return rv.PreviewState;
+				n = n.Parent;
+			}
+			return null;
+		}
+	}
+	
+	class PreviewStateData
+	{
+		Dictionary<string, object> _data = new Dictionary<string, object>();
+		
+		public void Set( string key, object data )
+		{
+			_data[key] = data;
+		}
+		
+		public object Get( string key )
+		{
+			object v;
+			if (_data.TryGetValue( key, out v) )
+				return v;
+			return null;
+		}
+	}
+	
+
+	interface IPreviewStateSaver
+	{
+		void Save( PreviewStateData data );
+	}
+	
+	interface IStateSource
+	{
+		
+	}
+}

--- a/Source/Fuse.Nodes/PreviewState.uno
+++ b/Source/Fuse.Nodes/PreviewState.uno
@@ -25,6 +25,8 @@ namespace Fuse
 			}
 			
 			_current = data;
+			if (_current != null)
+				_current.Consumed = true;
 		}
 		
 		PreviewStateData _current;

--- a/Source/Fuse.Nodes/PreviewState.uno
+++ b/Source/Fuse.Nodes/PreviewState.uno
@@ -79,12 +79,12 @@ namespace Fuse
 		}
 		
 		/** Returns true if data has been stored for this key. Note that a null value is not considered to be actual data. */
-		public object Has( string key )
+		public bool Has( string key )
 		{
 			Entry v;
 			if (_data.TryGetValue( key, out v) )
 				return v.Data != null;
-			return null;
+			return false;
 		}
 		
 		/** Obtains the data just once, returning null on subsequent requests. This allows for rooting to only pick up the state data the first time, not if rerooted without it being saved again. */

--- a/Source/Fuse.Nodes/PreviewState.uno
+++ b/Source/Fuse.Nodes/PreviewState.uno
@@ -17,7 +17,7 @@ namespace Fuse
 		
 		public void SetState(PreviewStateData data)
 		{
-			if (data.Consumed)
+			if (data != null && data.Consumed)
 			{
 				Fuse.Diagnostics.InternalError( "Attempting to restore an already consumed state", this );
 				_current = null;

--- a/Source/Fuse.Nodes/RootViewport.uno
+++ b/Source/Fuse.Nodes/RootViewport.uno
@@ -273,5 +273,27 @@ namespace Fuse
 			return ViewportHelpers.WorldToLocalRay(this, world, worldRay, where);
 		}
 
+		/** Composition for PreviewState support */
+		PreviewState _previewState = new PreviewState();
+		internal PreviewState PreviewState { get { return _previewState; } }
+		
+		/** Returns an opaque object of the saved state for preview. */
+		public object PreviewSaveState()
+		{
+			if (_previewState != null)
+				return _previewState.Save();
+			return null;
+		}
+		
+		/** Sets the current state to restore (may be null). This must be called prior to adding any children. */
+		public void PreviewSetState(object state)
+		{
+			var psd = state as PreviewStateData;
+			if (psd == null && state != null)
+				Fuse.Diagnostics.InternalError( "Incorrect state type for PreviewSetState", this );
+				
+			if (_previewState != null)
+				_previewState.SetState(psd);
+		}
 	}
 }

--- a/Source/Fuse.Nodes/RootViewport.uno
+++ b/Source/Fuse.Nodes/RootViewport.uno
@@ -277,7 +277,7 @@ namespace Fuse
 		PreviewState _previewState = new PreviewState();
 		internal PreviewState PreviewState { get { return _previewState; } }
 		
-		/** Returns an opaque object of the saved state for preview. */
+		/** Returns an opaque object of the saved state for preview. This is neither a serialized nor cloned state; it can be used only once in `PreviewRestoreState` */
 		public object PreviewSaveState()
 		{
 			if (_previewState != null)
@@ -285,8 +285,8 @@ namespace Fuse
 			return null;
 		}
 		
-		/** Sets the current state to restore (may be null). This must be called prior to adding any children. */
-		public void PreviewSetState(object state)
+		/** Sets the current state to restore (may be null). This must be called prior to adding any children. The state contained here will only be used once. Each time a state must be restored `PreviewSaveState` and `PreviewSetState` should be called again. */
+		public void PreviewRestoreState(object state)
 		{
 			var psd = state as PreviewStateData;
 			if (psd == null && state != null)

--- a/Source/Fuse.Nodes/RootViewport.uno
+++ b/Source/Fuse.Nodes/RootViewport.uno
@@ -277,16 +277,22 @@ namespace Fuse
 		PreviewState _previewState = new PreviewState();
 		internal PreviewState PreviewState { get { return _previewState; } }
 		
-		/** Returns an opaque object of the saved state for preview. This is neither a serialized nor cloned state; it can be used only once in `PreviewRestoreState` */
-		public object PreviewSaveState()
+		/** Returns an opaque object of the saved state for preview. This is neither a serialized nor cloned state; it can be used only once in `RestorePreviewState` 
+		
+			@hide for Preview only
+		*/
+		public object SavePreviewState()
 		{
 			if (_previewState != null)
 				return _previewState.Save();
 			return null;
 		}
 		
-		/** Sets the current state to restore (may be null). This must be called prior to adding any children. The state contained here will only be used once. Each time a state must be restored `PreviewSaveState` and `PreviewSetState` should be called again. */
-		public void PreviewRestoreState(object state)
+		/** Sets the current state to restore (may be null). This must be called prior to adding any children. The state contained here will only be used once. Each time a state must be restored `SavePreviewState` and `PreviewSetState` should be called again. 
+		
+			@hide for Preview only
+		*/
+		public void RestorePreviewState(object state)
 		{
 			var psd = state as PreviewStateData;
 			if (psd == null && state != null)

--- a/Source/Fuse.Nodes/Tests/Preview.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Preview.Test.uno
@@ -19,11 +19,14 @@ namespace Fuse.Test
 				p.st.Value = "store";
 				
 				var o = root.RootViewport.SavePreviewState();
+				Assert.AreEqual( null, root.RootViewport.PreviewState.Current );
 				
 				root.Children.Remove(p);
 				root.StepFrame();
 				
 				root.RootViewport.RestorePreviewState( o );
+				Assert.IsTrue( root.RootViewport.PreviewState.Current.Has( StateTest.StateId ) );
+				Assert.IsFalse( root.RootViewport.PreviewState.Current.Has( "none" ) );
 				
 				p = new UX.Preview.State();
 				root.Children.Add(p);
@@ -43,11 +46,11 @@ namespace Fuse.Test
 	{
 		public string Value = "init";
 		
-		const string _id = "StateTest";
+		public const string StateId = "StateTest";
 		
 		void IPreviewStateSaver.Save( PreviewStateData data )
 		{
-			data.Set( _id, Value );
+			data.Set( StateId, Value );
 		}
 		
 		protected override void OnRooted()
@@ -61,7 +64,7 @@ namespace Fuse.Test
 				var cur = ps.Current;
 				if (cur != null)
 				{
-					var q = cur.Consume( _id ) as string;
+					var q = cur.Consume( StateId ) as string;
 					if (q != null)
 						Value = q;
 				}

--- a/Source/Fuse.Nodes/Tests/Preview.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Preview.Test.uno
@@ -1,0 +1,68 @@
+using Uno;
+using Uno.Testing;
+using Uno.UX;
+
+using FuseTest;
+
+namespace Fuse.Test
+{
+	/** Tests for preview integration APIs */
+	public class PreviewTest : TestBase
+	{
+		[Test]
+		public void State()
+		{
+			var p = new UX.Preview.State();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( "init", p.st.Value );
+				p.st.Value = "okay";
+				
+				var o = root.RootViewport.PreviewSaveState();
+				
+				root.Children.Remove(p);
+				root.StepFrame();
+				
+				root.RootViewport.PreviewSetState( o );
+				
+				p = new UX.Preview.State();
+				root.Children.Add(p);
+				Assert.AreEqual( "okay", p.st.Value );
+			}
+		}
+	}
+	
+	public class StateTest : Behavior, IPreviewStateSaver
+	{
+		public string Value = "init";
+		
+		const string _id = "StateTest";
+		
+		void IPreviewStateSaver.Save( PreviewStateData data )
+		{
+			data.Set( _id, Value );
+		}
+		
+		protected override void OnRooted()
+		{
+			base.OnRooted();
+
+			var ps = PreviewState.Find(this);
+			if (ps != null)
+			{
+				ps.AddSaver( this );
+				var cur = ps.Current;
+				if (cur != null)
+					Value = cur.Get( _id ) as string;
+			}
+		}
+		
+		protected override void OnUnrooted()
+		{
+			var ps = PreviewState.Find(this);
+			if (ps != null)
+				ps.RemoveSaver(this);
+			base.OnUnrooted();
+		}
+	}
+}

--- a/Source/Fuse.Nodes/Tests/Preview.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Preview.Test.uno
@@ -18,12 +18,12 @@ namespace Fuse.Test
 				Assert.AreEqual( "init", p.st.Value );
 				p.st.Value = "store";
 				
-				var o = root.RootViewport.PreviewSaveState();
+				var o = root.RootViewport.SavePreviewState();
 				
 				root.Children.Remove(p);
 				root.StepFrame();
 				
-				root.RootViewport.PreviewRestoreState( o );
+				root.RootViewport.RestorePreviewState( o );
 				
 				p = new UX.Preview.State();
 				root.Children.Add(p);

--- a/Source/Fuse.Nodes/Tests/Preview.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Preview.Test.uno
@@ -16,18 +16,25 @@ namespace Fuse.Test
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
 				Assert.AreEqual( "init", p.st.Value );
-				p.st.Value = "okay";
+				p.st.Value = "store";
 				
 				var o = root.RootViewport.PreviewSaveState();
 				
 				root.Children.Remove(p);
 				root.StepFrame();
 				
-				root.RootViewport.PreviewSetState( o );
+				root.RootViewport.PreviewRestoreState( o );
 				
 				p = new UX.Preview.State();
 				root.Children.Add(p);
-				Assert.AreEqual( "okay", p.st.Value );
+				Assert.AreEqual( "store", p.st.Value );
+				
+				//the second rooting should not use the state, it was consumed
+				root.Children.Remove(p);
+				root.StepFrame();
+				p = new UX.Preview.State();
+				root.Children.Add(p);
+				Assert.AreEqual( "init", p.st.Value );
 			}
 		}
 	}
@@ -53,7 +60,11 @@ namespace Fuse.Test
 				ps.AddSaver( this );
 				var cur = ps.Current;
 				if (cur != null)
-					Value = cur.Get( _id ) as string;
+				{
+					var q = cur.Consume( _id ) as string;
+					if (q != null)
+						Value = q;
+				}
 			}
 		}
 		

--- a/Source/Fuse.Nodes/Tests/UX/Preview.State.ux
+++ b/Source/Fuse.Nodes/Tests/UX/Preview.State.ux
@@ -1,0 +1,3 @@
+<Panel ux:Class="UX.Preview.State">
+	<Fuse.Test.StateTest ux:Name="st"/>
+</Panel>


### PR DESCRIPTION
Implements the state migration interface to allow Preview to save/restore the state.

For preview you need to call the `SavePreviewState` prior to unrooting the old nodes and then `RestorePreviewState` prior to creating/adding the new nodes:

- `var store = app.RootViewport.SavePreviewState()`
- Unroot/cleanup
- `app.RootViewport.RestorePreviewState(store)`
- add new children

This PR contains:
- [ ] ~Changelog~ - no user visible API changes
- [x] Documentation
- [x] Tests
