### PR TITLE
IMirror.Reflect now takes a Scripting.Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@
 ## Fuse.Panel
 - Fixed a bug where `IsFrozen` would ignore `Panel.Opacity`.
 
+## Scripting
+- Invoke now takes an Action<Scripting.Context>. This is the first step in refactoring our scripting layer to make sure code does not evaluate JS on the wrong thread
+- The `Observable` property has been removed from Context & IThreadWorker
+- `Fuse.Scripting`'s `Function` type has a `Call` method, this now takes a `Scripting.Context`. This guarentees that it can only occur on the VM thread.
+- IMirror is no longer implemented by ThreadWorker. This functionality has been moved to the context
+- Moved `ArrayMirror`, `ClassInstance`, `ModuleInstance`, `ObjectMirror`, `Observable`, `ObservableProperty`, `RootableScriptModule` & `ThreadWorker` to the `Fuse.Scripting.JavaScript` namespace
+- Removed the `CanEvaluate` method and instead rely on the passing of the `Scripting.Context` to know if we are on the VM thread or not. This required adding some methods to the `ISubscription` which take the `Scripting.Context`
+- The 'wrapping' functionality has been moved from the `ThreadWorker` to a standalone static class called `TypeWrapper`. The `IThreadWorker` no longer provides `Wrap` & `UnWrap`
+- `ThreadWorker.ScriptClass` functionality moved to context. We will likely want to factor this out to a helper class however for now the major benefit is that `ThreadWorker` no longer owns these features.
+- Remove the public `Context` property from the `ThreadWorker`. Sadly the context is still available via the internal field so that the tests can work. This will need to be fixed.
+- `Fuse.Reactive` now depends on `Fuse.Scripting` so that it can talk about the `Scripting.Context` in it's provided interfaces.
+- `DateTimeConverterHelpers` moved to its own uno file.
+- `IMirror`'s `Reflect` now takes a `Scripting.Context`
 
 # 1.4
 
@@ -25,19 +38,7 @@
 - The `Observable` property has been removed from Context & IThreadWorker
 
 ### Fuse.Reactive.JavaScript
-## Scripting
-- Invoke now takes an Action<Scripting.Context>. This is the first step in refactoring our scripting layer to make sure code does not evaluate JS on the wrong thread
-- The `Observable` property has been removed from Context & IThreadWorker
 - Fuse.Reactive.JavaScript has been renamed to Fuse.Scripting.JavaScript & the separate VM packages are now subdirectories of this package
-- `Fuse.Scripting`'s `Function` type has a `Call` method, this now takes a `Scripting.Context`. This guarentees that it can only occur on the VM thread.
-- IMirror is no longer implemented by ThreadWorker. This functionality has been moved to the context
-- Moved `ArrayMirror`, `ClassInstance`, `ModuleInstance`, `ObjectMirror`, `Observable`, `ObservableProperty`, `RootableScriptModule` & `ThreadWorker` to the `Fuse.Scripting.JavaScript` namespace
-- Removed the `CanEvaluate` method and instead rely on the passing of the `Scripting.Context` to know if we are on the VM thread or not. This required adding some methods to the `ISubscription` which take the `Scripting.Context`
-- The 'wrapping' functionality has been moved from the `ThreadWorker` to a standalone static class called `TypeWrapper`. The `IThreadWorker` no longer provides `Wrap` & `UnWrap`
-- `ThreadWorker.ScriptClass` functionality moved to context. We will likely want to factor this out to a helper class however for now the major benefit is that `ThreadWorker` no longer owns these features.
-- Remove the public `Context` property from the `ThreadWorker`. Sadly the context is still available via the internal field so that the tests can work. This will need to be fixed.
-- `Fuse.Reactive` now depends on `Fuse.Scripting` so that it can talk about the `Scripting.Context` in it's provided interfaces.
-- `DateTimeConverterHelpers` moved to its own uno file.
 
 ### DesktopApp Updates
 - Fixed an issue about certain event not triggering a proper update and redraw on desktop preview/build

