### PR TITLE
Fix incorrect Remove called in RemoveAllChildren (ScrollView breaking)

### DIFF
--- a/Source/Fuse.Nodes/Tests/UX/Rooting.RemoveAll.ux
+++ b/Source/Fuse.Nodes/Tests/UX/Rooting.RemoveAll.ux
@@ -1,0 +1,4 @@
+<Panel ux:Class="UX.Rooting.RemoveAll">
+	<Fuse.Test.RootTracker ux:Name="a"/>
+	<Fuse.Test.RootTracker ux:Name="b"/>
+</Panel>

--- a/Source/Fuse.Nodes/Tests/UX/Rooting.ScrollViewScenario.ux
+++ b/Source/Fuse.Nodes/Tests/UX/Rooting.ScrollViewScenario.ux
@@ -1,0 +1,3 @@
+<Panel ux:Class="UX.Rooting.ScrollViewScenario">
+	<Fuse.Test.ScrollViewScenarioBehavior ux:Name="a"/>
+</Panel>

--- a/Source/Fuse.Nodes/Visual.Children.uno
+++ b/Source/Fuse.Nodes/Visual.Children.uno
@@ -67,7 +67,7 @@ namespace Fuse
 		{
 			// Has to use use safe iterator, ref discussion on https://github.com/fusetools/fuselibs-public/pull/260
 			foreach (var c in Children) 
-				if (c is T) Children_Remove(c);
+				if (c is T) Remove(c);
 		}
 
 		[UXPrimary]


### PR DESCRIPTION
fixes https://github.com/fusetools/fuselibs-public/issues/518

InProgress: I want to get a test added here before we merge. This was something that wasn't caught during the Childre/LinkedList changes but should have been. It only exhibits in ScrollView since that's the one of two places that use the API in question.

This PR contains:
- [ ] ~Changelog~ Fixes an unreleased regression
- [ ] ~Documentation~
- [x] Tests
