### PR TITLE
Fix #501

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## MultiDensityImageSource
 - Added native support, meaning it can be used by images inside a `NativeViewHost`.
 
+## Video
+
+- Fixed bug in Video where playback actions, like `Play`, used before the video was initialized would end up getting swallowed.
+
 # 1.3
 
 ## 1.3.0

--- a/Source/Fuse.Controls.Video/VideoVisual.uno
+++ b/Source/Fuse.Controls.Video/VideoVisual.uno
@@ -54,6 +54,16 @@ namespace Fuse.Controls.VideoImpl
 		IVideoCallbacks,
 		IMediaPlayback
 	{
+
+		enum PlaybackTarget
+		{
+			Playing,
+			Paused,
+			Stopped
+		}
+
+		PlaybackTarget _playbackTarget = PlaybackTarget.Stopped;
+
 		protected override void Attach()
 		{
 			Control.RenderParamChanged += OnRenderParamChanged;
@@ -116,6 +126,13 @@ namespace Fuse.Controls.VideoImpl
 		{
 			ResetTriggers();
 			BusyTask.SetBusy(Control, ref _busyTask, BusyTaskActivity.None);
+
+			if (_playbackTarget == PlaybackTarget.Playing)
+				((IPlayback)this).Resume();
+			else if (_playbackTarget == PlaybackTarget.Paused)
+				((IPlayback)this).Pause();
+			else if (_playbackTarget == PlaybackTarget.Stopped)
+				((IPlayback)this).Stop();
 		}
 
 		void IVideoCallbacks.OnCompleted()
@@ -144,6 +161,7 @@ namespace Fuse.Controls.VideoImpl
 
 		void IPlayback.Stop()
 		{
+			_playbackTarget = PlaybackTarget.Stopped;
 			((IPlayback)this).Pause();
 			((IMediaPlayback)this).Position = 0.0;
 		}
@@ -159,6 +177,7 @@ namespace Fuse.Controls.VideoImpl
 
 		void IPlayback.Pause()
 		{
+			_playbackTarget = PlaybackTarget.Paused;
 			if (_videoService.IsValid)
 			{
 				_videoService.Pause();
@@ -169,6 +188,7 @@ namespace Fuse.Controls.VideoImpl
 
 		void IPlayback.Resume()
 		{
+			_playbackTarget = PlaybackTarget.Playing;
 			if (_videoService.IsValid)
 			{
 				ResetTriggers();


### PR DESCRIPTION
There was a problem with Video where if one used the `Play` action while
the video was still initializing, the action would not be applied.

After some conversing with Nekronos, we agreed that it would make more
sense for the video playback actions (Play, Pause, Stop) to (internally)
set a target state, so that if the user for example uses `Play` while
the Video is still initializing, the video will eventually start playing
when it is ready.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
