### PR TITLE
Feature/remove dispatcher from ithreadworker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - `Fuse.Reactive` now depends on `Fuse.Scripting` so that it can talk about the `Scripting.Context` in it's provided interfaces.
 - `DateTimeConverterHelpers` moved to its own uno file.
 - `IMirror`'s `Reflect` now takes a `Scripting.Context`
-
+- IThreadWorker no longer implement IDispatcher
 
 # 1.4
 

--- a/Source/Fuse.Navigation/Router.ScriptClass.uno
+++ b/Source/Fuse.Navigation/Router.ScriptClass.uno
@@ -343,32 +343,32 @@ namespace Fuse.Navigation
 			}
 
 			var route = r.GetCurrentRoute();
-			c.Invoke(new GetRouteCallback(route, callback, c).Run);
+			c.Invoke(new GetRouteCallback(route, callback).Run);
 		}
 		class GetRouteCallback
 		{
 			readonly Route _route;
 			readonly Function _callback;
-			readonly Context _context;
-			public GetRouteCallback(Route route, Function callback, Context context)
+			public GetRouteCallback(Route route, Function callback)
 			{
 				_route = route;
 				_callback = callback;
-				_context = context;
 			}
+
 			public void Run(Scripting.Context context)
 			{
-				_callback.Call(context, ToArray());
+				_callback.Call(context, ToArray(context));
 			}
-			Array ToArray()
+
+			Array ToArray(Scripting.Context context)
 			{
 				var route = _route;
 				var len = route.Length;
-				var arr = _context.NewArray(len*2);
+				var arr = context.NewArray(len*2);
 				for (int i = 0; i < len; i++)
 				{
 					arr[i*2+0] = route.Path;
-					arr[i*2+1] = _context.ParseJson(route.Parameter);
+					arr[i*2+1] = context.ParseJson(route.Parameter);
 					route = route.SubRoute;
 				}
 				return arr;

--- a/Source/Fuse.Nodes/Node.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Node.ScriptClass.uno
@@ -72,12 +72,12 @@ namespace Fuse
 			protected override void Resolve(IObject provider, object data)
 			{
 				_data = data;
-				_context.Dispatcher.Invoke(Update);
+				_context.ThreadWorker.Invoke(Update);
 			}
 
-			void Update()
+			void Update(Scripting.Context context)
 			{
-				_updateCallback.Call(_context, _context.Unwrap(_data));
+				_updateCallback.Call(context, context.Unwrap(_data));
 			}
 		}
 	}

--- a/Source/Fuse.Scripting.JavaScript/FuseJS/Http.uno
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/Http.uno
@@ -52,6 +52,25 @@ namespace Fuse.Reactive.FuseJS
 			}
 		}
 
+		class HttpJSDispatcher : Uno.Threading.IDispatcher
+		{
+			Scripting.IThreadWorker _worker;
+			public HttpJSDispatcher(Scripting.IThreadWorker worker)
+			{
+				_worker = worker;
+			}
+
+			public void Invoke(Action action)
+			{
+				_worker.Invoke<Action>(DoIt, action);
+			}
+
+			public void DoIt(Scripting.Context context, Action action)
+			{
+				action();
+			}
+		}
+
 		class FuseJSHttpClient
 		{
 			public Scripting.Object Obj { get; private set; }
@@ -72,8 +91,9 @@ namespace Fuse.Reactive.FuseJS
 			{
 				var method = args[0] as string;
 				var url = args[1] as string;
-
-				return new FuseJSHttpRequest(_context, _client.CreateRequest(method, url, _context.Dispatcher)).Obj;
+				var dispatcher = new HttpJSDispatcher(_context.ThreadWorker);
+				
+				return new FuseJSHttpRequest(_context, _client.CreateRequest(method, url, dispatcher)).Obj;
 			}
 		}
 

--- a/Source/Fuse.Scripting.JavaScript/FuseJS/Http.uno
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/Http.uno
@@ -92,7 +92,7 @@ namespace Fuse.Reactive.FuseJS
 				var method = args[0] as string;
 				var url = args[1] as string;
 				var dispatcher = new HttpJSDispatcher(_context.ThreadWorker);
-				
+
 				return new FuseJSHttpRequest(_context, _client.CreateRequest(method, url, dispatcher)).Obj;
 			}
 		}

--- a/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
@@ -12,9 +12,8 @@ namespace Fuse.Scripting.JavaScript
 		object Reflect(Scripting.Context context, object obj);
 	}
 
