### PR TITLE
Native TimePickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## DatePicker
 - Introced Fuse.Controls.DatePicker class, which wraps native date pickers on Android and iOS. See the `DatePicker` class documentation for more details.
 
+## TimePicker
+- Introduced Fuse.Controls.TimePicker class, which wraps native time pickers on Android and iOS. See the `TimePicker` class documentation for more details.
+
 ## TextView
 - Fixed bug on Android where setting `TextWrapping="NoWrap"` would force the `TextView` to be single line. New behavior is to instead allow the view to scroll horizontally instead of automatically wrapping the text.
 

--- a/Source/Fuse.Controls.DatePicker/Android/DatePicker.uno
+++ b/Source/Fuse.Controls.DatePicker/Android/DatePicker.uno
@@ -8,31 +8,6 @@ using Fuse.Controls.Native;
 
 namespace Fuse.Controls.Native.Android
 {
-	extern(Android) static class DateTimeConverterHelpers
-	{
-		const long DotNetTicksInMs = 10000L;
-		const long UnixEpochInDotNetTicks = 621355968000000000L;
-
-		public static DateTime ConvertMsSince1970InUtcToDateTime(long msSince1970InUtc)
-		{
-			var dotNetTicksRelativeToUnixEpoch = msSince1970InUtc * DotNetTicksInMs;
-			var dotNetTicks = dotNetTicksRelativeToUnixEpoch + UnixEpochInDotNetTicks;
-
-			return new DateTime(dotNetTicks, DateTimeKind.Utc);
-		}
-
-		public static long ConvertDateTimeToMsSince1970InUtc(DateTime dt)
-		{
-			dt = dt.ToUniversalTime();
-
-			var dotNetTicks = dt.Ticks;
-			var dotNetTicksRelativeToUnixEpoch = dotNetTicks - UnixEpochInDotNetTicks;
-			var msSince1970InUtc = dotNetTicksRelativeToUnixEpoch / DotNetTicksInMs;
-
-			return msSince1970InUtc;
-		}
-	}
-
 	extern(!Android) class DatePickerView
 	{
 		[UXConstructor]

--- a/Source/Fuse.Controls.DatePicker/iOS/DatePicker.uno
+++ b/Source/Fuse.Controls.DatePicker/iOS/DatePicker.uno
@@ -9,65 +9,6 @@ using Fuse.Controls.Native.iOS;
 
 namespace Fuse.Controls.Native.iOS
 {
-	extern(iOS) static class DateTimeConverterHelpers
-	{
-		const long DotNetTicksInSecond = 10000000L;
-		const long UnixEpochInDotNetTicks = 621355968000000000L;
-
-		public static DateTime ConvertNSDateToDateTime(ObjC.Object date)
-		{
-			var secondsSince1970InUtc = (long)NSDateToSecondsSince1970InUtc(date);
-
-			var dotNetTicksRelativeToUnixEpoch = (long)secondsSince1970InUtc * DotNetTicksInSecond;
-			var dotNetTicks = dotNetTicksRelativeToUnixEpoch + UnixEpochInDotNetTicks;
-
-			return new DateTime(dotNetTicks, DateTimeKind.Utc);
-		}
-
-		public static ObjC.Object ConvertDateTimeToNSDate(DateTime dt)
-		{
-			dt = dt.ToUniversalTime();
-
-			var dotNetTicks = dt.Ticks;
-			var dotNetTicksRelativeToUnixEpoch = dotNetTicks - UnixEpochInDotNetTicks;
-			var secondsSince1970InUtc = dotNetTicksRelativeToUnixEpoch / DotNetTicksInSecond;
-
-			return SecondsSince1970InUtcToNSDate((double)secondsSince1970InUtc);
-		}
-
-		[Foreign(Language.ObjC)]
-		public static double NSDateToSecondsSince1970InUtc(ObjC.Object date)
-		@{
-			return [date timeIntervalSince1970];
-		@}
-
-		[Foreign(Language.ObjC)]
-		public static ObjC.Object SecondsSince1970InUtcToNSDate(double secondsSince1970InUtc)
-		@{
-			return [NSDate dateWithTimeIntervalSince1970:secondsSince1970InUtc];
-		@}
-
-		[Foreign(Language.ObjC)]
-		public static ObjC.Object ReconstructUtcDate(ObjC.Object date)
-		@{
-			if (!date)
-				return [NSDate dateWithTimeIntervalSince1970:0];
-
-			// Reconstruct the same date in UTC without time components
-			NSCalendar *utcCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-			[utcCalendar setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
-
-			NSDateComponents *components = [utcCalendar components:NSYearCalendarUnit|NSMonthCalendarUnit|NSDayCalendarUnit fromDate:date];
-
-			NSDateComponents *utcComponents = [[NSDateComponents alloc] init];
-			[utcComponents setYear:[components year]];
-			[utcComponents setMonth:[components month]];
-			[utcComponents setDay:[components day]];
-
-			return [utcCalendar dateFromComponents:utcComponents];
-		@}
-	}
-
 	extern(!iOS) class DatePickerView
 	{
 		[UXConstructor]

--- a/Source/Fuse.Controls.Native/Android/DateTimeConverterHelpers.uno
+++ b/Source/Fuse.Controls.Native/Android/DateTimeConverterHelpers.uno
@@ -1,0 +1,29 @@
+using Uno;
+
+namespace Fuse.Controls.Native.Android
+{
+	extern(Android) internal static class DateTimeConverterHelpers
+	{
+		const long DotNetTicksInMs = 10000L;
+		const long UnixEpochInDotNetTicks = 621355968000000000L;
+
+		public static DateTime ConvertMsSince1970InUtcToDateTime(long msSince1970InUtc)
+		{
+			var dotNetTicksRelativeToUnixEpoch = msSince1970InUtc * DotNetTicksInMs;
+			var dotNetTicks = dotNetTicksRelativeToUnixEpoch + UnixEpochInDotNetTicks;
+
+			return new DateTime(dotNetTicks, DateTimeKind.Utc);
+		}
+
+		public static long ConvertDateTimeToMsSince1970InUtc(DateTime dt)
+		{
+			dt = dt.ToUniversalTime();
+
+			var dotNetTicks = dt.Ticks;
+			var dotNetTicksRelativeToUnixEpoch = dotNetTicks - UnixEpochInDotNetTicks;
+			var msSince1970InUtc = dotNetTicksRelativeToUnixEpoch / DotNetTicksInMs;
+
+			return msSince1970InUtc;
+		}
+	}
+}

--- a/Source/Fuse.Controls.Native/Fuse.Controls.Native.unoproj
+++ b/Source/Fuse.Controls.Native/Fuse.Controls.Native.unoproj
@@ -15,6 +15,7 @@
     "Fuse.Controls.DatePicker",
     "Fuse.Controls.Panels",
     "Fuse.Controls.Primitives",
+    "Fuse.Controls.TimePicker",
   ],
   "Packages": [
     "Uno.Collections",

--- a/Source/Fuse.Controls.Native/iOs/DateTimeConverterHelpers.uno
+++ b/Source/Fuse.Controls.Native/iOs/DateTimeConverterHelpers.uno
@@ -60,5 +60,27 @@ namespace Fuse.Controls.Native.iOS
 
 			return [utcCalendar dateFromComponents:utcComponents];
 		@}
+
+		[Foreign(Language.ObjC)]
+		public static ObjC.Object ReconstructUtcTime(ObjC.Object date)
+		@{
+			if (!date)
+				return [NSDate dateWithTimeIntervalSince1970:0];
+
+			// Reconstruct the same date in UTC without date components
+			NSCalendar *utcCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+			[utcCalendar setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+
+			NSDateComponents *components = [utcCalendar components:NSHourCalendarUnit|NSMinuteCalendarUnit fromDate:date];
+
+			NSDateComponents *utcComponents = [[NSDateComponents alloc] init];
+			[utcComponents setYear:1970];
+			[utcComponents setMonth:1];
+			[utcComponents setDay:1];
+			[utcComponents setHour:[components hour]];
+			[utcComponents setMinute:[components minute]];
+
+			return [utcCalendar dateFromComponents:utcComponents];
+		@}
 	}
 }

--- a/Source/Fuse.Controls.Native/iOs/DateTimeConverterHelpers.uno
+++ b/Source/Fuse.Controls.Native/iOs/DateTimeConverterHelpers.uno
@@ -1,0 +1,64 @@
+using Uno;
+using Uno.Compiler.ExportTargetInterop;
+
+namespace Fuse.Controls.Native.iOS
+{
+	extern(iOS) internal static class DateTimeConverterHelpers
+	{
+		const long DotNetTicksInSecond = 10000000L;
+		const long UnixEpochInDotNetTicks = 621355968000000000L;
+
+		public static DateTime ConvertNSDateToDateTime(ObjC.Object date)
+		{
+			var secondsSince1970InUtc = (long)NSDateToSecondsSince1970InUtc(date);
+
+			var dotNetTicksRelativeToUnixEpoch = (long)secondsSince1970InUtc * DotNetTicksInSecond;
+			var dotNetTicks = dotNetTicksRelativeToUnixEpoch + UnixEpochInDotNetTicks;
+
+			return new DateTime(dotNetTicks, DateTimeKind.Utc);
+		}
+
+		public static ObjC.Object ConvertDateTimeToNSDate(DateTime dt)
+		{
+			dt = dt.ToUniversalTime();
+
+			var dotNetTicks = dt.Ticks;
+			var dotNetTicksRelativeToUnixEpoch = dotNetTicks - UnixEpochInDotNetTicks;
+			var secondsSince1970InUtc = dotNetTicksRelativeToUnixEpoch / DotNetTicksInSecond;
+
+			return SecondsSince1970InUtcToNSDate((double)secondsSince1970InUtc);
+		}
+
+		[Foreign(Language.ObjC)]
+		public static double NSDateToSecondsSince1970InUtc(ObjC.Object date)
+		@{
+			return [date timeIntervalSince1970];
+		@}
+
+		[Foreign(Language.ObjC)]
+		public static ObjC.Object SecondsSince1970InUtcToNSDate(double secondsSince1970InUtc)
+		@{
+			return [NSDate dateWithTimeIntervalSince1970:secondsSince1970InUtc];
+		@}
+
+		[Foreign(Language.ObjC)]
+		public static ObjC.Object ReconstructUtcDate(ObjC.Object date)
+		@{
+			if (!date)
+				return [NSDate dateWithTimeIntervalSince1970:0];
+
+			// Reconstruct the same date in UTC without time components
+			NSCalendar *utcCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+			[utcCalendar setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+
+			NSDateComponents *components = [utcCalendar components:NSYearCalendarUnit|NSMonthCalendarUnit|NSDayCalendarUnit fromDate:date];
+
+			NSDateComponents *utcComponents = [[NSDateComponents alloc] init];
+			[utcComponents setYear:[components year]];
+			[utcComponents setMonth:[components month]];
+			[utcComponents setDay:[components day]];
+
+			return [utcCalendar dateFromComponents:utcComponents];
+		@}
+	}
+}

--- a/Source/Fuse.Controls.TimePicker/Android/TimePicker.uno
+++ b/Source/Fuse.Controls.TimePicker/Android/TimePicker.uno
@@ -1,0 +1,163 @@
+using Uno;
+using Uno.UX;
+using Uno.Compiler.ExportTargetInterop;
+
+using Fuse;
+using Fuse.Controls;
+using Fuse.Controls.Native;
+
+namespace Fuse.Controls.Native.Android
+{
+	extern(!Android) class TimePickerView
+	{
+		[UXConstructor]
+		public TimePickerView([UXParameter("Host")]ITimePickerHost host) { }
+	}
+
+	extern(Android) class TimePickerView : LeafView, ITimePickerView
+	{
+		ITimePickerHost _host;
+
+		[UXConstructor]
+		public TimePickerView([UXParameter("Host")]ITimePickerHost host) : base(Create())
+		{
+			_host = host;
+
+			// onTimeChanged is extremely inconsistent, esp. when using the now-default clock mode, so
+			//  let's just skip trying to use it altogether and go for a polling-based approach instead.
+			UpdatePollValueCache();
+		}
+
+		public override void Dispose()
+		{
+			base.Dispose();
+			_host = null;
+		}
+
+		public DateTime Value
+		{
+			get
+			{
+				var msSince1970InUtc = GetTimeInMsSince1970InUtc(Handle);
+				return DateTimeConverterHelpers.ConvertMsSince1970InUtcToDateTime(msSince1970InUtc);
+			}
+			set
+			{
+				SetTime(Handle, DateTimeConverterHelpers.ConvertDateTimeToMsSince1970InUtc(value));
+				UpdatePollValueCache();
+			}
+		}
+
+		DateTime _pollValueCache;
+
+		void UpdatePollValueCache()
+		{
+			_pollValueCache = Value;
+		}
+
+		public void PollViewValue()
+		{
+			if (Value != _pollValueCache)
+			{
+				OnValueChanged();
+				UpdatePollValueCache();
+			}
+		}
+
+		public void OnRooted()
+		{
+			UpdateManager.AddAction(PollViewValue);
+		}
+
+		public void OnUnrooted()
+		{
+			UpdateManager.RemoveAction(PollViewValue);
+		}
+
+		public bool Is24HourView
+		{
+			get { return GetIs24HourView(Handle); }
+			set { SetIs24HourView(Handle, value); }
+		}
+
+		void OnValueChanged()
+		{
+			_host.OnValueChanged();
+		}
+
+		[Foreign(Language.Java)]
+		static Java.Object Create()
+		@{
+			return new android.widget.TimePicker(@(Activity.Package).@(Activity.Name).GetRootActivity());
+		@}
+
+		[Foreign(Language.Java)]
+		void SetTime(Java.Object timePickerHandle, long msSince1970InUtc)
+		@{
+			java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"), java.util.Locale.getDefault());
+			cal.setTimeInMillis(msSince1970InUtc);
+
+			int hour = cal.get(java.util.Calendar.HOUR);
+			if (cal.get(java.util.Calendar.AM_PM) == java.util.Calendar.PM)
+				hour += 12;
+			int minute = cal.get(java.util.Calendar.MINUTE);
+
+			android.widget.TimePicker timePicker = (android.widget.TimePicker)timePickerHandle;
+
+			if (android.os.Build.VERSION.SDK_INT >= 23) {
+				timePicker.setHour(hour);
+				timePicker.setMinute(minute);
+			} else {
+				timePicker.setCurrentHour(hour);
+				timePicker.setCurrentMinute(minute);
+			}
+		@}
+
+		[Foreign(Language.Java)]
+		long GetTimeInMsSince1970InUtc(Java.Object timePickerHandle)
+		@{
+			android.widget.TimePicker timePicker = (android.widget.TimePicker)timePickerHandle;
+
+			int hour, minute;
+
+			if (android.os.Build.VERSION.SDK_INT >= 23) {
+				hour = timePicker.getHour();
+				minute = timePicker.getMinute();
+			} else {
+				hour = timePicker.getCurrentHour();
+				minute = timePicker.getCurrentMinute();
+			}
+
+			// Remove date offsets so we only express the time in UTC
+			java.util.Calendar cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"), java.util.Locale.getDefault());
+
+			cal.set(java.util.Calendar.YEAR, 1970);
+			cal.set(java.util.Calendar.MONTH, 0); // Android month starts at 0
+			cal.set(java.util.Calendar.DAY_OF_MONTH, 1);
+
+			cal.set(java.util.Calendar.AM_PM, java.util.Calendar.AM);
+			cal.set(java.util.Calendar.HOUR, hour);
+			cal.set(java.util.Calendar.MINUTE, minute);
+			cal.set(java.util.Calendar.SECOND, 0);
+			cal.set(java.util.Calendar.MILLISECOND, 0);
+
+			return cal.getTimeInMillis();
+		@}
+
+		[Foreign(Language.Java)]
+		void SetIs24HourView(Java.Object timePickerHandle, bool value)
+		@{
+			android.widget.TimePicker timePicker = (android.widget.TimePicker)timePickerHandle;
+
+			timePicker.setIs24HourView(value);
+		@}
+
+		[Foreign(Language.Java)]
+		bool GetIs24HourView(Java.Object timePickerHandle)
+		@{
+			android.widget.TimePicker timePicker = (android.widget.TimePicker)timePickerHandle;
+
+			return timePicker.is24HourView();
+		@}
+	}
+}

--- a/Source/Fuse.Controls.TimePicker/Fuse.Controls.TimePicker.unoproj
+++ b/Source/Fuse.Controls.TimePicker/Fuse.Controls.TimePicker.unoproj
@@ -1,0 +1,22 @@
+{
+  "Copyright": "Copyright (c) Fusetools AS 2017",
+  "Description": "Native TimePicker",
+  "Publisher": "Fusetools AS",
+  "Version": "1.0.0",
+  "Package": {
+    "ProjectUrl": "https://fusetools.com"
+  },
+  "Projects": [
+    "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Controls.Native/Fuse.Controls.Native.unoproj",
+    "../Fuse.Controls.Panels/Fuse.Controls.Panels.unoproj",
+    "../Fuse.Controls.Primitives/Fuse.Controls.Primitives.unoproj",
+    "../Fuse.Drawing/Fuse.Drawing.unoproj",
+    "../Fuse.Elements/Fuse.Elements.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+  ],
+  "Includes": [
+    "*"
+  ]
+}

--- a/Source/Fuse.Controls.TimePicker/TimePicker.Docs.uno
+++ b/Source/Fuse.Controls.TimePicker/TimePicker.Docs.uno
@@ -1,0 +1,60 @@
+namespace Fuse.Controls
+{
+	/**
+		Displays a component to select a time.
+
+		Currently, the TimePicker only has native implementations, so it should be contained in a @NativeViewHost.
+
+		A `TimePicker` can be used to select a specific time value. The type of its `Value` property is `Uno.DateTime`,
+		which is marshalled automatically to and from the JavaScript `Date` type. This makes interaction between JavaScript
+		and the `TimePicker` type seamless via databinding. If you plan to wrap a `TimePicker` in a UX component and use a
+		UX property to hook up this value, the `Uno.DateTime` type should be used.
+
+		Both `Uno.DateTime` and JS' `Date` type represent a specific timestamp. These types have both date and time
+		components, and their interpretation depends on a given time zone, which can cause a great deal of confusion. To
+		simplify all of this and ensure consistent behavior accross different time zones and locales, `TimePicker` will assume
+		incoming values are relative to UTC, and truncate the date component to the Unix epoch (1 Jan 1970), effectively
+		ignoring the date component altogether. Similarly, values read from `TimePicker` properties will only consist of a time
+		component at on 1 Jan 1970. This makes values going to/from the `TimePicker` control easy to create and interpret
+		consistently, but also means that if a value with a date component other than the unix epoch is written to TimePicker`'s
+		`Value` property, subsequent values read from the property may not match the written value, as the date component will
+		have been truncated.
+
+		You should avoid modifying the `TimePicker` values programmatically while the control has focus, as this is known to
+		have some issues on some Android devices (particularly ones which use the new `clock` appearance prior to Android 7).
+
+		## Example
+
+		The following example shows how to set up a `TimePicker` object and set the value from JS using a `Date` object:
+
+			<StackPanel>
+				<JavaScript>
+					var Observable = require("FuseJS/Observable");
+
+					var someTime = Observable(new Date(Date.parse("2007-02-14T12:34:56.000Z")));
+
+					someTime.onValueChanged(module, function(date) {
+						console.log("someTime changed: " + JSON.stringify(date));
+					});
+
+					module.exports = {
+						someTime: someTime,
+
+						timeToGetCracking: function() {
+							someTime.value = new Date(Date.parse("1970-01-01T13:37:00.000Z"));
+						}
+					};
+				</JavaScript>
+
+				<NativeViewHost>
+					<TimePicker Value="{someTime}" Is24HourTimeView="true" />
+				</NativeViewHost>
+
+				<Button Text="Time to get cracking!" Clicked="{timeToGetCracking}" Margin="5" />
+			</StackPanel>
+
+	*/
+	public partial class TimePicker
+	{
+	}
+}

--- a/Source/Fuse.Controls.TimePicker/TimePicker.uno
+++ b/Source/Fuse.Controls.TimePicker/TimePicker.uno
@@ -1,0 +1,126 @@
+using Uno;
+using Uno.UX;
+using Uno.Compiler.ExportTargetInterop;
+
+using Fuse;
+using Fuse.Controls.Native;
+using Fuse.Scripting;
+
+namespace Fuse.Controls
+{
+	using Native.iOS;
+	using Native.Android;
+
+	interface ITimePickerView
+	{
+		DateTime Value { get; set; }
+		bool Is24HourView { get; set; }
+
+		void OnRooted();
+		void OnUnrooted();
+	}
+
+	interface ITimePickerHost
+	{
+		void OnValueChanged();
+	}
+
+	public abstract partial class TimePickerBase : Panel, ITimePickerHost
+	{
+		static Selector _valueName = "Value";
+
+		[UXOriginSetter("SetValue")]
+		/**
+			Gets or sets the current time value selected by the `TimePicker`.
+		*/
+		public DateTime Value
+		{
+			get
+			{
+				var tpv = TimePickerView;
+				return tpv != null
+					? tpv.Value
+					: DateTime.UtcNow;
+			}
+			set { SetValue(value, this); }
+		}
+
+		public void SetValue(DateTime value, IPropertyListener origin)
+		{
+			var tpv = TimePickerView;
+			if (tpv != null && tpv.Value != value)
+			{
+				tpv.Value = value;
+				OnValueChanged(origin);
+			}
+		}
+
+		internal void OnValueChanged(IPropertyListener origin)
+		{
+			OnPropertyChanged(_valueName, origin);
+		}
+
+		static Selector _is24HourViewName = "Is24HourView";
+
+		[UXOriginSetter("SetIs24HourView")]
+		/**
+			Used to toggle 24-hour or am/pm view. Default is false (am/pm).
+
+			Currently only implemented for Android, as iOS doesn't expose an explicit API for this.
+		*/
+		public bool Is24HourView
+		{
+			get
+			{
+				var tpv = TimePickerView;
+				return tpv != null
+					? tpv.Is24HourView
+					: false;
+			}
+			set { SetIs24HourView(value, this); }
+		}
+
+		public void SetIs24HourView(bool value, IPropertyListener origin)
+		{
+			var tpv = TimePickerView;
+			if (tpv != null && tpv.Is24HourView != value)
+			{
+				tpv.Is24HourView = value;
+				OnIs24HourViewChanged(origin);
+			}
+		}
+
+		internal void OnIs24HourViewChanged(IPropertyListener origin)
+		{
+			OnPropertyChanged(_is24HourViewName, origin);
+		}
+
+		ITimePickerView TimePickerView
+		{
+			get { return (ITimePickerView)NativeView; }
+		}
+
+		void ITimePickerHost.OnValueChanged()
+		{
+			OnValueChanged(this);
+		}
+
+		protected override void OnRooted()
+		{
+			base.OnRooted();
+
+			var tpv = TimePickerView;
+			if (tpv != null)
+				tpv.OnRooted();
+		}
+
+		protected override void OnUnrooted()
+		{
+			var tpv = TimePickerView;
+			if (tpv != null)
+				tpv.OnUnrooted();
+
+			base.OnUnrooted();
+		}
+	}
+}

--- a/Source/Fuse.Controls.TimePicker/TimePicker.ux
+++ b/Source/Fuse.Controls.TimePicker/TimePicker.ux
@@ -1,0 +1,10 @@
+<Fuse.Controls.TimePickerBase ux:Class="Fuse.Controls.TimePicker" ux:Name="self">
+	<Panel ux:Template="GraphicsAppearance" Margin="4" Background="#eee" Padding="30">
+		<Text Value="GraphicsAppearance for TimePicker not implemented!" Alignment="Center" TextWrapping="Wrap" />
+		<Rectangle Layer="Background">
+			<Stroke Color="#000" />
+		</Rectangle>
+	</Panel>
+	<Fuse.Controls.Native.iOS.TimePickerView ux:Condition="iOS" ux:Template="iOSAppearance" Host="self" />
+	<Fuse.Controls.Native.Android.TimePickerView ux:Condition="Android" ux:Template="AndroidAppearance" Host="self" />
+</Fuse.Controls.TimePickerBase>

--- a/Source/Fuse.Controls.TimePicker/iOS/TimePicker.uno
+++ b/Source/Fuse.Controls.TimePicker/iOS/TimePicker.uno
@@ -1,0 +1,99 @@
+using Uno;
+using Uno.UX;
+using Uno.Compiler.ExportTargetInterop;
+
+using Fuse;
+using Fuse.Controls;
+using Fuse.Controls.Native;
+using Fuse.Controls.Native.iOS;
+
+namespace Fuse.Controls.Native.iOS
+{
+	extern(!iOS) class TimePickerView
+	{
+		[UXConstructor]
+		public TimePickerView([UXParameter("Host")]ITimePickerHost host) { }
+	}
+
+	[Require("Source.Include", "UIKit/UIKit.h")]
+	extern(iOS) class TimePickerView : LeafView, ITimePickerView
+	{
+		ITimePickerHost _host;
+		IDisposable _valueChangedEvent;
+
+		[UXConstructor]
+		public TimePickerView([UXParameter("Host")]ITimePickerHost host) : base(Create())
+		{
+			_host = host;
+			_valueChangedEvent = UIControlEvent.AddValueChangedCallback(Handle, OnValueChanged);
+		}
+
+		public override void Dispose()
+		{
+			base.Dispose();
+			_valueChangedEvent.Dispose();
+			_valueChangedEvent = null;
+			_host = null;
+		}
+
+		void OnValueChanged(ObjC.Object sender, ObjC.Object args)
+		{
+			_host.OnValueChanged();
+		}
+
+		public DateTime Value
+		{
+			get { return DateTimeConverterHelpers.ConvertNSDateToDateTime(DateTimeConverterHelpers.ReconstructUtcTime(GetTime(Handle))); }
+			set { SetTime(Handle, DateTimeConverterHelpers.ReconstructUtcTime(DateTimeConverterHelpers.ConvertDateTimeToNSDate(value))); }
+		}
+
+		// Dummy prop, as the iOS API doesn't provide an explicit API for this.
+		public bool Is24HourView
+		{
+			get { return false; }
+			set {
+				// Do nothing
+			}
+		}
+
+		public void OnRooted()
+		{
+			// Do nothing
+		}
+
+		public void OnUnrooted()
+		{
+			// Do nothing
+		}
+
+		[Foreign(Language.ObjC)]
+		static ObjC.Object Create()
+		@{
+			UIDatePicker *dp = [[UIDatePicker alloc] init];
+
+			[dp setDatePickerMode:UIDatePickerModeTime];
+
+			// Make sure the time picker interprets date values in UTC
+			[dp setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+
+			return dp;
+		@}
+
+		[Foreign(Language.ObjC)]
+		void SetTime(ObjC.Object datePickerHandle, ObjC.Object time)
+		@{
+			UIDatePicker *dp = (UIDatePicker *)datePickerHandle;
+
+			[dp setDate:time animated:true];
+		@}
+
+		[Foreign(Language.ObjC)]
+		ObjC.Object GetTime(ObjC.Object datePickerHandle)
+		@{
+			UIDatePicker *dp = (UIDatePicker *)datePickerHandle;
+
+			return [dp date];
+		@}
+	}
+
+}

--- a/Source/Fuse/Fuse.unoproj
+++ b/Source/Fuse/Fuse.unoproj
@@ -18,6 +18,7 @@
     "../Fuse.Controls.Panels/Fuse.Controls.Panels.unoproj",
     "../Fuse.Controls.Primitives/Fuse.Controls.Primitives.unoproj",
     "../Fuse.Controls.ScrollView/Fuse.Controls.ScrollView.unoproj",
+    "../Fuse.Controls.TimePicker/Fuse.Controls.TimePicker.unoproj",
     "../Fuse.Controls.Video/Fuse.Controls.Video.unoproj",
     "../Fuse.Controls.WebView/Fuse.Controls.WebView.unoproj",
     "../Fuse.Common/Fuse.Common.unoproj",

--- a/Tests/ManualTests/ManualTestingApp/DatePicker/DatePickerPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/DatePicker/DatePickerPage.ux
@@ -10,7 +10,7 @@
 		<p>Finally, press the "Log DateTime property" button and ensure the currently picked date is output to the console, and push the "Change DateTime property" button and ensure the time picked by both pickers matches 8th June 1984.</p>
 	</InfoStack>
 
-	<StackPanel ux:Class="MyClass">
+	<StackPanel ux:Class="DatePickerCustomComponent">
 		<Uno.DateTime ux:Property="DateTime" />
 
 		<JavaScript>
@@ -52,7 +52,7 @@
 			<Text>Placeholder area to hide native controls beneath info panel; scroll down for test view</Text>
 			<Panel Height="600" />
 
-			<MyClass DateTime="{someDate}" />
+			<DatePickerCustomComponent DateTime="{someDate}" />
 
 			<NativeViewHost>
 				<StackPanel>

--- a/Tests/ManualTests/ManualTestingApp/MainView.ux
+++ b/Tests/ManualTests/ManualTestingApp/MainView.ux
@@ -144,12 +144,14 @@
 			<Android>
 				<WebViewPage/>
 				<DatePickerPage/>
+				<NativeTimePickerPage/>
 				<BackButtonView/>
 			</Android>
 			<iOS>
 				<MapViewPage/>
 				<WebViewPage/>
 				<DatePickerPage/>
+				<NativeTimePickerPage/>
 			</iOS>
 		</PageControl>
 		<BottomFrameBackground DockPanel.Dock="Bottom"/>

--- a/Tests/ManualTests/ManualTestingApp/TimePicker/NativeTimePickerPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/TimePicker/NativeTimePickerPage.ux
@@ -1,0 +1,72 @@
+<Page Title="TimePicker" ux:Class="NativeTimePickerPage">
+	<InfoStack ux:Key="Info">
+		<h2>Goal</h2>
+		<p>To test that native TimePickers work as expected.</p>
+		<h2>Instructions</h2>
+		<p>Below there should be two different TimePickers, both showing 10:11 AM.</p>
+		<p>First, push the "Change DateTime property" button and ensure the time picked by both pickers matches 17:34 (5:34 PM).</p>
+		<Android>
+			<p>Push the "toggle AM/PM" button a couple times and ensure that both pickers switch between AM/PM and 24 hour modes.</p>
+		</Android>
+		<p>Change the time in the first picker, wait for animations to settle, and make sure the value of the second picker changes to match the value of the first.</p>
+		<p>Then, change the value of the second picker, wait for animations to settle, and make sure the value of the first picker changes to match the value of the second.</p>
+	</InfoStack>
+
+	<StackPanel ux:Class="TimePickerCustomComponent">
+		<Uno.DateTime ux:Property="DateTime" />
+
+		<JavaScript>
+			var self = this;
+
+			module.exports = {
+				whoYouGonnaCall: function() {
+					self.DateTime.value = new Date(Date.parse("1984-06-08T17:34:56.000Z"));
+				}
+			};
+		</JavaScript>
+
+		<Button Text="Change DateTime property" Clicked="{whoYouGonnaCall}" Margin="5" />
+	</StackPanel>
+
+	<ScrollView>
+		<StackPanel>
+			<JavaScript>
+				var Observable = require("FuseJS/Observable");
+
+				var someTime = Observable(new Date(Date.parse("1970-01-01T10:11:12.000Z")));
+
+				var is24HourView = Observable(false);
+
+				someTime.onValueChanged(module, function(date) {
+					console.log("someTime changed in JS: " + JSON.stringify(date));
+				});
+
+				module.exports = {
+					someTime: someTime,
+
+					is24HourView: is24HourView,
+
+					toggleIs24HourView: function() {
+						is24HourView.value = !is24HourView.value;
+					}
+				};
+			</JavaScript>
+
+			<Text>Placeholder area to hide native controls beneath info panel; scroll down for test view</Text>
+			<Panel Height="600" />
+
+			<TimePickerCustomComponent DateTime="{someTime}" />
+
+			<Android>
+				<Button Text="Toggle AM/PM" Clicked="{toggleIs24HourView}" Margin="5" />
+			</Android>
+
+			<NativeViewHost>
+				<StackPanel>
+					<TimePicker Value="{someTime}" Is24HourView="{is24HourView}" />
+					<TimePicker Value="{someTime}" Is24HourView="{is24HourView}" />
+				</StackPanel>
+			</NativeViewHost>
+		</StackPanel>
+	</ScrollView>
+</Page>

--- a/Tests/ManualTests/ManualTestingApp/UnoComponents.unoproj
+++ b/Tests/ManualTests/ManualTestingApp/UnoComponents.unoproj
@@ -41,5 +41,6 @@
     "StrokeAndFills/StrokeAndFills.ux.uno:Source",
     "StrokeAndFills/StrokeAndFills.ux:UX",
     "TestAppTheme.ux:UX",
+    "TimePicker/NativeTimePickerPage.ux:UX",
   ]
 }


### PR DESCRIPTION
Introduces the `Fuse.Controls.TimePicker` package, which includes a `TimePicker` class that proxies native views on Android and iOS. On desktop, a simple placeholder is shown.

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests