### PR TITLE
Fuse.UserEvents: disable spuriously failing test

### DIFF
--- a/Source/Fuse.UserEvents/Tests/UserEvent.Test.uno
+++ b/Source/Fuse.UserEvents/Tests/UserEvent.Test.uno
@@ -7,6 +7,7 @@ namespace Fuse.UserEvents.Test
 	public class UserEventTest : TestBase
 	{
 		[Test]
+		[Ignore("https://github.com/fusetools/fuselibs-public/issues/551")]
 		public void UserEventArgs()
 		{
 			var e = new UX.UserEventArgs();


### PR DESCRIPTION
Disabled to reduce interruptions on CI.

See #551