### PR TITLE
Cleanup old issue-references

### DIFF
--- a/Source/Fuse.Controls.ScrollView/Tests/ScrollView.Test.uno
+++ b/Source/Fuse.Controls.ScrollView/Tests/ScrollView.Test.uno
@@ -319,7 +319,6 @@ namespace Fuse.Controls.ScrollViewTest
 		
 		[Test]
 		//UserMode must be maintained regardless of what happens to the scroller
-		//https://github.com/fusetools/fuselibs/pull/3708
 		public void UserMode()
 		{
 			var s = new UX.UserMode();

--- a/Source/Fuse.Elements/Element.HitTest.uno
+++ b/Source/Fuse.Elements/Element.HitTest.uno
@@ -17,8 +17,7 @@ namespace Fuse.Elements
 		LocalBounds = 1<<1,
 		/** Only the cildren of this element will be hit tested. */
 		Children = 1 <<2,
-			
-		//TODO: temporary workaround for https://github.com/fusetools/fuselibs/issues/213
+
 		/** Hit testing will include the appearance of the element and its children. */
 		LocalVisualAndChildren = LocalVisual | Children,
 		/** Hit testing will include the size of the element and its children. */

--- a/Source/Fuse.Nodes/Tests/Pointer.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Pointer.Test.uno
@@ -184,39 +184,6 @@ namespace Fuse.Test
 		}
 
 		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs/issues/229")]
-		public void SoftCaptureForDisabledNode()
-		{
-			using (var root = CreateTestRootPanel())
-			{
-				var setup = SetupEnvironment(root, true);
-
-				Fuse.Input.Pointer.RaisePressed(root, GetDefaultPointerEventData());
-				setup.ChildPanel.IsEnabled = false;
-				Fuse.Input.Pointer.RaiseMoved(root, GetDefaultPointerEventData());
-				Assert.IsTrue(setup.ParentPanel.Captured);
-				Assert.IsTrue(setup.ChildPanel.Captured);
-				Assert.IsFalse(setup.Control.Captured);
-			}
-		}
-
-		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs/issues/229")]
-		public void SoftCaptureForUnrootedNode()
-		{
-			using (var root = CreateTestRootPanel())
-			{
-				var setup = SetupEnvironment(root, true);
-				Fuse.Input.Pointer.RaisePressed(root, GetDefaultPointerEventData());
-				setup.ChildPanel.Children.Remove(setup.Control);
-				Fuse.Input.Pointer.RaiseMoved(root, GetDefaultPointerEventData());
-				Assert.IsTrue(setup.ParentPanel.Captured);
-				Assert.IsTrue(setup.ChildPanel.Captured);
-				Assert.IsFalse(setup.Control.Captured);
-			}
-		}
-
-		[Test]
 		public void PointerEnterLeave()
 		{
 			using (var root = CreateTestRootPanel())

--- a/Tests/ManualTests/ManualTestingApp/UserEvents/PopupNotices.ux
+++ b/Tests/ManualTests/ManualTestingApp/UserEvents/PopupNotices.ux
@@ -20,10 +20,7 @@
 		</Rectangle>
 		<ChattyLabel Value="{messageText}" TextWrapping="Wrap" TextAlignment="Center"/>
 	</Panel>
-	
-	<!-- if we have UX level event bindings the JS part would not be needed 
-		https://github.com/fusetools/fuselibs/issues/619
-	-->
+
 	<OnUserEvent EventName="Chatty.ContactDeleted" Handler="{contactDeleted}" Filter="Global">
 		<Change Warning.Opacity="1" Duration="0.1" DelayBack="2"/>
 	</OnUserEvent>


### PR DESCRIPTION
These issues are ancient, and there's no longer any point in talking about them. As for the soft-capture tests, the behavior changed so long ago that it should now just be accepted as what we do.