### PR TITLE
Make Invoke take an Action<Scripting.Context>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Scripting.Context
+- Invoke now takes an Action<Scripting.Context>. This is the first step in refactoring our scripting layer to make sure code does not evaluate JS on the wrong thread
+
 ## DesktopApp Updates
 - Fixed an issue about certain event not triggering a proper update and redraw on desktop preview/build
 

--- a/Source/Fuse.Navigation/Router.ScriptClass.uno
+++ b/Source/Fuse.Navigation/Router.ScriptClass.uno
@@ -356,7 +356,8 @@ namespace Fuse.Navigation
 				_callback = callback;
 				_context = context;
 			}
-			public void Run() {
+			public void Run(Scripting.Context context)
+			{
 				_callback.Call(ToArray());
 			}
 			Array ToArray()

--- a/Source/Fuse.Reactive.JavaScript/ClassInstance.uno
+++ b/Source/Fuse.Reactive.JavaScript/ClassInstance.uno
@@ -91,7 +91,7 @@ namespace Fuse.Reactive
 			return op.GetObservable().Object;
 		}
 
-		void Unroot()
+		void Unroot(Scripting.Context context)
 		{
 			if (_self == null) return;
 

--- a/Source/Fuse.Reactive.JavaScript/FunctionMirror.uno
+++ b/Source/Fuse.Reactive.JavaScript/FunctionMirror.uno
@@ -29,7 +29,7 @@ namespace Fuse.Reactive
 				_e = e;
 			}
 
-			public void Call()
+			public void Call(Scripting.Context context)
 			{
 				_f.ClearDiagnostic();
 

--- a/Source/Fuse.Reactive.JavaScript/ModuleInstance.uno
+++ b/Source/Fuse.Reactive.JavaScript/ModuleInstance.uno
@@ -22,7 +22,7 @@ namespace Fuse.Reactive
 		}
 
 		// JS thread
-		void Evaluate()
+		void Evaluate(Scripting.Context context)
 		{
 			var deps = new Dictionary<string, object>();
 			foreach (var key in _deps.Keys)

--- a/Source/Fuse.Reactive.JavaScript/Observable.uno
+++ b/Source/Fuse.Reactive.JavaScript/Observable.uno
@@ -93,7 +93,7 @@ namespace Fuse.Reactive
 				readonly int Origin;
 				readonly DiagnosticSubject DiagnosticSubject;
 
-				public void Perform()
+				public void Perform(Scripting.Context context)
 				{
 					try
 					{
@@ -121,7 +121,7 @@ namespace Fuse.Reactive
 
 				var op = new SetExclusiveOperation(_om._worker, _om.Object, newValue, _origin, this);
 				if (_om._worker.CanEvaluate)
-					op.Perform();
+					op.Perform(null);
 				else
 					_om._worker.Invoke(op.Perform);
 			}
@@ -140,7 +140,7 @@ namespace Fuse.Reactive
 				readonly int Origin;
 
 
-				public void Perform()
+				public void Perform(Scripting.Context context)
 				{
 					Object.CallMethod("replaceAllWithOrigin", NewValue, Origin);
 				}
@@ -154,7 +154,7 @@ namespace Fuse.Reactive
 
 				var op = new ReplaceAllExclusiveOperation(_om.Object, _om._worker.Context.NewArray(arr), _origin);
 				if (_om._worker.CanEvaluate)
-					op.Perform();
+					op.Perform(null);
 				else
 					_om._worker.Invoke(op.Perform);
 			}
@@ -171,7 +171,7 @@ namespace Fuse.Reactive
 				readonly int Origin;
 
 
-				public void Perform()
+				public void Perform(Scripting.Context context)
 				{
 					Object.CallMethod("clear", Origin);
 				}
@@ -181,7 +181,7 @@ namespace Fuse.Reactive
 			{
 				var op = new ClearExclusiveOperation(_om.Object, _origin);
 				if (_om._worker.CanEvaluate)
-					op.Perform();
+					op.Perform(null);
 				else
 					_om._worker.Invoke(op.Perform);
 			}
@@ -320,7 +320,7 @@ namespace Fuse.Reactive
 			}
 		}
 
-		void RemoveSubscriber()
+		void RemoveSubscriber(Scripting.Context context)
 		{
 			_observable.CallMethod("removeSubscriber", _observeChange);
 			_observeChange = null;

--- a/Source/Fuse.Reactive.JavaScript/ObservableProperty.uno
+++ b/Source/Fuse.Reactive.JavaScript/ObservableProperty.uno
@@ -136,7 +136,7 @@ namespace Fuse.Reactive
 				_arg = arg;
 			}
 
-			public void Run()
+			public void Run(Scripting.Context context)
 			{
 				_push(_arg);
 			}

--- a/Source/Fuse.Scripting/Context.uno
+++ b/Source/Fuse.Scripting/Context.uno
@@ -11,6 +11,7 @@ namespace Fuse.Scripting
 	{
 		Function Observable { get; }
 		IDispatcher Dispatcher { get; }
+		void Invoke(Uno.Action<Scripting.Context> action);
 		object Unwrap(object obj);
 		object Wrap(object obj);
 	}
@@ -73,9 +74,9 @@ namespace Fuse.Scripting
 
 		public IDispatcher Dispatcher { get { return _worker.Dispatcher; } }
 
-		public void Invoke(Action action)
+		public void Invoke(Uno.Action<Scripting.Context> action)
 		{
-			_worker.Dispatcher.Invoke(action);
+			_worker.Invoke(action);
 		}
 
 		public Function Observable

--- a/Source/Fuse.Scripting/ModuleResult.uno
+++ b/Source/Fuse.Scripting/ModuleResult.uno
@@ -104,7 +104,7 @@ namespace Fuse.Scripting
 			Context.Invoke(OnDisposed);
 		}
 
-		void OnDisposed()
+		void OnDisposed(Scripting.Context action)
 		{
 			if (Object.ContainsKey("disposed"))
 			{

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -226,7 +226,7 @@ namespace Fuse.Scripting
 				_context.Invoke(DispatchFuture);
 			}
 
-			void DispatchFuture()
+			void DispatchFuture(Scripting.Context action)
 			{
 				_promiseClosure.OnFutureReady(_future);
 			}


### PR DESCRIPTION
This is the start of a run of PRs to make the `Context` only be
accessible from the JS thread. The rest of the codebase will interface
through it via a (soon to be stripped down) `ThreadWorker`.

The way code will get access to the context is by running an action
on the JS thread. To enable this we start by making the `Invoke`
method take an `Action<Scripting.Context>` rather than an `Action`

There are two main evils in this commit:

- In Fuse.Reactive.JavaScript/Observable.uno:L93 we call Perform with
  null. This in temporary as Observable shouldn't be querying if it is
  on the JS thread so this will be removed in a future commit.

- Adding Invoke to `IThreadWorker`. I didn't want to add more to this
  already questionable interface, however ultimately `Invoke` probably
  should be the only method on the interface. The others can be
  removed in a later PR

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