-	class ThreadWorker: IDisposable, IDispatcher, IThreadWorker
+	class ThreadWorker: IDisposable, IThreadWorker
 	{
-		IDispatcher IThreadWorker.Dispatcher { get { return this; } }
 		public Function Observable { get { return FuseJS.Observable; } }
 
 		internal JSContext _context;

--- a/Source/Fuse.Scripting.JavaScript/V8/Debugger.uno
+++ b/Source/Fuse.Scripting.JavaScript/V8/Debugger.uno
@@ -298,7 +298,7 @@ namespace Fuse.Scripting.V8
 							var message = new String(buffer);
 							var cxt = _parent._context._context;
 							Simple.Debug.SendCommand(cxt, message, message.Length);
-							_parent._context.Dispatcher.Invoke1(Simple.Debug.ProcessMessages, cxt);
+							_parent._context.ThreadWorker.Invoke<Simple.JSContext>(ProcessMessages, cxt);
 						}
 					}
 					else
@@ -318,6 +318,11 @@ namespace Fuse.Scripting.V8
 					Reconnect();
 				}
 				return this;
+			}
+
+			void ProcessMessages(Scripting.Context uContext, Simple.JSContext sContext)
+			{
+				Simple.Debug.ProcessMessages(sContext);
 			}
 
 			public void Reconnect()

