### PR TITLE
fixes PageControl.ActiveIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # 1.3
 
+## 1.3.1
+
+### Navigation
+- Fixed an issue where `PageControl.ActiveIndex` would not update if navigation done with JavaScript `seekToPath` or `Router` interfaces.
+
 ## 1.3.0
 
 ### Native UI:

--- a/Source/Fuse.Controls.Navigation/PageControl.uno
+++ b/Source/Fuse.Controls.Navigation/PageControl.uno
@@ -398,7 +398,7 @@ namespace Fuse.Controls
 			
 			This can used to get and set the current page from JavaScript as well as listen to page changes. When used in conjunction with an `Each` to create dynamic pages the `ActiveIndex` is an index into that list of items (assuming no other children are added).
 			
-			@see VisualNavigation.ActiveIndex
+			@see VisualNavigation.DesiredActiveIndex
 		*/
 		public int ActiveIndex
 		{

--- a/Source/Fuse.Controls.Navigation/Tests/PageControl.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/PageControl.Test.uno
@@ -10,7 +10,7 @@ namespace Fuse.Controls.Test
 	public class PageControlTest : TestBase
 	{
 		[Test]
-		public void ActiveIndex()
+		public void ActiveIndexBasic()
 		{
 			var p = new UX.PageControl.PageIndex();
 			using (var root = TestRootPanel.CreateWithChild(p, int2(100)))
@@ -32,6 +32,20 @@ namespace Fuse.Controls.Test
 				Assert.AreEqual( "Page2", p.R.Value );
 
 				p.PC.Active = p.D;
+				root.StepFrameJS();
+				Assert.AreEqual( 3, p.PC.ActiveIndex );
+				Assert.AreEqual( p.D, p.PC.Active );
+				Assert.AreEqual( "3", p.Q.Value );
+				Assert.AreEqual( "Page3", p.R.Value );
+
+				p.Seek1.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( 1, p.PC.ActiveIndex );
+				Assert.AreEqual( p.B, p.PC.Active );
+				Assert.AreEqual( "1", p.Q.Value );
+				Assert.AreEqual( "Page1", p.R.Value );
+				
+				p.RouteGoto4.Pulse();
 				root.StepFrameJS();
 				Assert.AreEqual( 3, p.PC.ActiveIndex );
 				Assert.AreEqual( p.D, p.PC.Active );

--- a/Source/Fuse.Controls.Navigation/Tests/UX/PageControl.PageIndex.ux
+++ b/Source/Fuse.Controls.Navigation/Tests/UX/PageControl.PageIndex.ux
@@ -1,4 +1,5 @@
 <Panel ux:Class="UX.PageControl.PageIndex">
+	<Router IsMasterRouter="false"/>
 	<JavaScript>
 		var Observable = require("FuseJS/Observable");
 		var tabList = Observable();
@@ -12,6 +13,7 @@
 		exports.goto0 = function() { exports.pageIndex.value = 0 }
 		exports.goto2 = function() { exports.pageIndex.value = 2 }
 		exports.goto4 = function() { exports.pageIndex.value = 4 }
+		exports.seek1 = function() { PC.seekToPath( "B" ) }
 	</JavaScript>
 	
 	<PageControl ActiveIndex="{pageIndex}" ClipToBounds="true" ux:Name="PC">
@@ -27,5 +29,8 @@
 	
 	<FuseTest.Invoke Handler="{goto0}" ux:Name="Goto0"/>
 	<FuseTest.Invoke Handler="{goto2}" ux:Name="Goto2"/>
-	<FuseTest.Invoke Handler="{goto4}" ux:Name="Goto4"/>
+	<FuseTest.Invoke Handler="{seek1}" ux:Name="Seek1"/>
+	<Timeline ux:Name="RouteGoto4">
+		<GotoRoute Path=" 'D' "/>
+	</Timeline>
 </Panel>

--- a/Source/Fuse.Navigation/DynamicLinearNavigation.uno
+++ b/Source/Fuse.Navigation/DynamicLinearNavigation.uno
@@ -130,13 +130,24 @@ namespace Fuse.Navigation
 			get { return Progress; }
 		}
 
+		/*
+			External goto is a "desired" requres, and thus updates the desired mode.
+		*/
 		public override void Goto(Visual element, NavigationGotoMode mode)
 		{
 			if (mode != NavigationGotoMode.Transition &&
 				mode != NavigationGotoMode.Bypass)
 				return;
 		
-			_desiredActive = element;
+			UpdateDesired(element, -1);
+			GotoInternal(element, mode);
+		}
+		
+		/*
+			Internal goto does not update the desired mode. It should be used by anything internally that needs a Goto but does not reflect a user desired change.
+		*/
+		void GotoInternal(Visual element, NavigationGotoMode mode)
+		{
 			if (!IsRootingCompleted)
 			{
 				//queue until rooted
@@ -407,14 +418,14 @@ namespace Fuse.Navigation
 		{
 			UpdateDesired(page, -1);
 			_desired = Desired.Active;
-			Goto(page, NavigationGotoMode.Transition);
+			GotoInternal(page, NavigationGotoMode.Transition);
 		}
 		
 		void SetDesiredActiveIndex( int index )
 		{
 			UpdateDesired( null, index );
 			_desired = Desired.Index;
-			Goto( _desiredActive, NavigationGotoMode.Transition );
+			GotoInternal( _desiredActive, NavigationGotoMode.Transition );
 		}
 		
 		void DirectSetActive(Visual page)


### PR DESCRIPTION
fixes https://github.com/fusetools/fuselibs-public/issues/614

@kusma This fixes a regression in 1.3, so at the very least it should be in 1.4, or if there is planned 1.3 release then there.

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [x] Tests
