### PR TITLE
use Color.Parse instead of Color.FromHex

### DIFF
--- a/Source/Fuse.BasicTheme/Basic.Resources.ux.uno
+++ b/Source/Fuse.BasicTheme/Basic.Resources.ux.uno
@@ -40,7 +40,7 @@ namespace Basic
 		{
 			var s = GetColorScheme(scheme);
 			for (int i = 0; i < ColorCodes.Length; i++)
-				control.SetResource(ColorCodes[i], Uno.Color.FromHex(s[i]));				
+				control.SetResource(ColorCodes[i], Uno.Color.Parse(s[i]));
 		}
 
         static string[] GetColorScheme(ColorScheme scheme)

--- a/Source/Fuse.Marshal/Marshal.Cast.uno
+++ b/Source/Fuse.Marshal/Marshal.Cast.uno
@@ -124,7 +124,7 @@ namespace Fuse
 			{
 				var s = (string)o;
 				if (s.StartsWith("#"))
-					return Uno.Color.FromHex(s);
+					return Uno.Color.Parse(s);
 			}
 			else if (o is Size)
 			{
@@ -208,17 +208,13 @@ namespace Fuse
 				var s = (string)o;
 				if (s.StartsWith("#"))
 				{
-					//TODO: once https://github.com/fusetools/uno/pull/1383 is avialble use Color.TryParse instead
-					try
+					if (Uno.Color.TryParse(s, out value))
 					{
-						value = Uno.Color.FromHex(s);
 						size = 4;
 						return true;
 					}
-					catch (ArgumentException ex)
-					{
-						return false;
-					}
+
+					return false;
 				}
 			}
 			else if (o is IArray)

--- a/Source/Fuse.Marshal/Marshal.Parse.uno
+++ b/Source/Fuse.Marshal/Marshal.Parse.uno
@@ -36,7 +36,7 @@ namespace Fuse
 			if (s == "false") return false;
 
 			if (s.Contains("#"))
-				return Uno.Color.FromHex(s);
+				return Uno.Color.Parse(s);
 
 			var unit = Unit.Unspecified;
 			if (s.EndsWith("px"))


### PR DESCRIPTION
Color.FromHex has been marked as obsolete, as it's a bit quirky. Instead, Color.Parse() has been introduced, including a TryParse-variant that doesn't throw exceptions. So let's use these instead, to avoid both obsoletion-warnings, and needless exceptions.