### PR TITLE
Fuse.Drawing.Surface: re-introduce IsEmptyPath-hack

### DIFF
--- a/Source/Fuse.Drawing.Surface/DotNetSurface.uno
+++ b/Source/Fuse.Drawing.Surface/DotNetSurface.uno
@@ -156,6 +156,8 @@ namespace Fuse.Drawing
 			var actualPath = (DotNetCanvasPath)path;
 
 			var graphicsPath = actualPath.Path.GetGraphicsPath();
+			if (DotNetHelpers.IsEmptyPath(graphicsPath))
+				return;
 
 			bool eoFill = actualPath.FillRule == FillRule.EvenOdd;
 			// set the path filling mode
@@ -227,6 +229,8 @@ namespace Fuse.Drawing
 			var actualPath = (DotNetCanvasPath)path;
 
 			var graphicsPath = actualPath.Path.GetGraphicsPath();
+			if (DotNetHelpers.IsEmptyPath(graphicsPath))
+				return;
 
 			bool eoFill = actualPath.FillRule == FillRule.EvenOdd;
 			// set the path filling mode
@@ -568,6 +572,11 @@ namespace Fuse.Drawing
 				buffer
 			);
 			return;
+		}
+
+		public static extern bool IsEmptyPath(GraphicsPath path)
+		{
+			return path.GetBounds().Width == 0 && path.GetBounds().Height == 0;
 		}
 
 		public static extern void SetEOFill(GraphicsPath path, bool eoFill)


### PR DESCRIPTION
In 6bed36f, we dropped the incorrect IsEmptyPath-hack because we
had a more directed fix. However, this doesn't seem to cover all
cases. So let's reintroduce a less broken version of this check
(e.g one that checks if *both* width and height is zero) just to
be safe.

We should probably try to get rid of this at the benefit of a more
targetted fix later, but let's not try to deal with that right now.

This fixes a crash on startup in ManualTestingApp on dotnet-targets.