### PR TITLE
hard-code FUSELIBS_NO_TOASTS on

### DIFF
--- a/Source/Fuse.Common/Diagnostics.uno
+++ b/Source/Fuse.Common/Diagnostics.uno
@@ -166,13 +166,10 @@ namespace Fuse
 		*/
 		public static IDisposable ReportTemporal(Diagnostic d)
 		{
-			if defined(FUSELIBS_NO_TOASTS)
-			{
-				if (DiagnosticReported != null)
-					DiagnosticReported(d);
+			if (DiagnosticReported != null)
+				DiagnosticReported(d);
 
-				Uno.Diagnostics.Debug.Log(d.ToString(), d.UnoType);
-			}
+			Uno.Diagnostics.Debug.Log(d.ToString(), d.UnoType);
 
 			return new Temporal(d);
 		}
@@ -182,23 +179,17 @@ namespace Fuse
 		*/
 		public static IDisposable ReportTemporalWarning(Diagnostic d)
 		{
-			if defined(FUSELIBS_NO_TOASTS)
-			{
-				d.IsTemporalWarning = true;
+			d.IsTemporalWarning = true;
 
-				if (DiagnosticReported != null)
-					DiagnosticReported(d);
-			}
+			if (DiagnosticReported != null)
+				DiagnosticReported(d);
 
 			return new Temporal(d);
 		}
 
 		public static IDisposable ReportTemporalUserWarning(string message, object origin)
 		{
-			if defined(FUSELIBS_NO_TOASTS)
-				return ReportTemporalWarning(new Diagnostic(DiagnosticType.UserWarning, message, origin, null, 0, null, null));
-			else
-				return ReportTemporal(new Diagnostic(DiagnosticType.UserWarning, message, origin, null, 0, null, null));
+			return ReportTemporalWarning(new Diagnostic(DiagnosticType.UserWarning, message, origin, null, 0, null, null));
 		}
 
 		/**

--- a/Source/Fuse.Reactive.JavaScript/FunctionMirror.uno
+++ b/Source/Fuse.Reactive.JavaScript/FunctionMirror.uno
@@ -47,10 +47,7 @@ namespace Fuse.Reactive
 				}
 				catch( ScriptException ex )
 				{
-					if defined(FUSELIBS_NO_TOASTS)
-						_f.SetDiagnostic(ex);
-					else
-						JavaScript.UserScriptError( "JavaScript call error", ex, this );
+					_f.SetDiagnostic(ex);
 				}
 			}
 		}

--- a/Source/Fuse.Reactive.JavaScript/JavaScript.uno
+++ b/Source/Fuse.Reactive.JavaScript/JavaScript.uno
@@ -64,15 +64,6 @@ namespace Fuse.Reactive
 			base.OnUnrooted();
 		}
 
-		extern(!FUSELIBS_NO_TOASTS)
-		internal static void UserScriptError(string msg, ScriptException ex, object obj,
-			[CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0,
-			[CallerMemberName] string memberName = "" )
-		{
-			msg = msg + " in " + ex.FileName + " line " + ex.LineNumber;
-			Fuse.Diagnostics.UserError(msg, obj, filePath, lineNumber, memberName, ex);
-		}
-
 		Module IModuleProvider.GetModule()
 		{
 			if (IsRootingCompleted) throw new Exception("Cannot require() a rooted module");

--- a/Source/Fuse.Reactive.JavaScript/ModuleInstance.uno
+++ b/Source/Fuse.Reactive.JavaScript/ModuleInstance.uno
@@ -77,7 +77,6 @@ namespace Fuse.Reactive
 
 		static object _resetHookMutex = new object();
 
-		extern(!FUSELIBS_NO_TOASTS) static string previousErrorFile;
 		DiagnosticSubject _diagnostic = new DiagnosticSubject();
 
 		void EvaluateModule()
@@ -92,32 +91,14 @@ namespace Fuse.Reactive
 				newModuleResult.AddDependency(_js.DispatchEvaluate);
 
 				if (newModuleResult.Error == null)
-				{
 					_moduleResult = newModuleResult;
-					if defined(!FUSELIBS_NO_TOASTS)
-					{
-						if (previousErrorFile == _js.FileName + _js.LineNumber)
-						{
-							Diagnostics.UserSuccess("JavaScript error in " + _js.FileName + " fixed!", this);
-							previousErrorFile = null;
-						}
-					}
-				}
 				else
 				{
 					var se = newModuleResult.Error;
 
 					// Don't report chain-errors of already reported errors
 					if (!se.Message.Contains(ScriptModule.ModuleContainsAnErrorMessage))
-					{
-						if defined(FUSELIBS_NO_TOASTS)
-							_diagnostic.SetDiagnostic(se);
-						else
-						{
-							JavaScript.UserScriptError( "JavaScript error", se, this );
-							previousErrorFile = _js.FileName + _js.LineNumber;
-						}
-					}
+						_diagnostic.SetDiagnostic(se);
 				}
 			}
 		}

--- a/Source/Fuse.Reactive.JavaScript/Observable.uno
+++ b/Source/Fuse.Reactive.JavaScript/Observable.uno
@@ -104,10 +104,7 @@ namespace Fuse.Reactive
 					{
 						//This assumes the Observable.js code is not the source of the error and thus it must be
 						//user code causing the problem
-						if defined(FUSELIBS_NO_TOASTS)
-							DiagnosticSubject.SetDiagnostic(ex);
-						else
-							JavaScript.UserScriptError( "Failed to set Observable value", ex, this );
+						DiagnosticSubject.SetDiagnostic(ex);
 					}
 				}
 			}

--- a/Source/Fuse.Reactive.JavaScript/Tests/UXExpressionsTest.uno
+++ b/Source/Fuse.Reactive.JavaScript/Tests/UXExpressionsTest.uno
@@ -82,37 +82,6 @@ namespace Fuse.Reactive.Test
 				root.StepFrameJS();
 
 				Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
-
-				if defined(FUSELIBS_NO_TOASTS)
-				{
-					using (var dg = new RecordDiagnosticGuard())
-					{
-						var diagnostics = dg.DequeueAll();
-						Assert.AreEqual(0, diagnostics.Count);
-
-						e.CallDec.Perform(); // index = -2 now, so that's = -1 and should give errro
-						root.StepFrameJS();
-
-						Assert.AreEqual("Hello foo : FOO!", e.t1.Value);
-
-						diagnostics = dg.DequeueAll();
-						Assert.AreEqual(1, diagnostics.Count);
-						Assert.IsTrue(diagnostics[0].Message.Contains("Index was outside the bounds of the array"));
-
-						e.CallInc.Perform();
-						root.StepFrameJS();
-
-						diagnostics = dg.DequeueAll();
-						Assert.AreEqual(0, diagnostics.Count);
-
-						e.CallIllegalIndex.Perform(); // index = 'foo', should give error
-						root.StepFrameJS();
-
-						diagnostics = dg.DequeueAll();
-						Assert.AreEqual(1, diagnostics.Count);
-						Assert.IsTrue(diagnostics[0].Message.Contains("Index must be a number"));
-					}
-				}
 			}
 		}
 


### PR DESCRIPTION
FUSELIBS_NO_TOASTS is a blast from the past, when we needed the different
versions of the tool with different error-handling using the same fuselibs
version.

But that need is long gone, and the tool always enables this switch. So
let's get rid of the disabled case, as it just complicates things.