--- a/Source/Fuse.Scripting/AppInitialized.uno
+++ b/Source/Fuse.Scripting/AppInitialized.uno
@@ -16,7 +16,7 @@ namespace Fuse.Scripting
 	{
 		static bool _initialized;
 
-		public static void On(Context context, Action action)
+		public static void On(IThreadWorker worker, Action action)
 		{
 			if (_initialized)
 			{
@@ -24,7 +24,7 @@ namespace Fuse.Scripting
 			}
 			else
 			{
-				UpdateManager.Dispatcher.Invoke(new Closure(context, action).Run);
+				UpdateManager.Dispatcher.Invoke(new Closure(worker, action).Run);
 			}
 		}
 
@@ -35,18 +35,18 @@ namespace Fuse.Scripting
 
 		class Closure
 		{
-			readonly Context _context;
+			readonly IThreadWorker _worker;
 			readonly Action _action;
 
-			public Closure(Context context, Action action)
+			public Closure(IThreadWorker worker, Action action)
 			{
-				_context = context;
+				_worker = worker;
 				_action = action;
 			}
 
 			public void Run()
 			{
-				_context.ThreadWorker.Invoke<Action>(RunJS, _action);
+				_worker.Invoke<Action>(RunJS, _action);
 			}
 
 			static void RunJS(Scripting.Context context, Action action)

--- a/Source/Fuse.Scripting/AppInitialized.uno
+++ b/Source/Fuse.Scripting/AppInitialized.uno
@@ -46,10 +46,10 @@ namespace Fuse.Scripting
 
 			public void Run()
 			{
-				_context.Dispatcher.Invoke1(RunJS, _action);
+				_context.ThreadWorker.Invoke<Action>(RunJS, _action);
 			}
 
-			static void RunJS(Action action)
+			static void RunJS(Scripting.Context context, Action action)
 			{
 				_initialized = true;
 				action();

--- a/Source/Fuse.Scripting/Context.uno
+++ b/Source/Fuse.Scripting/Context.uno
@@ -9,7 +9,6 @@ namespace Fuse.Scripting
 {
 	public interface IThreadWorker
 	{
-		IDispatcher Dispatcher { get; }
 		void Invoke(Uno.Action<Scripting.Context> action);
 		void Invoke<T>(Uno.Action<Scripting.Context, T> action, T arg0);
 	}
@@ -66,8 +65,6 @@ namespace Fuse.Scripting
 
 		public abstract object Wrap(object obj);
 		public abstract object Unwrap(object obj);
-
-		public IDispatcher Dispatcher { get { return ThreadWorker.Dispatcher; } }
 
 		public void Invoke(Uno.Action<Scripting.Context> action)
 		{

--- a/Source/Fuse.Scripting/NativeEventEmitterModule.uno
+++ b/Source/Fuse.Scripting/NativeEventEmitterModule.uno
@@ -49,7 +49,7 @@ namespace Fuse.Scripting
 			lock (_mutex)
 				foreach (var l in _listeningCallbacks)
 					Dispatch(new OnClosure(l.Item1, l.Item2).On, true);
-			AppInitialized.On(_context, OnAppInitialized);
+			AppInitialized.On(_context.ThreadWorker, OnAppInitialized);
 		}
 
 		override object CreateExportsObject(Context c)
@@ -57,7 +57,7 @@ namespace Fuse.Scripting
 			_context = c;
 			_this = EventEmitterModule.GetConstructor(_context).Construct(_eventNames);
 
-			AppInitialized.On(c, OnAppInitialized);
+			AppInitialized.On(c.ThreadWorker, OnAppInitialized);
 
 			return _this;
 		}

--- a/Source/Fuse.Scripting/NativeEventEmitterModule.uno
+++ b/Source/Fuse.Scripting/NativeEventEmitterModule.uno
@@ -137,7 +137,7 @@ namespace Fuse.Scripting
 					return;
 				}
 			}
-			_context.Dispatcher.Invoke2(action, _context, _this);
+			_context.ThreadWorker.Invoke<Scripting.Object>(action, _this);
 		}
 
 		/** Connect a @NativeEvent to an event.

--- a/Source/Fuse.Scripting/NativePromise.uno
+++ b/Source/Fuse.Scripting/NativePromise.uno
@@ -121,27 +121,27 @@ namespace Fuse.Scripting
 	    	{
 	    		_result = result;
 	    		if(_resolve != null)
-	    			_c.Dispatcher.Invoke(this.InternalResolve);
+	    			_c.ThreadWorker.Invoke(this.InternalResolve);
 	    	}
 
-	    	void InternalResolve()
+	    	void InternalResolve(Scripting.Context context)
     		{
     			if(_converter != null)
-    				_resolve.Call(_c, _converter(_c, _result));
+    				_resolve.Call(context, _converter(context, _result));
     			else
-    				_resolve.Call(_c, _result);
+    				_resolve.Call(context, _result);
     		}
 
 	    	void Reject(Exception reason)
 	    	{
 	    		_reason = reason;
 	    		if(_reject != null)
-	    			_c.Dispatcher.Invoke(this.InternalReject);
+	    			_c.ThreadWorker.Invoke(this.InternalReject);
 	    	}
 
-	    	void InternalReject()
+	    	void InternalReject(Scripting.Context context)
 	    	{
-	    		_reject.Call(_c, _reason.Message);
+	    		_reject.Call(context, _reason.Message);
 	    	}
 	    }
 	}

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -272,7 +272,7 @@ namespace Fuse.Scripting
 			{
 				_result = result;
 				if (_resolve != null)
-					_context.Dispatcher.Invoke(DispatchResolve);
+					_context.ThreadWorker.Invoke(DispatchResolve);
 			}
 
 			Exception _reason;
@@ -280,10 +280,10 @@ namespace Fuse.Scripting
 			{
 				_reason = reason;
 				if (_reject != null)
-					_context.Dispatcher.Invoke(DispatchReject);
+					_context.ThreadWorker.Invoke(DispatchReject);
 			}
 
-			void DispatchResolve()
+			void DispatchResolve(Scripting.Context context)
 			{
 				if (_resultConverter != null)
 					_resolve.Call(_context, _resultConverter(_context, _result));
@@ -291,7 +291,7 @@ namespace Fuse.Scripting
 					_resolve.Call(_context, _result);
 			}
 
-			void DispatchReject()
+			void DispatchReject(Scripting.Context context)
 			{
 				_reject.Call(_context, _reason.Message);
 			}

--- a/Source/Fuse.Scripting/Tests/Scripting.Test.uno
+++ b/Source/Fuse.Scripting/Tests/Scripting.Test.uno
@@ -169,11 +169,7 @@ namespace Fuse.Scripting.Test
 
 		class ContextObjectFactory
 		{
-			readonly Context _context;
-			public ContextObjectFactory(Context context)
-			{
-				_context = context;
-			}
+			public ContextObjectFactory() {}
 
 			public object Callback(Scripting.Context context, object[] args)
 			{
@@ -181,7 +177,7 @@ namespace Fuse.Scripting.Test
 				{
 					var x = AsInt(args[0]);
 					var y = AsInt(args[1]);
-					var result = _context.NewObject();
+					var result = context.NewObject();
 					result["x"] = x;
 					result["y"] = y;
 					return result;
@@ -234,7 +230,7 @@ namespace Fuse.Scripting.Test
 				var f = context.Evaluate(
 					"CallbackAsConstructor",
 					"(function(f) { return new f(12, 13); })") as Scripting.Function;
-				var res = f.Construct(new object[] { new Scripting.Callback(new ContextObjectFactory(context).Callback) });
+				var res = f.Construct(new object[] { new Scripting.Callback(new ContextObjectFactory().Callback) });
 				Assert.IsTrue(res is Scripting.Object);
 				Assert.IsTrue(res.ContainsKey("x"));
 				Assert.IsTrue(res.ContainsKey("y"));


### PR DESCRIPTION
It was a poor fit given the new requirement to pass the context to all
JS related operations. In all places were it was used the IThreadWorker
itself serves well.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
