### PR TITLE
Fix TextInput PlaceholderText android drawing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## 1.4.0
 
+### TextInput
+- Fixed issue on android where placeholder text on a `<TextInput IsPassword="true" />` would be drawn as password dots
+
 ### Scripting.Context
 - Invoke now takes an `Action<Scripting.Context>`. This is the first step in refactoring our scripting layer to make sure code does not evaluate JS on the wrong thread
 - The `Observable` property has been removed from Context & IThreadWorker

--- a/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/MobileTextEdit.uno
@@ -314,7 +314,7 @@ namespace Fuse.Controls
 
 			target.setImeOptions(source.getImeOptions());
 			target.setIncludeFontPadding(source.getIncludeFontPadding());
-			target.setTransformationMethod(source.getTransformationMethod());
+			target.setTransformationMethod(isHint ? null : source.getTransformationMethod());
 
 			// Setting the inputtype causes bugs when rendering RTL text,
 			// it triggers the same symptoms as the TextAlignment bug below.

--- a/Tests/ManualTests/ManualTestingApp/Singles/TextInputPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/TextInputPage.ux
@@ -35,7 +35,7 @@
 
 			<h2 ColumnSpan="2">Password text with background color</h2>
 			<Indicator ux:Name="IndPassword"/>
-			<StdTextInput ux:Name="PasswordInput" IsPassword="true" Value="Hidden text"
+			<StdTextInput ux:Name="PasswordInput" IsPassword="true" PlaceholderText="Password"
 				Background="#FFc">
 				<!-- TODO: https://github.com/fusetools/fuselibs/issues/1387
 					Alignment="Right" -->


### PR DESCRIPTION
Fixed issue where the placeholdertext would be drawn with password dots. Since we have to draw placeholder as regular text this would happen since we always set transformationMethod. We should not do that while when drawing the placeholder.

Updated ManualTestingApp to account for this

This PR contains:
- [x] Changelog
- [ ] Documentation
- [x] Tests
