### PR TITLE
Fuse.Nodes: complain about null up-front

### DIFF
--- a/Source/Fuse.Nodes/Input/Gesture.uno
+++ b/Source/Fuse.Nodes/Input/Gesture.uno
@@ -354,6 +354,9 @@ namespace Fuse.Input
 		*/
 		static public Gesture Add( IGesture handler, Visual target, GestureType type )
 		{
+			if (handler == null)
+				throw new ArgumentNullException( nameof(handler) );
+
 			if (_gestures.ContainsKey(handler))
 				throw new ArgumentException( "This gesture handler is already registered" );
 				


### PR DESCRIPTION
The code is going to die at a later point if this argument is null,
so let's complain early, so we can find out what's doing this.

This is an old patch that I found useful while debugging, and as
this is public API, I think this could make sense to upstream.