### PR TITLE
Fix threading bugs in TreeObservable

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeArray.uno
+++ b/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeArray.uno
@@ -97,11 +97,10 @@ namespace Fuse.Scripting.JavaScript
 			{
 				var ta = SubscriptionSubject as TreeArray;
 
-				var worker = Fuse.Reactive.JavaScript.Worker;
 				var replaceAll = new ReplaceAllOperation((Scripting.Array)ta.Raw, values);
 				replaceAll.Perform(context);
 
-				ta.ReplaceAll(values, this);
+				UpdateManager.PostAction(new ReplaceAllOnUIThreadClosure(ta, values, this).Perform);
 			}
 
 			public void ReplaceAllExclusive(IArray values)
@@ -152,6 +151,25 @@ namespace Fuse.Scripting.JavaScript
 						return _values[index];
 					}
 				}
+			}
+		}
+
+		class ReplaceAllOnUIThreadClosure
+		{
+			TreeArray _treeArray;
+			IArray _newValues;
+			ArraySubscription _exclude;
+
+			public ReplaceAllOnUIThreadClosure(TreeArray treeArray, IArray newValues, ArraySubscription exclude)
+			{
+				_treeArray = treeArray;
+				_newValues = newValues;
+				_exclude = exclude;
+			}
+
+			public void Perform()
+			{
+				_treeArray.ReplaceAll(_newValues, _exclude);
 			}
 		}
 

--- a/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeObservable.uno
+++ b/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeObservable.uno
@@ -95,25 +95,25 @@ namespace Fuse.Scripting.JavaScript
 
 		object Set(Fuse.Scripting.Context context, object[] args)
 		{
-			new SetOperation(context, this, args);
+			new SetOperation(context, this, args).Perform();
 			return null;
 		}
 
 		object Add(Fuse.Scripting.Context context, object[] args)
 		{
-			new AddOperation(context, this, args);
+			new AddOperation(context, this, args).Perform();
 			return null;
 		}
 
 		object RemoveAt(Fuse.Scripting.Context context, object[] args)
 		{
-			new RemoveAtOperation(this, args);
+			new RemoveAtOperation(this, args).Perform();
 			return null;
 		}
 
 		object InsertAt(Fuse.Scripting.Context context, object[] args)
 		{
-			new InsertAtOperation(context, this, args);
+			new InsertAtOperation(context, this, args).Perform();
 			return null;
 		}
 
@@ -125,6 +125,10 @@ namespace Fuse.Scripting.JavaScript
 			{
 				Arguments = args;
 				TreeObservable = inst;
+			}
+
+			public void Perform()
+			{
 				UpdateManager.PostAction(PerformStart);
 			}
 


### PR DESCRIPTION
This fixes a couple of cases where JS would be called on the UI thread and vice versa.

- Parsing of arguments passed to TreeObservable operators now happens on the JS thread, and only the call to `Perform(object dc)` implemented by each `Operation` is dispatched onto the UI thread. This has the side-effect of no longer calling JS code from the UI thread with a cached `Scripting.Context` (fixes #639)
- Replacing the contents of a TreeObject using `Set(Scripting.Context, IMirror, Scripting.Object)` now updates UI state and notifies subscribers on the UI thread (as it should)
   - The same goes for TreeArray write-back operations

This PR contains:
- [ ] Changelog (N/A)
- [ ] Documentation (N/A)
- [ ] Tests (not really sure how one would go about writing meaningful tests for this)