### PR TITLE
Fuse.Controls.Panels: respect Panel.Opacity when rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Fuse.Marshal
 - `ToDouble` replaced with `TryToDouble` for naming consistency (old names remain as deprecated)
 
+## Fuse.Panel
+- Fixed a bug where `IsFrozen` would ignore `Panel.Opacity`.
+
 
 # 1.4
 

--- a/Source/Fuse.Controls.Panels/Panel.Freeze.uno
+++ b/Source/Fuse.Controls.Panels/Panel.Freeze.uno
@@ -198,7 +198,7 @@ namespace Fuse.Controls
 				return;
 			}
 
-			FreezeDrawable.Singleton.Draw(dc, this, 1, Scale, _frozenRenderBounds, _frozenBuffer);
+			FreezeDrawable.Singleton.Draw(dc, this, Opacity, Scale, _frozenRenderBounds, _frozenBuffer);
 		}
 		
 		internal override bool IsLayoutRoot
@@ -226,7 +226,7 @@ namespace Fuse.Controls
 				Texture: buffer.ColorBuffer;
 				Invert: true;
 				
-				PixelColor: float4( prev.XYZ, prev.W * Opacity );
+				PixelColor: prev * Opacity;
 			};
 
 			if defined(FUSELIBS_DEBUG_DRAW_RECTS)

--- a/Source/Fuse.Controls.Panels/Tests/FreezePanel.Test.uno
+++ b/Source/Fuse.Controls.Panels/Tests/FreezePanel.Test.uno
@@ -22,5 +22,33 @@ namespace Fuse.Controls.Panels.Test
 				Assert.IsTrue(p.FP.TestHasFreezePrepared);
 			}
 		}
+
+		[Test]
+		public void FreezeWithOpacity()
+		{
+			var tolerance = 1.0f / 255;
+			var p = new UX.Freeze.Opacity();
+			using (var root = TestRootPanel.CreateWithChild(p, int2(10, 10)))
+			{
+				// make sure we've drawn a frame first
+				p.FreezeMe.IsFrozen = false;
+				root.TestDraw();
+
+				using (var fb = root.CaptureDraw())
+				{
+					fb.AssertPixel(float4(0.5f, 0.5f, 0, 1), int2(5, 5), tolerance);
+				}
+
+				// make sure we've drawn a frame first
+				p.FreezeMe.IsFrozen = true;
+				root.TestDraw();
+
+				using (var fb = root.CaptureDraw())
+				{
+					fb.AssertPixel(float4(0.5f, 0.5f, 0, 1), int2(5, 5), tolerance);
+				}
+			}
+		}
+
 	}
 }

--- a/Source/Fuse.Controls.Panels/Tests/UX/Freeze.Opacity.ux
+++ b/Source/Fuse.Controls.Panels/Tests/UX/Freeze.Opacity.ux
@@ -1,0 +1,3 @@
+<Panel ux:Class="UX.Freeze.Opacity" Color="#f00">
+	<Panel ux:Name="FreezeMe" Color="#0f0" Opacity="0.5" />
+</Panel>


### PR DESCRIPTION
This was discovered during code-inspection.

This PR contains:
- [x] Changelog
- [ ] ~Documentation~ No new feature
- [x] Tests
