### PR TITLE
Fuse.Drawing.Primitives: avoid differing uniform precision

### DIFF
--- a/Source/Fuse.Drawing.Primitives/Circle.uno
+++ b/Source/Fuse.Drawing.Primitives/Circle.uno
@@ -100,7 +100,7 @@ namespace Fuse.Drawing.Primitives
 				
 				float2 VertexPosition: V0 * (radius + extend*2);
 				LocalPosition: VertexPosition + center;
-				// Mali-400 hax GP16 max precision, which cannot square big numbers without overflowing.
+				// Mali-400 has FP16 max precision, which cannot square big numbers without overflowing.
 				// So let's make sure the vector we do Length() always has a result in the 0..1 range, to
 				// avoid overflowing.
 				float2 VertexPositionScaled: VertexPosition / radius;

--- a/Source/Fuse.Drawing.Primitives/Circle.uno
+++ b/Source/Fuse.Drawing.Primitives/Circle.uno
@@ -84,6 +84,7 @@ namespace Fuse.Drawing.Primitives
 			if (_bufferVertex == null)
 				InitBuffers();
 
+			float radiusRcp = 1.0f / radius;
 			draw
 			{
 				apply Common;
@@ -103,7 +104,7 @@ namespace Fuse.Drawing.Primitives
 				// Mali-400 has FP16 max precision, which cannot square big numbers without overflowing.
 				// So let's make sure the vector we do Length() always has a result in the 0..1 range, to
 				// avoid overflowing.
-				float2 VertexPositionScaled: VertexPosition / radius;
+				float2 VertexPositionScaled: VertexPosition * radiusRcp;
 				float RawDistance: (Vector.Length(pixel VertexPositionScaled) - 1.0f) * radius;
 				float2 EdgeNormal: Vector.Normalize(pixel V0);
 				


### PR DESCRIPTION
On Mali-400, the fragment-shader does not support highp floats, but
the vertex-shader does.

And since we set the default-precision to highp for all floats when
supported, we end up with different default-precision in the shader
stages. This cause issues when two uniforms have the same name in
both stages.

To side-step this, pre-calculate 1 / radius on the CPU, and use that
instead in the vertex-shader. This is a very minor optimization, but
is worth it simply due to avoiding using the same uniform-name.

Fixes fusetools/fuselibs#4266