### PR TITLE
CallMethod now takes a Scripting.Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Invoke now takes an Action<Scripting.Context>. This is the first step in refactoring our scripting layer to make sure code does not evaluate JS on the wrong thread
 - The `Observable` property has been removed from Context & IThreadWorker
 - `Fuse.Scripting`'s `Function` type has a `Call` method, this now takes a `Scripting.Context`. This guarentees that it can only occur on the VM thread.
+- `Fuse.Scripting`'s `Object` type has a `CallMethod` method, this now takes a `Scripting.Context`. This guarentees that it can only occur on the VM thread.
 - IMirror is no longer implemented by ThreadWorker. This functionality has been moved to the context
 - Moved `ArrayMirror`, `ClassInstance`, `ModuleInstance`, `ObjectMirror`, `Observable`, `ObservableProperty`, `RootableScriptModule` & `ThreadWorker` to the `Fuse.Scripting.JavaScript` namespace
 - Removed the `CanEvaluate` method and instead rely on the passing of the `Scripting.Context` to know if we are on the VM thread or not. This required adding some methods to the `ISubscription` which take the `Scripting.Context`
@@ -25,6 +26,7 @@
 - `Fuse.Reactive` now depends on `Fuse.Scripting` so that it can talk about the `Scripting.Context` in it's provided interfaces.
 - `DateTimeConverterHelpers` moved to its own uno file.
 - `IMirror`'s `Reflect` now takes a `Scripting.Context`
+
 
 # 1.4
 

--- a/Source/Fuse.Scripting.JavaScript/ClassInstance.uno
+++ b/Source/Fuse.Scripting.JavaScript/ClassInstance.uno
@@ -34,11 +34,11 @@ namespace Fuse.Scripting.JavaScript
 		}
 
 		/** Calls a function on this node instance, making the node 'this' within the function */
-		public void CallMethod(Scripting.Function method, object[] args)
+		public void CallMethod(Scripting.Context context, Scripting.Function method, object[] args)
 		{
 			// TODO: Rewrite to use Function.apply() to avoid leaking this member
 			_self["_tempMethod"] = method;
-			_self.CallMethod("_tempMethod", args);
+			_self.CallMethod(context, "_tempMethod", args);
 		}
 
 		/** Called on JS thread when the node instance must be rooted. */

--- a/Source/Fuse.Scripting.JavaScript/DateTimeConverterHelpers.uno
+++ b/Source/Fuse.Scripting.JavaScript/DateTimeConverterHelpers.uno
@@ -15,7 +15,7 @@ namespace Fuse.Scripting.JavaScript
 
 		public static DateTime ConvertDateToDateTime(Scripting.Context context, Scripting.Object date)
 		{
-			var jsTicks = (long)(double)context.Wrap(date.CallMethod("getTime"));
+			var jsTicks = (long)(double)context.Wrap(date.CallMethod(context, "getTime"));
 			var dotNetTicksRelativeToUnixEpoch = jsTicks * DotNetTicksInJsTick;
 			var dotNetTicks = dotNetTicksRelativeToUnixEpoch + UnixEpochInDotNetTicks;
 

--- a/Source/Fuse.Scripting.JavaScript/Duktape/Object.uno
+++ b/Source/Fuse.Scripting.JavaScript/Duktape/Object.uno
@@ -88,7 +88,7 @@ namespace Fuse.Scripting.Duktape
 			}
 		}
 
-		public override object CallMethod(string name, params object[] args)
+		public override object CallMethod(Scripting.Context context, string name, params object[] args)
 		{
 			if (name == null) throw new ArgumentNullException(nameof(name));
 			var index = _ctx.DukContext.push_heapptr(_handle);

--- a/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Object.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Object.uno
@@ -68,19 +68,20 @@ namespace Fuse.Scripting.JavaScriptCore
 					_context._onError);
 		}
 
-		public override object CallMethod(string name, params object[] args)
+		public override object CallMethod(Scripting.Context context, string name, params object[] args)
 		{
+			var ctx = (Context)context;
 			if (name == null) throw new ArgumentException("Object.CallMethod.name");
 			var f = _value.GetProperty(
-				_context._context,
+				ctx._context,
 				name,
-				_context._onError).GetJSObjectRef(_context._context);
-			return _context.Wrap(
+				ctx._onError).GetJSObjectRef(ctx._context);
+			return ctx.Wrap(
 				f.CallAsFunction(
-					_context._context,
+					ctx._context,
 					_value,
-					_context.Unwrap(args),
-					_context._onError));
+					ctx.Unwrap(args),
+					ctx._onError));
 		}
 
 		public override bool ContainsKey(string key)

--- a/Source/Fuse.Scripting.JavaScript/Observable.uno
+++ b/Source/Fuse.Scripting.JavaScript/Observable.uno
@@ -98,7 +98,7 @@ namespace Fuse.Scripting.JavaScript
 					try
 					{
 						var newValue = context.Unwrap(NewValue);
-						Object.CallMethod("setValueWithOrigin", newValue, Origin);
+						Object.CallMethod(context, "setValueWithOrigin", newValue, Origin);
 					}
 					catch (Scripting.ScriptException ex)
 					{
@@ -158,7 +158,7 @@ namespace Fuse.Scripting.JavaScript
 					for (int i = 0; i < NewValues.Length; i++)
 						NewValues[i] = context.Unwrap(NewValues[i]);
 
-					Object.CallMethod("replaceAllWithOrigin", context.NewArray(NewValues), Origin);
+					Object.CallMethod(context, "replaceAllWithOrigin", context.NewArray(NewValues), Origin);
 				}
 			}
 
