### PR TITLE
Fuse.Triggers: restore arg.sender argument on callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # 1.3
 
+## 1.3.2
+
+### Callback
+- Fixed a regression where args.sender was no longer the `ux:Name` of the parent of the trigger.
+
 ## 1.3.1
 
 ### Navigation

--- a/Source/Fuse.Triggers/Actions/Callback.uno
+++ b/Source/Fuse.Triggers/Actions/Callback.uno
@@ -36,7 +36,13 @@ namespace Fuse.Triggers.Actions
 				Action();
 				
 			if (Handler != null)
-				Handler(target, new VisualEventArgs(target.FindByType<Visual>()) );
+			{
+				var visual = target.FindByType<Visual>();
+				// HACK: Users use 'args.sender' to identify which visual people
+				// for instance clicked. To restore this behavior, lie about the
+				// sender here, and pass `visual` instead.
+				Handler(visual, new VisualEventArgs(visual));
+			}
 		}
 	}
 }

--- a/Source/Fuse.Triggers/Tests/Callback.Test.uno
+++ b/Source/Fuse.Triggers/Tests/Callback.Test.uno
@@ -1,0 +1,28 @@
+using Uno;
+using Uno.Data.Json;
+using Uno.Testing;
+using Uno.UX;
+
+using Fuse.Controls;
+
+using FuseTest;
+
+namespace Fuse.Test
+{
+	public class CallbackTest : TestBase
+	{
+		[Test]
+		public void ArgsContainsSender()
+		{
+			var p = new UX.Callback.ArgsContainsSender();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.PointerPress(float2(1, 1));
+				root.PointerRelease();
+
+				root.StepFrameJS();
+				Assert.AreEqual("ExpectedSender", p.Sender.Value);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Triggers/Tests/UX/Callback.ArgsContainsSender.ux
+++ b/Source/Fuse.Triggers/Tests/UX/Callback.ArgsContainsSender.ux
@@ -1,0 +1,20 @@
+<Panel ux:Class="UX.Callback.ArgsContainsSender" ux:Name="ExpectedSender">
+	<JavaScript>
+		var Observable = require("FuseJS/Observable");
+		var sender = Observable();
+		var callback = function (args) {
+			console.log(JSON.stringify(args));
+			sender.value = args.sender;
+		}
+		module.exports = {
+			callback: callback,
+			sender: sender
+		};
+	</JavaScript>
+
+	<Clicked>
+		<Callback Handler="{callback}"/>
+	</Clicked>
+
+	<Text ux:Name="Sender" Value="{sender}" />
+</Panel>


### PR DESCRIPTION
Users depend on args.sender in the JavaScript handler of a Callback
to contain the name of the visual that was for instance pressed.

However, 51ec407 changed the sender to be the trigger itself, which
broke this behavior.

Let's restore this behavior, by lying about what the sender is inside
Callback. This should be the only user-visible effect of the
sender-change.

Fixes #659

This PR contains:
- [x] Changelog
- [x] Tests
