### PR TITLE
Remove log step in DatePicker manual test

### DIFF
--- a/Tests/ManualTests/ManualTestingApp/DatePicker/DatePickerPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/DatePicker/DatePickerPage.ux
@@ -7,7 +7,7 @@
 		<p>Change the date in the first picker, wait for animations to settle, and make sure the value of the second picker changes to match the value of the first.</p>
 		<p>Then, change the value of the second picker, wait for animations to settle, and make sure the value of the first picker changes to match the value of the second.</p>
 		<p>Then, using either picker, try to pick a date before 1st January 1950 or after 1st January 2050 and verify that this isn't possible.</p>
-		<p>Finally, press the "Log DateTime property" button and ensure the currently picked date is output to the console, and push the "Change DateTime property" button and ensure the time picked by both pickers matches 8th June 1984.</p>
+		<p>Finally, press the "Change DateTime property" button and ensure the time picked by both pickers matches 8th June 1984.</p>
 	</InfoStack>
 
 	<StackPanel ux:Class="MyClass">
@@ -17,16 +17,12 @@
 			var self = this;
 
 			module.exports = {
-				logDateTime: function() {
-					console.log("DateTime: " + JSON.stringify(self.DateTime.value));
-				},
 				whoYouGonnaCall: function() {
 					self.DateTime.value = new Date(Date.parse("1984-06-08T00:00:00.000Z"));
 				}
 			};
 		</JavaScript>
 
-		<Button Text="Log DateTime property" Clicked="{logDateTime}" Margin="5" />
 		<Button Text="Change DateTime property" Clicked="{whoYouGonnaCall}" Margin="5" />
 	</StackPanel>
 


### PR DESCRIPTION
I didn't realize that our testers don't have a log available.
