### PR TITLE
Fuse.Marshal: apply float-vector conversion-rules to IArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ## Video
 - Fixed bug in Video where playback actions, like `Play`, used before the video was initialized would end up getting swallowed.
 
+## Fuse.Marshal:
+- Fixed a bug where UX expressions that produce two component floats did not expand to four compoent floats the same same way as literals did.
+
 ## Fuse.Reactive framework changes (Uno-level)
 - These are breaking changes, but very unlikely to affect your app:
  * The `DataBinding`, `EventBinding` and `ExpressionBinding` class constructors no longer take a `NameTable` argument.

--- a/Source/Fuse.Marshal/Marshal.Cast.uno
+++ b/Source/Fuse.Marshal/Marshal.Cast.uno
@@ -114,7 +114,16 @@ namespace Fuse
 				var y = a.Length > 1 ? ToFloat(a[1]) : 0.0f;
 				var z = a.Length > 2 ? ToFloat(a[2]) : 0.0f;
 				var w = a.Length > 3 ? ToFloat(a[3]) : 1.0f;
-				return float4(x,y,z,w);
+
+				switch (a.Length)
+				{
+					case 0: return default(float4);
+					case 1: return ToFloat4(x);
+					case 2: return ToFloat4(float2(x, y));
+					case 3: return ToFloat4(float3(x, y, z));
+					default:
+						return float4(x, y, z, w);
+				}
 			}
 
 			double d;

--- a/Source/Fuse.Marshal/Marshal.Cast.uno
+++ b/Source/Fuse.Marshal/Marshal.Cast.uno
@@ -64,19 +64,24 @@ namespace Fuse
 			return double.TryParse(s, out res);
 		}
 
+		static float4 ToFloat4(float3 f)
+		{
+			return float4(f.X, f.Y, f.Z, 1.0f);
+		}
+
+		static float4 ToFloat4(float2 f)
+		{
+			return float4(f.X, f.Y, f.X, f.Y);
+		}
+
 		public static float4 ToFloat4(object o)
 		{
-			if (o is float4) return (float4)o;
+			if (o is float4)
+				return (float4)o;
 			else if (o is float3)
-			{
-				var f = (float3)o;
-				return float4(f.X, f.Y, f.Z, 1.0f);
-			}
+				return ToFloat4((float3)o);
 			else if (o is float2)
-			{
-				var f = (float2)o;
-				return float4(f.X, f.Y, f.X, f.Y);
-			}
+				return ToFloat4((float2)o);
 			else if (o is string)
 			{
 				var s = (string)o;

--- a/Source/Fuse.Marshal/Marshal.Cast.uno
+++ b/Source/Fuse.Marshal/Marshal.Cast.uno
@@ -74,6 +74,11 @@ namespace Fuse
 			return float4(f.X, f.Y, f.X, f.Y);
 		}
 
+		static float4 ToFloat4(float f)
+		{
+			return float4(f);
+		}
+
 		public static float4 ToFloat4(object o)
 		{
 			if (o is float4)
@@ -82,6 +87,8 @@ namespace Fuse
 				return ToFloat4((float3)o);
 			else if (o is float2)
 				return ToFloat4((float2)o);
+			else if (o is float)
+				return ToFloat4((float)o);
 			else if (o is string)
 			{
 				var s = (string)o;

--- a/Source/Fuse.Marshal/Tests/Fuse.Marshal.Test.unoproj
+++ b/Source/Fuse.Marshal/Tests/Fuse.Marshal.Test.unoproj
@@ -1,11 +1,6 @@
 {
   "Packages": [
-    "Fuse.Marshal",
-    "Fuse.Common",
-    "Uno.Collections",
-    "UnoCore",
-    "Uno.Testing",
-    "Uno.Threading"
+    "Fuse"
   ],
   "Projects": [
     "../../Fuse.Common/Tests/FuseTest/FuseTest.unoproj"

--- a/Source/Fuse.Marshal/Tests/Marshal.Test.uno
+++ b/Source/Fuse.Marshal/Tests/Marshal.Test.uno
@@ -173,5 +173,21 @@ namespace Fuse
 			Assert.AreEqual(new Size(r.X, Unit.Unspecified), Marshal.ToSize(v));
 
 		}
+
+		[Test]
+		public void VectorMarshaling()
+		{
+			var p = new UX.VectorMarshalling();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(float4(1, 1, 1, 1), p.Literal1.Margin);
+				Assert.AreEqual(float4(1, 2, 1, 2), p.Literal2.Margin);
+				Assert.AreEqual(float4(1, 2, 3, 4), p.Literal4.Margin);
+
+				Assert.AreEqual(float4(1, 1, 1, 1), p.Constant1.Margin);
+				Assert.AreEqual(float4(1, 2, 1, 2), p.Constant2.Margin);
+				Assert.AreEqual(float4(1, 2, 3, 4), p.Constant4.Margin);
+			}
+		}
 	}
 }

--- a/Source/Fuse.Marshal/Tests/UX/VectorMarshaling.ux
+++ b/Source/Fuse.Marshal/Tests/UX/VectorMarshaling.ux
@@ -1,0 +1,10 @@
+<Panel ux:Class="UX.VectorMarshalling">
+	<Panel ux:Name="Literal1" Margin="1" />
+	<Panel ux:Name="Literal2" Margin="1, 2" />
+	<Panel ux:Name="Literal4" Margin="1, 2, 3, 4" />
+
+	<float ux:Global="One" ux:Value="1" />
+	<Panel ux:Name="Constant1" Margin="1 * One" />
+	<Panel ux:Name="Constant2" Margin="1 * One, 2 * One" />
+	<Panel ux:Name="Constant4" Margin="1 * One, 2 * One, 3 * One, 4 * One" />
+</Panel>


### PR DESCRIPTION
The rules for how to upscale a vector should be the same for literals
and expressions, but this wasn't the case. Make sure it is.

Fixes #540

This PR contains:
- [x] Changelog
- [ ] ~Documentation~ this is a bug-fix
- [x] Tests