@@ -196,7 +196,7 @@ namespace Fuse.Scripting.JavaScript
 
 				public void Perform(Scripting.Context context)
 				{
-					Object.CallMethod("clear", Origin);
+					Object.CallMethod(context, "clear", Origin);
 				}
 			}
 
@@ -252,7 +252,7 @@ namespace Fuse.Scripting.JavaScript
 			_worker = worker;
 			_observable = obj;
 			_observeChange = context.CallbackToFunction((Scripting.Callback)ObserveChange);
-			obj.CallMethod("addSubscriber", _observeChange, suppressCallback);
+			obj.CallMethod(context, "addSubscriber", _observeChange, suppressCallback);
 		}
 
 		internal static Observable Create(Scripting.Context context, ThreadWorker worker)
@@ -350,7 +350,7 @@ namespace Fuse.Scripting.JavaScript
 
 		void RemoveSubscriber(Scripting.Context context)
 		{
-			_observable.CallMethod("removeSubscriber", _observeChange);
+			_observable.CallMethod(context, "removeSubscriber", _observeChange);
 			_observeChange = null;
 			_observable = null;
 		}

--- a/Source/Fuse.Scripting.JavaScript/RootableScriptModule.uno
+++ b/Source/Fuse.Scripting.JavaScript/RootableScriptModule.uno
@@ -53,7 +53,7 @@ namespace Fuse.Scripting.JavaScript
 
 		protected override void CallModuleFunc(Context context, Function moduleFunc, object[] args)
 		{
-			_classInstance.CallMethod(moduleFunc, args);
+			_classInstance.CallMethod(context, moduleFunc, args);
 		}
 	}
 }

--- a/Source/Fuse.Scripting.JavaScript/V8/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/V8/Context.uno
@@ -93,7 +93,7 @@ namespace Fuse.Scripting.V8
 			var jsExceptionObj = Marshaller.Wrap(this, jsException) as Object;
 			if (jsExceptionObj != null)
 			{
-				exceptionName = jsExceptionObj.CallMethod("toString") as string;
+				exceptionName = jsExceptionObj.CallMethod(this, "toString") as string;
 			}
 
 			var se = new ScriptException(

--- a/Source/Fuse.Scripting.JavaScript/V8/Object.uno
+++ b/Source/Fuse.Scripting.JavaScript/V8/Object.uno
@@ -85,7 +85,7 @@ namespace Fuse.Scripting.V8
 			return (bool)_context._instanceOf.Call(_context, this, type);
 		}
 
-		public override object CallMethod(string name, params object[] args)
+		public override object CallMethod(Scripting.Context context, string name, params object[] args)
 		{
 			var cxt = _context._context;
 			object result = null;

--- a/Source/Fuse.Scripting/NativeEventEmitterModule.uno
+++ b/Source/Fuse.Scripting/NativeEventEmitterModule.uno
@@ -39,12 +39,12 @@ namespace Fuse.Scripting
 			}
 
 			if (_context != null)
-				_context.Dispatcher.Invoke(ResetListenersJS);
+				_context.ThreadWorker.Invoke(ResetListenersJS);
 		}
 
-		void ResetListenersJS()
+		void ResetListenersJS(Scripting.Context context)
 		{
-			_this.CallMethod("removeAllListeners");
+			_this.CallMethod(context, "removeAllListeners");
 			// Reconnect any callbacks set from native code
 			lock (_mutex)
 				foreach (var l in _listeningCallbacks)
@@ -171,7 +171,7 @@ namespace Fuse.Scripting
 
 			public void Emit(Context c, Scripting.Object o)
 			{
-				o.CallMethod("emit", _args);
+				o.CallMethod(c, "emit", _args);
 			}
 		}
 
@@ -186,7 +186,7 @@ namespace Fuse.Scripting
 
 			public void Emit(Context c, Scripting.Object o)
 			{
-				o.CallMethod("emit", _argsFactory(c));
+				o.CallMethod(c, "emit", _argsFactory(c));
 			}
 		}
 
@@ -203,7 +203,7 @@ namespace Fuse.Scripting
 
 			public void Emit(Context c, Scripting.Object o)
 			{
-				o.CallMethod("emit", _argsFactory(c, _t));
+				o.CallMethod(c, "emit", _argsFactory(c, _t));
 			}
 		}
 
@@ -220,7 +220,7 @@ namespace Fuse.Scripting
 
 			public void On(Context c, Scripting.Object o)
 			{
-				o.CallMethod("on", _eventName, _listener);
+				o.CallMethod(c, "on", _eventName, _listener);
 			}
 		}
 	}

--- a/Source/Fuse.Scripting/Types.uno
+++ b/Source/Fuse.Scripting/Types.uno
@@ -35,7 +35,7 @@ namespace Fuse.Scripting
 		public abstract object this[string key] { get; set; }
 		public abstract string[] Keys { get; }
 		public abstract bool InstanceOf(Function type);
-		public abstract object CallMethod(string name, params object[] args);
+		public abstract object CallMethod(Context context, string name, params object[] args);
 		public abstract bool ContainsKey(string key);
 		public abstract bool Equals(Object o);
 


### PR DESCRIPTION
This makes `CallMethod` have the same guarantees as `Function.Call`

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
