### PR TITLE
[Feature] Add navigation methods to WebView for use in FuseJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
  * `IObservable` and `IObservableArray` no longer push their initial value on `Subscribe`.
 
 
+### WebView
+- Exported the methods goBack, goForward, reload and stop for use in FuseJS
+
 # 1.3
 
 ## 1.3.0
@@ -84,8 +87,6 @@
 
 ### WebView
 Fixed issue where custom URI schemes were matched too greedily in URLs, making for erroneously intercepted URL requests.
-
-- Exported the methods goBack, goForward, reload and stop for use in FuseJS
 
 ### Delay Push Notification Registration on iOS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Fixed `RangeControl.RelativeValue` to properly update when bound in UX
 - Allowed `Minimum` to be less than `Maximum` on `RangeControl` making it easier to do left-to-right `100..0` ranges.
 
+### WebView
+- Exported the methods goBack, goForward, reload and stop for use in FuseJS
+
+# 1.2
 ## ScrollViewPager
 - Fixed a NullReferenceError that could happen while using ScrollViewPager in preview
 
@@ -39,9 +43,6 @@
  * The `Fuse.Reactive.IWriteable` interface has changed (breaking!). The method signature is now `bool TrySetExclusive(object)` instead of `void SetExclusive(object)`. Unlikely to affect your code.
  * `IObservable` and `IObservableArray` no longer push their initial value on `Subscribe`.
 
-
-### WebView
-- Exported the methods goBack, goForward, reload and stop for use in FuseJS
 
 # 1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@
 - Fixed `RangeControl.RelativeValue` to properly update when bound in UX
 - Allowed `Minimum` to be less than `Maximum` on `RangeControl` making it easier to do left-to-right `100..0` ranges.
 
-### WebView
+## WebView
 - Exported the methods goBack, goForward, reload and stop for use in FuseJS
 
-# 1.2
 ## ScrollViewPager
 - Fixed a NullReferenceError that could happen while using ScrollViewPager in preview
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
 ### WebView
 Fixed issue where custom URI schemes were matched too greedily in URLs, making for erroneously intercepted URL requests.
 
+- Exported the methods goBack, goForward, reload and stop for use in FuseJS
+
 ### Delay Push Notification Registration on iOS
 
 On iOS you can now put the following in your unoproj file:

--- a/Source/Fuse.Controls.WebView/WebView.ScriptClass.uno
+++ b/Source/Fuse.Controls.WebView/WebView.ScriptClass.uno
@@ -16,6 +16,10 @@ namespace Fuse.Controls
 		{
 			ScriptClass.Register(typeof(WebView),
 				new ScriptMethod<WebView>("goto", setUrl, ExecutionThread.MainThread),
+				new ScriptMethod<WebView>("goBack", goBack, ExecutionThread.MainThread),
+				new ScriptMethod<WebView>("goForward", goForward, ExecutionThread.MainThread),
+				new ScriptMethod<WebView>("reload", reload, ExecutionThread.MainThread),
+				new ScriptMethod<WebView>("stop", stop, ExecutionThread.MainThread),
 				new ScriptMethod<WebView>("loadHtml", loadHtml, ExecutionThread.MainThread),
 				new ScriptMethod<WebView>("setBaseUrl", setBaseUrl, ExecutionThread.MainThread));
 		}
@@ -44,6 +48,47 @@ namespace Fuse.Controls
 					return;
 			}
 
+		}
+
+		/**
+			Go back to the previous page.
+
+			@scriptmethod goBack()
+		*/
+		static void goBack(Context c, WebView view, object[] args)
+		{
+			view.GoBack();
+		}
+
+		/**
+			Go forward to the next page.
+
+			@scriptmethod goForward()
+		*/
+		static void goForward(Context c, WebView view, object[] args)
+		{
+			view.GoForward();
+		}
+
+		/**
+			Reload the current page.
+
+			@scriptmethod reload()
+		*/
+		static void reload(Context c, WebView view, object[] args)
+		{
+			view.Reload();
+		}
+
+
+		/**
+			Stop loading the page.
+
+			@scriptmethod stop()
+		*/
+		static void stop(Context c, WebView view, object[] args)
+		{
+			view.Stop();
 		}
 
 		/**

--- a/Source/Fuse.Controls.WebView/WebView.ScriptClass.uno
+++ b/Source/Fuse.Controls.WebView/WebView.ScriptClass.uno
@@ -57,7 +57,15 @@ namespace Fuse.Controls
 		*/
 		static void goBack(Context c, WebView view, object[] args)
 		{
-			view.GoBack();
+			switch(args.Length)
+			{
+				case 0:
+					view.GoBack();
+					return;
+				default:
+					Fuse.Diagnostics.UserError( "WebView.goBack does not take any arguments", view);
+					return;
+			}
 		}
 
 		/**
@@ -67,7 +75,15 @@ namespace Fuse.Controls
 		*/
 		static void goForward(Context c, WebView view, object[] args)
 		{
-			view.GoForward();
+			switch(args.Length)
+			{
+				case 0:
+					view.GoForward();
+					return;
+				default:
+					Fuse.Diagnostics.UserError( "WebView.goForward does not take any arguments", view);
+					return;
+			}
 		}
 
 		/**
@@ -77,7 +93,15 @@ namespace Fuse.Controls
 		*/
 		static void reload(Context c, WebView view, object[] args)
 		{
-			view.Reload();
+			switch(args.Length)
+			{
+				case 0:
+					view.Reload();
+					return;
+				default:
+					Fuse.Diagnostics.UserError( "WebView.reload does not take any arguments", view);
+					return;
+			}
 		}
 
 
@@ -88,7 +112,15 @@ namespace Fuse.Controls
 		*/
 		static void stop(Context c, WebView view, object[] args)
 		{
-			view.Stop();
+			switch(args.Length)
+			{
+				case 0:
+					view.Stop();
+					return;
+				default:
+					Fuse.Diagnostics.UserError( "WebView.stop does not take any arguments", view);
+					return;
+			}
 		}
 
 		/**


### PR DESCRIPTION
This patch exports four methods of WebViews to allow them to be controlled by FuseJS code. This allows the creation of UI elements or logic to build a mini-webbrowser, which can be sometimes useful in apps.

This PR contains:
- [X] Changelog
- [ ] Documentation
Are the code comments enough?
- [ ] Tests
If needed, some guidance would be appreciated as I'm pretty new to Fuse/Uno development.
