### PR TITLE
transition to new Native build target (fusetools/uno#1382)

### DIFF
--- a/Source/Fuse.FileSystem/Uno/IO/FileStatusHelpers.Windows.uno
+++ b/Source/Fuse.FileSystem/Uno/IO/FileStatusHelpers.Windows.uno
@@ -30,7 +30,7 @@ namespace Fuse.FileSystem
         @{
             WIN32_FILE_ATTRIBUTE_DATA data;
 
-            if (!GetFileAttributesEx(path->Ptr(), GetFileExInfoStandard, &data))
+            if (!GetFileAttributesEx((LPCWSTR) path->Ptr(), GetFileExInfoStandard, &data))
                 return @{FileStatus():New()};
 
             uint64_t size = ((uint64_t)data.nFileSizeHigh << 32) | data.nFileSizeLow;

--- a/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
+++ b/Source/Fuse.Scripting.JavaScript/V8/V8Simple.cpp.uxl
@@ -3,7 +3,8 @@
 	<Require Condition="Android" JNI.SharedLibrary="@('lib/Android/libV8Simple.so':Path)" />
 	<Require Condition="OSX" LinkDirectory="@('lib/OSX':Path)" />
 	<Require Condition="WIN32" LinkDirectory="@('lib/Windows/$(PlatformShortName)':Path)" />
-	<CopyFile Condition="WIN32" Name="lib/Windows/x86/V8Simple.dll" TargetName="V8Simple.dll" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('lib/Windows/x86/V8Simple.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('lib/Windows/x64/V8Simple.dll':Path)" />
 	<CopyFile Condition="TARGET_MSVC" Name="lib/Windows/x86/V8Simple.dll" TargetName="bin/Win32/Debug/V8Simple.dll" />
 	<CopyFile Condition="TARGET_MSVC" Name="lib/Windows/x86/V8Simple.dll" TargetName="bin/Win32/Release/V8Simple.dll" />
 	<CopyFile Condition="TARGET_MSVC" Name="lib/Windows/x64/V8Simple.dll" TargetName="bin/x64/Debug/V8Simple.dll" />

--- a/Source/Fuse.Text/Implementation/ICU.cpp.uxl
+++ b/Source/Fuse.Text/Implementation/ICU.cpp.uxl
@@ -1,31 +1,60 @@
 <Extensions Backend="CPlusPlus">
 	<Define USE_ICU="!Android" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icudt55.dll" TargetName="bin/Win32/Release/icudt55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icuin55.dll" TargetName="bin/Win32/Release/icuin55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icuio55.dll" TargetName="bin/Win32/Release/icuio55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icule55.dll" TargetName="bin/Win32/Release/icule55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/iculx55.dll" TargetName="bin/Win32/Release/ixulx55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icutu55.dll" TargetName="bin/Win32/Release/icutu55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icuuc55.dll" TargetName="bin/Win32/Release/icuuc55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icudt55.dll" TargetName="bin/Win32/Debug/icudt55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icuin55.dll" TargetName="bin/Win32/Debug/icuin55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icuio55.dll" TargetName="bin/Win32/Debug/icuio55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icule55.dll" TargetName="bin/Win32/Debug/icule55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/iculx55.dll" TargetName="bin/Win32/Debug/ixulx55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icutu55.dll" TargetName="bin/Win32/Debug/icutu55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x86/icu/bin/icuuc55.dll" TargetName="bin/Win32/Debug/icuuc55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icudt55.dll" TargetName="bin/x64/Release/icudt55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icuin55.dll" TargetName="bin/x64/Release/icuin55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icuio55.dll" TargetName="bin/x64/Release/icuio55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icule55.dll" TargetName="bin/x64/Release/icule55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/iculx55.dll" TargetName="bin/x64/Release/ixulx55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icutu55.dll" TargetName="bin/x64/Release/icutu55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icuuc55.dll" TargetName="bin/x64/Release/icuuc55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icudt55.dll" TargetName="bin/x64/Debug/icudt55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icuin55.dll" TargetName="bin/x64/Debug/icuin55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icuio55.dll" TargetName="bin/x64/Debug/icuio55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icule55.dll" TargetName="bin/x64/Debug/icule55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/iculx55.dll" TargetName="bin/x64/Debug/ixulx55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icutu55.dll" TargetName="bin/x64/Debug/icutu55.dll" />
-	<CopyFile Condition="MSVC" Name="../icu/x64/icu/bin64/icuuc55.dll" TargetName="bin/x64/Debug/icuuc55.dll" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icudt55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icuin55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icuio55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icule55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/iculx55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icutu55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icuuc55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icudt55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icuin55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icuio55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icule55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/iculx55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icutu55.dll':Path)" />
+	<Require Condition="WIN32 && X86" SharedLibrary="@('../icu/x86/icu/bin/icuuc55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icudt55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icuin55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icuio55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icule55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/iculx55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icutu55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icuuc55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icudt55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icuin55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icuio55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icule55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/iculx55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icutu55.dll':Path)" />
+	<Require Condition="WIN32 && X64" SharedLibrary="@('../icu/x64/icu/bin64/icuuc55.dll':Path)" />
+	<!-- Legacy -->
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icudt55.dll" TargetName="bin/Win32/Release/icudt55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icuin55.dll" TargetName="bin/Win32/Release/icuin55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icuio55.dll" TargetName="bin/Win32/Release/icuio55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icule55.dll" TargetName="bin/Win32/Release/icule55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/iculx55.dll" TargetName="bin/Win32/Release/ixulx55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icutu55.dll" TargetName="bin/Win32/Release/icutu55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icuuc55.dll" TargetName="bin/Win32/Release/icuuc55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icudt55.dll" TargetName="bin/Win32/Debug/icudt55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icuin55.dll" TargetName="bin/Win32/Debug/icuin55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icuio55.dll" TargetName="bin/Win32/Debug/icuio55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icule55.dll" TargetName="bin/Win32/Debug/icule55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/iculx55.dll" TargetName="bin/Win32/Debug/ixulx55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icutu55.dll" TargetName="bin/Win32/Debug/icutu55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x86/icu/bin/icuuc55.dll" TargetName="bin/Win32/Debug/icuuc55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icudt55.dll" TargetName="bin/x64/Release/icudt55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icuin55.dll" TargetName="bin/x64/Release/icuin55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icuio55.dll" TargetName="bin/x64/Release/icuio55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icule55.dll" TargetName="bin/x64/Release/icule55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/iculx55.dll" TargetName="bin/x64/Release/ixulx55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icutu55.dll" TargetName="bin/x64/Release/icutu55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icuuc55.dll" TargetName="bin/x64/Release/icuuc55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icudt55.dll" TargetName="bin/x64/Debug/icudt55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icuin55.dll" TargetName="bin/x64/Debug/icuin55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icuio55.dll" TargetName="bin/x64/Debug/icuio55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icule55.dll" TargetName="bin/x64/Debug/icule55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/iculx55.dll" TargetName="bin/x64/Debug/ixulx55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icutu55.dll" TargetName="bin/x64/Debug/icutu55.dll" />
+	<CopyFile Condition="TARGET_MSVC" Name="../icu/x64/icu/bin64/icuuc55.dll" TargetName="bin/x64/Debug/icuuc55.dll" />
 </Extensions>


### PR DESCRIPTION
* We now use `<Require SharedLibrary>` to get a DLL for the right architecture copied to the right place.
* Remaining `TARGET_MSVC`-things are no longer used by the new target and can soon be removed.
* Includes a compile fix after the `char16_t`-refactoring.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
