### PR TITLE
Fix ManualTestApp/issues/371

### DIFF
--- a/Source/Fuse.Controls.Video/VideoVisual.uno
+++ b/Source/Fuse.Controls.Video/VideoVisual.uno
@@ -57,12 +57,13 @@ namespace Fuse.Controls.VideoImpl
 
 		enum PlaybackTarget
 		{
+			Undefined,
 			Playing,
 			Paused,
 			Stopped
 		}
 
-		PlaybackTarget _playbackTarget = PlaybackTarget.Stopped;
+		PlaybackTarget _playbackTarget = PlaybackTarget.Undefined;
 
 		protected override void Attach()
 		{

--- a/Source/Fuse.Controls.Video/VideoVisual.uno
+++ b/Source/Fuse.Controls.Video/VideoVisual.uno
@@ -136,6 +136,8 @@ namespace Fuse.Controls.VideoImpl
 				((IPlayback)this).Pause();
 			else if (_playbackTarget == PlaybackTarget.Stopped)
 				((IPlayback)this).Stop();
+
+			_playbackTarget = PlaybackTarget.Undefined;
 		}
 
 		void IVideoCallbacks.OnCompleted()

--- a/Source/Fuse.Controls.Video/VideoVisual.uno
+++ b/Source/Fuse.Controls.Video/VideoVisual.uno
@@ -130,12 +130,21 @@ namespace Fuse.Controls.VideoImpl
 
 			Control.OnDurationChanged();
 
-			if (_playbackTarget == PlaybackTarget.Playing)
-				((IPlayback)this).Resume();
-			else if (_playbackTarget == PlaybackTarget.Paused)
-				((IPlayback)this).Pause();
-			else if (_playbackTarget == PlaybackTarget.Stopped)
-				((IPlayback)this).Stop();
+			var playback = (IPlayback)this;
+			switch (_playbackTarget)
+			{
+				case PlaybackTarget.Playing:
+					playback.Resume();
+					break;
+
+				case PlaybackTarget.Paused:
+					playback.Pause();
+					break;
+
+				case PlaybackTarget.Stopped:
+					playback.Stop();
+					break;
+			}
 
 			_playbackTarget = PlaybackTarget.Undefined;
 		}


### PR DESCRIPTION
https://github.com/fusetools/fuselibs-public/pull/506 changed the behavior of video slightly to go directly to the "paused" state when the video was ready to play. The expected behavior was neither "playing" nor "stopped", so I added an Undefined option to cover the last case. Should this perhaps be renamed to "Ready" or "Initialized"? This is simply to represent the state where the user hasn't done anything yet.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
