### PR TITLE
Fuse.Scripting.JavaScriptCore: do not throw exceptions through scriping-engine

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Array.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Array.uno
@@ -26,17 +26,23 @@ namespace Fuse.Scripting.JavaScriptCore
 		{
 			get
 			{
-				return _context.Wrap(_value.GetPropertyAtIndex(
-					_context._context,
-					index,
-					_context._onError));
+				object result = null;
+				using (var vm = new Context.EnterVM(_context))
+					result = _context.Wrap(_value.GetPropertyAtIndex(
+						_context._context,
+						index,
+						_context._onError));
+				_context.ThrowPendingException();
+				return result;
 			}
 			set
 			{
-				_value.SetPropertyAtIndex(_context._context,
-					index,
-					_context.Unwrap(value),
-					_context._onError);
+				using (var vm = new Context.EnterVM(_context))
+					_value.SetPropertyAtIndex(_context._context,
+						index,
+						_context.Unwrap(value),
+						_context._onError);
+				_context.ThrowPendingException();
 			}
 		}
 
@@ -44,12 +50,16 @@ namespace Fuse.Scripting.JavaScriptCore
 		{ 
 			get
 			{
-				return (int)_value.GetProperty(
-					_context._context,
-					"length",
-					_context._onError).ToNumber(
+				int result = 0;
+				using (var vm = new Context.EnterVM(_context))
+					result = (int)_value.GetProperty(
 						_context._context,
-						_context._onError);
+						"length",
+						_context._onError).ToNumber(
+							_context._context,
+							_context._onError);
+				_context.ThrowPendingException();
+				return result;
 			}
 		}
 

--- a/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Function.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Function.uno
@@ -26,21 +26,29 @@ namespace Fuse.Scripting.JavaScriptCore
 			// Ensure this function is being called from the context/vm it belongs to
 			assert context == _context;
 
-			return _context.Wrap(
-				_value.CallAsFunction(
-					_context._context,
-					default(JSObjectRef),
-					_context.Unwrap(args),
-					_context._onError));
+			object result = null;
+			using (var vm = new Context.EnterVM(_context))
+				result = _context.Wrap(
+					_value.CallAsFunction(
+						_context._context,
+						default(JSObjectRef),
+						_context.Unwrap(args),
+						_context._onError));
+			_context.ThrowPendingException();
+			return result;
 		}
 
 		public override Scripting.Object Construct(params object[] args)
 		{
-			return (Scripting.Object)_context.Wrap(
-				_value.CallAsConstructor(
-					_context._context,
-					_context.Unwrap(args),
-					_context._onError).GetJSValueRef());
+			Scripting.Object result = null;
+			using (var vm = new Context.EnterVM(_context))
+				result = (Scripting.Object)_context.Wrap(
+						_value.CallAsConstructor(
+						_context._context,
+						_context.Unwrap(args),
+						_context._onError).GetJSValueRef());
+			_context.ThrowPendingException();
+			return result;
 		}
 
 		public override bool Equals(Scripting.Function f)


### PR DESCRIPTION
JavaScriptCore is written in C, and cannot handle C++ exception-unwinding. So let's
avoid throwing exceptions through the scripting-engine, and do like we do on V8;
rethrow the exception when we've exited the VM.

This fixes ScriptingTest.CatchingUnoExceptions on iOS.

This PR contains:
- [x] Changelog
- [ ] ~Tests~ This already has a test that failed on iOS