--- a/Source/Fuse.Scripting.JavaScript/ArrayMirror.uno
+++ b/Source/Fuse.Scripting.JavaScript/ArrayMirror.uno
@@ -10,16 +10,16 @@ namespace Fuse.Scripting.JavaScript
 		/** Does not poulate the _props. This allows calling Set later with mirror == this */
 		protected ArrayMirror(Scripting.Array obj) : base(obj) {}
 
-		internal ArrayMirror(IMirror mirror, Scripting.Array arr): base(arr)
+		internal ArrayMirror(Scripting.Context context, IMirror mirror, Scripting.Array arr): base(arr)
 		{
-			Set(mirror, arr);
+			Set(context, mirror, arr);
 		}
 
-		internal void Set(IMirror mirror, Scripting.Array arr)
+		internal void Set(Scripting.Context context, IMirror mirror, Scripting.Array arr)
 		{
 			_items = new List<object>(arr.Length);
 			for (int i = 0; i < arr.Length; i++) {
-				_items.Add(mirror.Reflect(arr[i]));
+				_items.Add(mirror.Reflect(context, arr[i]));
 			}
 		}
 

--- a/Source/Fuse.Scripting.JavaScript/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/Context.uno
@@ -48,7 +48,7 @@ namespace Fuse.Scripting.JavaScript
 			return TypeWrapper.Unwrap(this, obj);
 		}
 
-		public object Reflect(object obj)
+		public object Reflect(Scripting.Context context, object obj)
 		{
 			var e = obj as Scripting.External;
 			if (e != null) return e.Object;
@@ -83,7 +83,7 @@ namespace Fuse.Scripting.JavaScript
 			var a = obj as Scripting.Array;
 			if (a != null)
 			{
-				return new ArrayMirror(this, a);
+				return new ArrayMirror(this, this, a);
 			}
 
 			var f = obj as Scripting.Function;
@@ -109,7 +109,7 @@ namespace Fuse.Scripting.JavaScript
 				}
 				else
 				{
-					return new ObjectMirror(this, o);
+					return new ObjectMirror(this, this, o);
 				}
 			}
 

--- a/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
+++ b/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
@@ -41,7 +41,7 @@ namespace Fuse.Scripting.JavaScript
 			}
 
 			_js.ScriptModule.Dependencies = deps;
-			_dc = ctx.Reflect(EvaluateExports(ctx));
+			_dc = ctx.Reflect(context, EvaluateExports(ctx));
 			UpdateManager.PostAction(SetDataContext);
 		}
 

--- a/Source/Fuse.Scripting.JavaScript/ObjectMirror.uno
+++ b/Source/Fuse.Scripting.JavaScript/ObjectMirror.uno
@@ -10,19 +10,19 @@ namespace Fuse.Scripting.JavaScript
 		/** Does not poulate the _props. This allows calling Set later with mirror == this */
 		protected ObjectMirror(Scripting.Object obj) : base(obj) {}
 
-		internal ObjectMirror(IMirror mirror, Scripting.Object obj): base(obj)
+		internal ObjectMirror(Scripting.Context context, IMirror mirror, Scripting.Object obj): base(obj)
 		{
-			Set(mirror, obj);
+			Set(context, mirror, obj);
 		}
 
-		internal virtual void Set(IMirror mirror, Scripting.Object obj)
+		internal virtual void Set(Scripting.Context context, IMirror mirror, Scripting.Object obj)
 		{
 			_props.Clear();
 			var k = obj.Keys;
 			for (int i = 0; i < k.Length; i++)
 			{
 				var s = k[i];
-				_props.Add(s, mirror.Reflect(obj[s]));
+				_props.Add(s, mirror.Reflect(context, obj[s]));
 			}
 		}
 

