### PR TITLE
Experimental.TextureLoader: tolerate image/jpg as content-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ which will stop push notifications registering (and potentially asking for permi
 
 ### Image
 - Fixed issue where an `<Image />` could fail to display inside a `<NativeViewHost />` on iOS
+- Fixed an issue where a JPEG image from a misconfigured server using `image/jpg` would fail to load.
 
 ### Each
 - Fixed a bug where replacing the whole list of items with an empty list would not immediately remove the items from the UI.

--- a/Source/Experimental.TextureLoader/TextureLoader.uno
+++ b/Source/Experimental.TextureLoader/TextureLoader.uno
@@ -82,7 +82,7 @@ namespace Experimental.TextureLoader
 
 		public static void ByteArrayToTexture2DContentType(Buffer arr, string contentType, Uno.Action<texture2D> callback)
 		{
-			if (contentType.IndexOf("image/jpeg") != -1)
+			if (contentType.IndexOf("image/jpeg") != -1 || contentType.IndexOf("image/jpg") != -1)
 				JpegByteArrayToTexture2D(arr, callback);
 			else if (contentType.IndexOf("image/png") != -1)
 				PngByteArrayToTexture2D(arr, callback);


### PR DESCRIPTION
Even though 'image/jpg' is not an IANA registered content-type, it
seems there's mis-configured servers out there using this. So let's
be a bit more fault-tolerant, and accept this variation.

Fixes issue #510

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
