### PR TITLE
fix a regression with not updating items

### DIFF
--- a/Source/Fuse.Reactive.Bindings/Each.uno
+++ b/Source/Fuse.Reactive.Bindings/Each.uno
@@ -158,14 +158,11 @@ namespace Fuse.Reactive
 		*/
 		public object Items
 		{
-			get { return _items; }
+			get { return GetItems(); }
 			set
 			{
-				if (_items != value)
-				{
-					_items = value;
-					OnItemsChanged();
-				}
+				if (GetItems() != value)
+					SetItems( value );
 			}
 		}
 

--- a/Source/Fuse.Reactive.Bindings/Instance.API.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.API.uno
@@ -296,11 +296,28 @@ namespace Fuse.Reactive
 		
 		internal bool HasLimit { get { return _hasLimit; } }
 
-		protected internal object _items;
+		object _items;
+		/** @hide */
+		protected object GetItems() { return _items; }
+		/** @hide */
+		protected void SetItems( object value )
+		{
+			_items = value;
+			if (!IsRootingCompleted) return;
+			RefreshItems();
+		}
+		/** Call to set the items during the OnRooted override (post base.OnRooted call)
+			@hide */
+		protected void SetItemsDerivedRooting( object value )
+		{
+			_items = value;
+			RefreshItems();
+		}
 		
 		class CountItem { }
 		
 		int _count;
+		/** @hide */
 		protected internal int Count
 		{
 			get { return _count; }
@@ -313,18 +330,8 @@ namespace Fuse.Reactive
 				var items = new object[_count];
 				for (int i=0; i < _count; ++i)
 					items[i] = new CountItem();
-				_items = items;
-				OnItemsChanged();
+				SetItems( items );
 			}
-		}
-		
-		
-		
-		protected internal void OnItemsChanged()
-		{
-			if (!IsRootingStarted) return;
-
-			RefreshItems();
 		}
 
 		void RefreshItems()
@@ -375,7 +382,8 @@ namespace Fuse.Reactive
 				if (_matchKey != value)
 				{
 					_matchKey = value;
-					OnItemsChanged();
+					if (IsRootingCompleted)
+						RefreshItems();
 				}
 			}
 		}

--- a/Source/Fuse.Reactive.Bindings/Instance.API.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.API.uno
@@ -322,7 +322,7 @@ namespace Fuse.Reactive
 		
 		protected internal void OnItemsChanged()
 		{
-			if (!IsRootingCompleted) return;
+			if (!IsRootingStarted) return;
 
 			RefreshItems();
 		}

--- a/Source/Fuse.Reactive.Bindings/Instance.uno
+++ b/Source/Fuse.Reactive.Bindings/Instance.uno
@@ -64,11 +64,13 @@ namespace Fuse.Reactive
 	[UXContentMode("Template")]
 	public partial class Instantiator: Behavior, IObserver, Node.ISubtreeDataProvider, IDeferred
 	{
+		/** @hide */
 		protected internal Instantiator(IList<Template> templates)
 		{
 			_templates = templates;
 		}
 
+		/** @hide */
 		protected internal Instantiator()
 		{
 		}

--- a/Source/Fuse.Reactive.Bindings/Tests/Instance.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/Instance.Test.uno
@@ -17,5 +17,28 @@ namespace Fuse.Reactive.Bindings.Test
 				Assert.AreEqual( "zero,one,two", GetText(p));
 			}
 		}
+		
+		[Test]
+		//a regression occurred when a derived class set Items (Charting does this)
+		public void RootItems()
+		{
+			var e = new UX.Instance.RootItems();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.PumpDeferred();
+				Assert.AreEqual("3,2", GetDudZ(e));
+			}
+		}
+	
+	}
+	
+	public class RootInstantiator : Instantiator
+	{
+		protected override void OnRooted()
+		{
+			base.OnRooted();
+			_items = new object[]{2,3};
+			OnItemsChanged();
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Bindings/Tests/Instance.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/Instance.Test.uno
@@ -37,8 +37,7 @@ namespace Fuse.Reactive.Bindings.Test
 		protected override void OnRooted()
 		{
 			base.OnRooted();
-			_items = new object[]{2,3};
-			OnItemsChanged();
+			SetItemsDerivedRooting( new object[]{2,3} );
 		}
 	}
 }

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Instance.RootItems.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Instance.RootItems.ux
@@ -1,0 +1,5 @@
+<Panel ux:Class="UX.Instance.RootItems">
+	<Fuse.Reactive.Bindings.Test.RootInstantiator>
+		<FuseTest.DudElement Value="{}"/>
+	</Fuse.Reactive.Bindings.Test.RootInstantiator>
+</Panel>


### PR DESCRIPTION
A change in Each.OnItemsChanged breaks an expected behaviour in Charting. The fix appears to be providing a more complete dervied API to resolve a rooting issue. Premiumlibs will need to use this new `SetItemsDerivedRooting` function.

This PR contains:
- [ ] ~Changelog~
- [ ] ~Documentation~
- [x] Tests