--- a/Source/Fuse.Scripting.JavaScript/Observable.uno
+++ b/Source/Fuse.Scripting.JavaScript/Observable.uno
@@ -278,7 +278,7 @@ namespace Fuse.Scripting.JavaScript
 
 			if (op == "set")
 			{
-				UpdateManager.PostAction(new Set(this, ctx.Reflect(args[3]), origin).Perform);
+				UpdateManager.PostAction(new Set(this, ctx.Reflect(context, args[3]), origin).Perform);
 			}
 			else if (op == "clear") 
 			{
@@ -286,15 +286,15 @@ namespace Fuse.Scripting.JavaScript
 			}
 			else if (op == "newAt")
 			{
-				UpdateManager.PostAction(new NewAt(this, ToInt(args[3]), ctx.Reflect(args[4])).Perform);
+				UpdateManager.PostAction(new NewAt(this, ToInt(args[3]), ctx.Reflect(context, args[4])).Perform);
 			}
 			else if (op == "newAll") 
 			{
-				UpdateManager.PostAction(new NewAll(this, (ArrayMirror)ctx.Reflect(args[3]), origin).Perform);
+				UpdateManager.PostAction(new NewAll(this, (ArrayMirror)ctx.Reflect(context, args[3]), origin).Perform);
 			}
 			else if (op == "add") 
 			{
-				UpdateManager.PostAction(new Add(this, ctx.Reflect(args[3])).Perform);
+				UpdateManager.PostAction(new Add(this, ctx.Reflect(context, args[3])).Perform);
 			}
 			else if (op == "removeAt")
 			{
@@ -302,7 +302,7 @@ namespace Fuse.Scripting.JavaScript
 			}
 			else if (op == "insertAt")
 			{
-				UpdateManager.PostAction(new InsertAt(this, ToInt(args[3]), ctx.Reflect(args[4])).Perform);
+				UpdateManager.PostAction(new InsertAt(this, ToInt(args[3]), ctx.Reflect(context, args[4])).Perform);
 			}
 			else if (op == "removeRange")
 			{
@@ -310,7 +310,7 @@ namespace Fuse.Scripting.JavaScript
 			}
 			else if (op == "insertAll") 
 			{
-				UpdateManager.PostAction(new InsertAll(this, ToInt(args[3]), (ArrayMirror)ctx.Reflect(args[4])).Perform);
+				UpdateManager.PostAction(new InsertAll(this, ToInt(args[3]), (ArrayMirror)ctx.Reflect(context, args[4])).Perform);
 			}
 			else if (op == "failed")
 			{

--- a/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
@@ -9,7 +9,7 @@ namespace Fuse.Scripting.JavaScript
 {
 	interface IMirror
 	{
-		object Reflect(object obj);
+		object Reflect(Scripting.Context context, object obj);
 	}
 
 	class ThreadWorker: IDisposable, IDispatcher, IThreadWorker

--- a/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeObject.uno
+++ b/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeObject.uno
@@ -78,7 +78,7 @@ namespace Fuse.Scripting.JavaScript
 			}
 		}
 
-		internal override void Set(IMirror mirror, Scripting.Object obj)
+		internal override void Set(Scripting.Context context, IMirror mirror, Scripting.Object obj)
 		{
 			_props.Clear();
 			var k = obj.Keys;
@@ -90,7 +90,7 @@ namespace Fuse.Scripting.JavaScript
 					_rawOverride = obj[s];
 					continue;
 				}
-				_props.Add(s, mirror.Reflect(obj[s]));
+				_props.Add(s, mirror.Reflect(context, obj[s]));
 			}
 
 			var sub = Subscribers as PropertySubscription;


### PR DESCRIPTION
As with our other commits in this area this seeks to make the
Scripting functionality more robust through the use of Scripting.Context.

This commit is interesting in that by updating the code we find an
exact place where the JS context is used incorrectly. Fixing this does
not belong in this commit but this should provide a sane place to
begin.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
