### PR TITLE
Fix DatePicker bogus scroll

### DIFF
--- a/Source/Fuse.Controls.DatePicker/DatePicker.uno
+++ b/Source/Fuse.Controls.DatePicker/DatePicker.uno
@@ -17,7 +17,8 @@ namespace Fuse.Controls
 		DateTime MinValue { get; set; }
 		DateTime MaxValue { get; set; }
 
-		void PollViewValue();
+		void OnRooted();
+		void OnUnrooted();
 	}
 
 	interface IDatePickerHost
@@ -131,15 +132,6 @@ namespace Fuse.Controls
 			get { return (IDatePickerView)NativeView; }
 		}
 
-		void PollViewValue()
-		{
-			var dpv = DatePickerView;
-			if (dpv == null)
-				return;
-
-			dpv.PollViewValue();
-		}
-
 		void IDatePickerHost.OnValueChanged()
 		{
 			OnValueChanged(this);
@@ -148,12 +140,18 @@ namespace Fuse.Controls
 		protected override void OnRooted()
 		{
 			base.OnRooted();
-			UpdateManager.AddAction(PollViewValue);
+
+			var dpv = DatePickerView;
+			if (dpv != null)
+				dpv.OnRooted();
 		}
 
 		protected override void OnUnrooted()
 		{
-			UpdateManager.RemoveAction(PollViewValue);
+			var dpv = DatePickerView;
+			if (dpv != null)
+				dpv.OnUnrooted();
+
 			base.OnUnrooted();
 		}
 	}

--- a/Source/Fuse.Controls.DatePicker/iOS/DatePicker.uno
+++ b/Source/Fuse.Controls.DatePicker/iOS/DatePicker.uno
@@ -59,7 +59,12 @@ namespace Fuse.Controls.Native.iOS
 			set { SetMaxValue(Handle, DateTimeConverterHelpers.ReconstructUtcDate(DateTimeConverterHelpers.ConvertDateTimeToNSDate(value))); }
 		}
 
-		public void PollViewValue()
+		public void OnRooted()
+		{
+			// Do nothing
+		}
+
+		public void OnUnrooted()
 		{
 			// Do nothing
 		}


### PR DESCRIPTION
On older versions of Android, layout changes can cause the calendar part of the DatePicker's
view to scroll to a bogus month, which both makes the view look like it has the wrong value,
and also makes it hard to pick a relevant value in many cases. To get around this, we need
to somehow get the control to scroll to show the currently set value whenever layout changes.
To achieve this, we'll reset a counter to zero on layout change, count that up a couple times
in order to wait at least 1 frame (we need more than just one iteration to avoid potential
update manager ordering issues). Then, we'll grab the picker's current value and write it
back, tricking the picker to invalidate and scroll where we want it. The downside of this
approach is that _any_ change in layout that causes this view to change size will scroll
the picker view to the currently selected value, but this is a decent tradeoff.

Also refactor some DatePicker interface code to move view polling and
other knowledge into the Android-specific implementation and expose a
root/unroot interface, which is much more general and could be useful
for other things in the future.

Fixes https://github.com/fusetools/ManualTestApp/issues/372.
