### PR TITLE
Font list parser fix master

### DIFF
--- a/Source/Fuse.Common/Font.uno
+++ b/Source/Fuse.Common/Font.uno
@@ -44,6 +44,12 @@ namespace Fuse
 
 		internal Font(List<FontFaceDescriptor> descriptors)
 		{
+			if (descriptors == null)
+				throw new ArgumentNullException(nameof(descriptors));
+
+			if (descriptors.Count < 1)
+				throw new Exception("font contains no descriptors!");
+
 			Descriptors = descriptors;
 		}
 

--- a/Source/Fuse.Common/Internal/AndroidSystemFont.uno
+++ b/Source/Fuse.Common/Internal/AndroidSystemFont.uno
@@ -117,7 +117,7 @@ namespace Fuse.Internal
 						result.Add(descriptor);
 				}
 			}
-			if (realMatch || style != Fuse.SystemFont.Style.Normal || weight != Fuse.SystemFont.Weight.Normal)
+			if (result.Count > 0 && (realMatch || style != Fuse.SystemFont.Style.Normal || weight != Fuse.SystemFont.Weight.Normal))
 			{
 				return result;
 			}

--- a/Source/Fuse.Common/Internal/AndroidSystemFont.uno
+++ b/Source/Fuse.Common/Internal/AndroidSystemFont.uno
@@ -88,13 +88,7 @@ namespace Fuse.Internal
 		{
 			var result = new List<FontFaceDescriptor>();
 			result.Add(new FontFaceDescriptor(file, 0));
-
-			var normal = Get(null, Fuse.SystemFont.Style.Normal, Fuse.SystemFont.Weight.Normal);
-			if (normal != null)
-			{
-				result.AddRange(normal);
-			}
-
+			result.AddRange(Get(null, Fuse.SystemFont.Style.Normal, Fuse.SystemFont.Weight.Normal));
 			return result;
 		}
 


### PR DESCRIPTION
This just cleans up the font-list parser changes that happened on a release-branch. Shouldn't have any functional effect, apart from making it easier to debug issues like this in the future.