### PR TITLE
Make Fuse.Elements internals visible to CameraView

### DIFF
--- a/Source/Fuse.Elements/Fuse.Elements.unoproj
+++ b/Source/Fuse.Elements/Fuse.Elements.unoproj
@@ -17,6 +17,7 @@
     "Fuse.Controls.Native",
     "Fuse.Controls.ScrollView",
     "Fuse.Controls.Test",
+    "Fuse.Controls.CameraView",
     "Fuse.Drawing.Surface",
     "Fuse.Effects",
     "Fuse.Elements.Test",


### PR DESCRIPTION
Internals must be visible to CameraView so it can use https://github.com/fusetools/fuselibs-public/pull/597

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
