### PR TITLE
Fuse.Text: do not use download.icu-project.org for dependencies

### DIFF
--- a/Source/Fuse.Text/icu/Windows.stuff
+++ b/Source/Fuse.Text/icu/Windows.stuff
@@ -1,4 +1,4 @@
 if HOST_WINDOWS {
-x86: "http://download.icu-project.org/files/icu4c/55.1/icu4c-55_1-Win32-msvc10.zip"
-x64: "http://download.icu-project.org/files/icu4c/55.1/icu4c-55_1-Win64-msvc10.zip"
+x86: "https://files.fusetools.com/tooling/HtthIgwJ2TdH-icu4c-55_1-Win32-msvc10.zip"
+x64: "https://files.fusetools.com/tooling/Oe1jy7Kg5uTN-icu4c-55_1-Win64-msvc10.zip"
 }


### PR DESCRIPTION
download.icu-project.org is having problems lately, and we don't
want dependencies hosted in places where we have no control. So
let's move this dependency to files.fusetools.com.