### PR TITLE
Fuse.Nodes: fix linked-list usage in Visual.Children.Clear

### DIFF
--- a/Source/Fuse.Nodes/Tests/UX/Visual.ChildrenClear.ux
+++ b/Source/Fuse.Nodes/Tests/UX/Visual.ChildrenClear.ux
@@ -1,0 +1,7 @@
+<Panel ux:Class="UX.Visual.ChildrenClear">
+	<Panel ux:Name="ParentA">
+		<Panel ux:Name="ChildA" />
+		<Panel ux:Name="ChildB" />
+	</Panel>
+	<Panel ux:Name="ParentB" />
+</Panel>

--- a/Source/Fuse.Nodes/Tests/Visual.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Visual.Test.uno
@@ -103,5 +103,21 @@ namespace Fuse.Test
 				Assert.IsTrue(p.B.HitTestBounds.IsEmpty);
 			}
 		}
+
+		[Test]
+		public void ChildrenClear()
+		{
+			var p = new UX.Visual.ChildrenClear();
+			using (var r = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(2, p.ParentA.Children.Count);
+				p.ParentA.Children.Clear();
+				Assert.AreEqual(0, p.ParentA.Children.Count);
+
+				p.ParentB.Children.Add(p.ChildA);
+				p.ParentB.Children.Add(p.ChildB);
+				Assert.AreEqual(2, p.ParentB.Children.Count);
+			}
+		}
 	}
 }

--- a/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
+++ b/Source/Fuse.Nodes/Visual.Children.LinkedList.uno
@@ -75,10 +75,12 @@ namespace Fuse
 		void Children_Clear()
 		{
 			Children_Invalidate();
-			
-			for (var c = _firstChild; c != null; c = c._nextSibling)
+
+			Node nextSibling;
+			for (var c = _firstChild; c != null; c = nextSibling)
 			{
 				Children_MakeOrphan(c);
+				nextSibling = c._nextSibling;
 				c._nextSibling = null;
 				c._previousSibling = (Node)null;
 			}


### PR DESCRIPTION
We can't null out _nextSibling and then attempt to look it up right
after. This means we effectively only unlinked the first child,
leading to trouble if the following children were ever attempted
inserted into some other child-list.

Fixes #528.