### PR TITLE
General-purpose blitter

### DIFF
--- a/Source/Fuse.Android.TextRenderer/TextRenderer.uno
+++ b/Source/Fuse.Android.TextRenderer/TextRenderer.uno
@@ -4,6 +4,7 @@ using OpenGL;
 using Fuse.Elements;
 using Fuse.Controls;
 using Fuse.Controls.Graphics;
+using Fuse.Drawing;
 using Fuse.Resources;
 using Uno.Compiler.ExportTargetInterop;
 
@@ -338,44 +339,13 @@ namespace Fuse.Android
 			}*/
 			
 			var m = dc.GetLocalToClipTransform(where);
-			Blitter.Singleton.Blit(_texture, position, pointSize, m);
+			Blitter.Singleton.Blit(_texture, new Rect(position, pointSize), m);
 		}
 
 		public void Draw(DrawContext dc, Visual where)
 		{
 			PrepareDraw();
 			OnBitmapDraw(dc,where,_arrangePosition,_arrangeSize);
-		}
-	}
-
-	class Blitter
-	{
-		internal static Blitter Singleton = new Blitter();
-
-		public void Blit(texture2D vt, float2 pos, float2 size, float4x4 localToClipTransform)
-		{
-			draw
-			{
-				apply Fuse.Drawing.PreMultipliedAlphaCompositing;
-
-				CullFace : PolygonFace.None;
-				DepthTestEnabled: false;
-				float2[] verts: readonly new float2[] {
-
-					float2(0,0),
-					float2(1,0),
-					float2(1,1),
-					float2(0,0),
-					float2(1,1),
-					float2(0,1)
-				};
-
-				float2 v: vertex_attrib(verts);
-				float2 LocalVertex: pos + v * size;
-				ClipPosition: Vector.Transform(LocalVertex, localToClipTransform);
-				float2 TexCoord: v;
-				PixelColor: sample(vt, TexCoord, SamplerState.LinearClamp);
-			};
 		}
 	}
 }

--- a/Source/Fuse.Controls.Native/NativeRenderer.uno
+++ b/Source/Fuse.Controls.Native/NativeRenderer.uno
@@ -70,9 +70,10 @@ namespace Fuse.Controls.Native
 			}
 			Blitter.Singleton.Blit(
 				new texture2D(_textureHandle, pixelSize, 1, Format.RGBA8888),
-				position,
-				size,
-				localToClipTransform);
+				new Rect(position, size),
+				localToClipTransform,
+				1.0f,
+				defined(iOS));
 		}
 
 		public void Invalidate()
@@ -236,40 +237,5 @@ namespace Fuse.Controls.Native
 			((android.graphics.Bitmap)bitmap).recycle();
 		@}
 
-	}
-
-	extern(Android || iOS) class Blitter
-	{
-		internal static Blitter Singleton = new Blitter();
-
-		extern(iOS) readonly bool _ios = true;
-		extern(Android) readonly bool _ios = false;
-
-		public void Blit(texture2D vt, float2 pos, float2 size, float4x4 localToClipTransform)
-		{
-			draw
-			{
-				apply Fuse.Drawing.PreMultipliedAlphaCompositing;
-
-				CullFace : PolygonFace.None;
-				DepthTestEnabled: false;
-				float2[] verts: readonly new float2[] {
-
-					float2(0,0),
-					float2(1,0),
-					float2(1,1),
-					float2(0,0),
-					float2(1,1),
-					float2(0,1)
-				};
-
-				float2 v: vertex_attrib(verts);
-				float2 LocalVertex: pos + v * size;
-				ClipPosition: Vector.Transform(LocalVertex, localToClipTransform);
-				float2 TexCoord: v;
-
-				PixelColor: _ios ? sample(vt, float2(TexCoord.X, 1.0f - TexCoord.Y)) : sample(vt, TexCoord);
-			};
-		}
 	}
 }

--- a/Source/Fuse.Controls.Panels/Panel.Freeze.uno
+++ b/Source/Fuse.Controls.Panels/Panel.Freeze.uno
@@ -179,7 +179,17 @@ namespace Fuse.Controls
 		{
 			if (IsFrozen && HasFreezePrepared)
 			{
-				FreezeDrawable.Singleton.Draw(dc, this, Opacity, Scale, _frozenRenderBounds, _frozenBuffer);
+				var rect = Rect.Scale(_frozenRenderBounds.FlatRect, Scale);
+				Blitter.Singleton.Blit(
+					_frozenBuffer.ColorBuffer,
+					rect,
+					dc.GetLocalToClipTransform(this),
+					Opacity,
+					true);
+
+					if defined(FUSELIBS_DEBUG_DRAW_RECTS)
+						DrawRectVisualizer.Capture(rect.Minimum, rect.Size, WorldTransform, dc);
+
 				return true;
 			}
 
@@ -198,43 +208,21 @@ namespace Fuse.Controls
 				return;
 			}
 
-			FreezeDrawable.Singleton.Draw(dc, this, Opacity, Scale, _frozenRenderBounds, _frozenBuffer);
+			var rect = Rect.Scale(_frozenRenderBounds.FlatRect, Scale);
+			Blitter.Singleton.Blit(
+				_frozenBuffer.ColorBuffer,
+				rect,
+				dc.GetLocalToClipTransform(this),
+				Opacity,
+				true);
+
+				if defined(FUSELIBS_DEBUG_DRAW_RECTS)
+					DrawRectVisualizer.Capture(rect.Minimum, rect.Size, WorldTransform, dc);
 		}
 		
 		internal override bool IsLayoutRoot
 		{
 			get { return HasFreezePrepared; }
-		}
-	}
-	
-	class FreezeDrawable
-	{
-		static public FreezeDrawable Singleton = new FreezeDrawable();
-		
-		public void Draw(DrawContext dc, Panel panel, float Opacity, float2 scale,
-			VisualBounds renderBounds, framebuffer buffer)
-		{
-			draw 
-			{
-				apply Fuse.Drawing.Planar.Image;
-				apply Fuse.Drawing.PreMultipliedAlphaCompositing;
-				
-				DrawContext: dc;
-				Visual: panel;
-				Size: renderBounds.Size.XY * scale;
-				Position: renderBounds.AxisMin.XY * scale;
-				Texture: buffer.ColorBuffer;
-				Invert: true;
-				
-				PixelColor: prev * Opacity;
-			};
-
-			if defined(FUSELIBS_DEBUG_DRAW_RECTS)
-			{
-				float2 position = renderBounds.AxisMin.XY * scale;
-				float2 size = renderBounds.Size.XY * scale;
-				DrawRectVisualizer.Capture(position, size, panel.WorldTransform, dc);
-			}
 		}
 	}
 }

--- a/Source/Fuse.Controls.Primitives/Image.Visual.uno
+++ b/Source/Fuse.Controls.Primitives/Image.Visual.uno
@@ -193,20 +193,10 @@ namespace Fuse.Controls
 			Texture2D tex, ResampleMode resampleMode,
 			float4 Color )
 		{
-			draw
-			{
-				apply Fuse.Drawing.Planar.Image;
-
-				DrawContext: dc;
-				Visual: element;
-				Size: size;
-				Position: offset;
-				Texture: tex;
-				SamplerState SamplerState: GetSamplerState(resampleMode);
-				TexCoord: VertexData * uvSize + uvPosition;
-				TexCoord: Vector.TransformCoordinate(prev, imageTransform);
-				TextureColor: prev * Color;
-			};
+			Blitter.Singleton.Blit(tex, GetSamplerState(resampleMode), false,
+			                       new Rect(uvPosition, uvSize), imageTransform,
+			                       new Rect(offset, size), dc.GetLocalToClipTransform(element),
+			                       Color);
 
 			if defined(FUSELIBS_DEBUG_DRAW_RECTS)
 				DrawRectVisualizer.Capture(offset, size, element.WorldTransform, dc);

--- a/Source/Fuse.Controls/Viewport.uno
+++ b/Source/Fuse.Controls/Viewport.uno
@@ -3,6 +3,7 @@ using Uno.Graphics;
 using Uno.UX;
 
 using Fuse.Nodes;
+using Fuse.Drawing;
 
 namespace Fuse.Elements
 {
@@ -263,16 +264,11 @@ namespace Fuse.Elements
 
 				dc.PopRenderTargetViewport();
 
-				//TODO: mvoe to static class
-				draw
-				{
-					apply Fuse.Drawing.Planar.Image;
-					DrawContext: dc;
-					Visual: this;
-					Size: ActualSize;
-					Invert: true;
-					Texture: fb.ColorBuffer;
-				};
+				Blitter.Singleton.Blit(
+					fb.ColorBuffer,
+					new Rect(float2(0, 0), ActualSize),
+					dc.GetLocalToClipTransform(this),
+					1.0f, true);
 
 				if defined(FUSELIBS_DEBUG_DRAW_RECTS)
 					DrawRectVisualizer.Capture(float2(0), ActualSize, WorldTransform, dc);

--- a/Source/Fuse.Drawing.Surface/Android/GraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/Android/GraphicsSurface.uno
@@ -129,7 +129,7 @@ namespace Fuse.Drawing
 			var fb = FramebufferPool.Lock( src.PixelSize, Uno.Graphics.Format.RGBA8888, false );
 
 			_drawContext.PushRenderTarget(fb);
-			AndroidGraphicsDrawHelper.Singleton.DrawImageFill(tex);
+			Blitter.Singleton.Blit(tex, new Rect(float2(-1), float2(2)), float4x4.Identity, 1.0f, true);
 			Java.Object imageRef = LoadImage((int)tex.GLTextureHandle, src.PixelSize.X, src.PixelSize.Y );
 			FramebufferPool.Release(fb);
 			_drawContext.PopRenderTarget();

--- a/Source/Fuse.Drawing.Surface/Android/Surface.uno
+++ b/Source/Fuse.Drawing.Surface/Android/Surface.uno
@@ -586,30 +586,4 @@ namespace Fuse.Drawing
 		@}
 
 	}
-
-	extern(Android)
-	class AndroidGraphicsDrawHelper
-	{
-		static public AndroidGraphicsDrawHelper Singleton = new AndroidGraphicsDrawHelper();
-
-		public void DrawImageFill( texture2D texture )
-		{
-			draw
-			{
-				float2[] Vertices: new []
-				{
-					float2(0, 0), float2(1, 0), float2(1, 1),
-					float2(1, 1), float2(0, 1), float2(0, 0)
-				};
-
-				float2 VertexData: vertex_attrib(Vertices);
-				VertexCount : 6;
-
-				ClipPosition: float4(VertexData*2 -1, 0,1);
-
-				DepthTestEnabled: false;
-				PixelColor: sample(texture, float2(VertexData.X,1-VertexData.Y), Uno.Graphics.SamplerState.LinearClamp);
-			};
-		}
-	}
 }

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/CoreGraphicsSurface.uno
@@ -530,31 +530,4 @@ namespace Fuse.Drawing
 			}
 		@}
 	}
-	
-	extern(iOS||OSX)
-	class CoreGraphicsDrawHelper
-	{
-		static public CoreGraphicsDrawHelper Singleton = new CoreGraphicsDrawHelper();
-		
-		public void DrawImageFill( texture2D texture )
-		{
-			draw
-			{
-				float2[] Vertices: new []
-				{
-					float2(0, 0), float2(1, 0), float2(1, 1),
-					float2(1, 1), float2(0, 1), float2(0, 0)
-				};
-
-				float2 VertexData: vertex_attrib(Vertices);
-				VertexCount : 6;
-
-				ClipPosition: float4(VertexData*2 -1, 0,1);
-
-				DepthTestEnabled: false;
-				PixelColor: sample(texture, float2(VertexData.X,1-VertexData.Y), Uno.Graphics.SamplerState.LinearClamp);
-			};
-		}
-	}
-	
 }

--- a/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
+++ b/Source/Fuse.Drawing.Surface/CoreGraphics/GraphicsSurface.uno
@@ -131,7 +131,7 @@ namespace Fuse.Drawing
 				//TODO: this is not entirely correct since _drawContext could be null now -- but it isn't
 				//in any of our use cases, but the contract certainly allows for it
 				_drawContext.PushRenderTarget(fb);
-				CoreGraphicsDrawHelper.Singleton.DrawImageFill(tex);
+				Blitter.Singleton.Blit(tex, new Rect(float2(-1), float2(2)), float4x4.Identity, 1.0f, true);
 				imageRef = LoadImagePoor(_context, src.PixelSize.X, src.PixelSize.Y );
 				FramebufferPool.Release(fb);
 				_drawContext.PopRenderTarget();

--- a/Source/Fuse.Drawing.Surface/DotNetSurface.uno
+++ b/Source/Fuse.Drawing.Surface/DotNetSurface.uno
@@ -476,7 +476,7 @@ namespace Fuse.Drawing
 			//TODO: this is not entirely correct since _drawContext could be null now -- but it isn't
 			//in any of our use cases, but the contract certainly allows for it
 			_drawContext.PushRenderTarget(fb);
-			DrawImageFill(tex);
+			Blitter.Singleton.Blit(tex, new Rect(float2(-1), float2(2)), float4x4.Identity, 1.0f, true);
 			var imageRef = LoadImage(src.PixelSize.X, src.PixelSize.Y );
 			FramebufferPool.Release(fb);
 			_drawContext.PopRenderTarget();
@@ -508,25 +508,6 @@ namespace Fuse.Drawing
 			var image = new Bitmap(width, height, width * 4, PixelFormat.Format32bppPArgb, buffer);			
 
 			return Tuple.Create(image, handle);
-		}
-
-		public void DrawImageFill( texture2D texture )
-		{
-			draw
-			{
-				float2[] Vertices: new []
-				{
-					float2(0, 0), float2(1, 0), float2(1, 1),
-					float2(1, 1), float2(0, 1), float2(0, 0)
-				};
-				float2 VertexData: vertex_attrib(Vertices);
-				VertexCount : 6;
-
-				ClipPosition: float4(VertexData*2 -1, 0,1);
-
-				DepthTestEnabled: false;
-				PixelColor: sample(texture, float2(VertexData.X,1-VertexData.Y), Uno.Graphics.SamplerState.LinearClamp);
-			};
 		}
 
 		void VerifyCreated()

--- a/Source/Fuse.Drawing/Blitter.uno
+++ b/Source/Fuse.Drawing/Blitter.uno
@@ -1,0 +1,82 @@
+using Uno;
+using Uno.Graphics;
+
+namespace Fuse.Drawing
+{
+	class Blitter
+	{
+		internal static Blitter Singleton = new Blitter();
+
+		public void Blit(texture2D texture, Rect rect, float4x4 localToClipTransform, float opacity = 1.0f, bool flipY = false, PolygonFace cullFace = PolygonFace.None)
+		{
+			float4x4 textureTransform = float4x4.Identity;
+			if (flipY)
+			{
+				textureTransform.M22 = -1;
+				textureTransform.M42 =  1;
+			}
+
+			Blit(texture, SamplerState.LinearClamp, true,
+			     new Rect(float2(0, 0), float2(1, 1)), textureTransform,
+			     rect, localToClipTransform,
+			     float4(1, 1, 1, opacity));
+		}
+
+		public void Blit(Texture2D texture, SamplerState samplerState, bool preMultiplied,
+		                 Rect textureRect, float4x4 textureTransform,
+		                 Rect localRect, float4x4 localToClipTransform,
+		                 float4 color, PolygonFace cullFace = PolygonFace.None)
+		{
+			BlendOperand srcRGB, dstRGB;
+			BlendOperand srcA, dstA;
+
+			if (preMultiplied)
+			{
+				srcRGB = BlendOperand.One;
+				dstRGB = BlendOperand.OneMinusSrcAlpha;
+
+				srcA = BlendOperand.OneMinusDstAlpha;
+				dstA = BlendOperand.One;
+				color = float4(color.XYZ * color.W, color.W);
+			}
+			else
+			{
+				srcRGB = BlendOperand.SrcAlpha;
+				dstRGB = BlendOperand.OneMinusSrcAlpha;
+
+				srcA = BlendOperand.One;
+				dstA = BlendOperand.OneMinusSrcAlpha;
+			}
+
+			// TODO: bake localRect + localToClipTransform
+			// TODO: bake textureRect + textureTransform
+			draw
+			{
+				BlendEnabled: true;
+				BlendSrcRgb: srcRGB;
+				BlendDstRgb: dstRGB;
+				BlendSrcAlpha: srcA;
+				BlendDstAlpha: dstA;
+
+				CullFace : cullFace;
+				DepthTestEnabled: false;
+				float2[] verts: readonly new float2[] {
+
+					float2(0,0),
+					float2(1,0),
+					float2(1,1),
+					float2(0,0),
+					float2(1,1),
+					float2(0,1)
+				};
+
+				float2 v: vertex_attrib(verts);
+				float2 LocalVertex: localRect.Minimum + v * localRect.Size;
+				ClipPosition: Vector.Transform(LocalVertex, localToClipTransform);
+				float2 TexCoord: textureRect.Minimum + v * textureRect.Size;
+				TexCoord: Vector.TransformCoordinate(prev, textureTransform);
+				PixelColor: sample(texture, TexCoord, samplerState) * color;
+			};
+		}
+	}
+}

--- a/Source/Fuse.Drawing/Fuse.Drawing.unoproj
+++ b/Source/Fuse.Drawing/Fuse.Drawing.unoproj
@@ -13,6 +13,7 @@
     "Fuse.Controls.Panels",
     "Fuse.Controls.Primitives",
     "Fuse.Drawing.Surface",
+    "Fuse.Elements",
     "Fuse.iOS.TextRenderer"
   ],
   "Packages": [

--- a/Source/Fuse.Drawing/Fuse.Drawing.unoproj
+++ b/Source/Fuse.Drawing/Fuse.Drawing.unoproj
@@ -9,7 +9,8 @@
   "InternalsVisibleTo": [
     "Fuse.Android.TextRenderer",
     "Fuse.Controls.Native",
-    "Fuse.Controls.Panels"
+    "Fuse.Controls.Panels",
+    "Fuse.Controls.Primitives"
   ],
   "Packages": [
     "Uno.Collections"

--- a/Source/Fuse.Drawing/Fuse.Drawing.unoproj
+++ b/Source/Fuse.Drawing/Fuse.Drawing.unoproj
@@ -8,6 +8,7 @@
   },
   "InternalsVisibleTo": [
     "Fuse.Android.TextRenderer",
+    "Fuse.Controls",
     "Fuse.Controls.Native",
     "Fuse.Controls.Panels",
     "Fuse.Controls.Primitives"

--- a/Source/Fuse.Drawing/Fuse.Drawing.unoproj
+++ b/Source/Fuse.Drawing/Fuse.Drawing.unoproj
@@ -12,7 +12,8 @@
     "Fuse.Controls.Native",
     "Fuse.Controls.Panels",
     "Fuse.Controls.Primitives",
-    "Fuse.Drawing.Surface"
+    "Fuse.Drawing.Surface",
+    "Fuse.iOS.TextRenderer"
   ],
   "Packages": [
     "Uno.Collections"

--- a/Source/Fuse.Drawing/Fuse.Drawing.unoproj
+++ b/Source/Fuse.Drawing/Fuse.Drawing.unoproj
@@ -11,7 +11,8 @@
     "Fuse.Controls",
     "Fuse.Controls.Native",
     "Fuse.Controls.Panels",
-    "Fuse.Controls.Primitives"
+    "Fuse.Controls.Primitives",
+    "Fuse.Drawing.Surface"
   ],
   "Packages": [
     "Uno.Collections"

--- a/Source/Fuse.Drawing/Fuse.Drawing.unoproj
+++ b/Source/Fuse.Drawing/Fuse.Drawing.unoproj
@@ -8,7 +8,8 @@
   },
   "InternalsVisibleTo": [
     "Fuse.Android.TextRenderer",
-    "Fuse.Controls.Native"
+    "Fuse.Controls.Native",
+    "Fuse.Controls.Panels"
   ],
   "Packages": [
     "Uno.Collections"

--- a/Source/Fuse.Drawing/Fuse.Drawing.unoproj
+++ b/Source/Fuse.Drawing/Fuse.Drawing.unoproj
@@ -7,7 +7,8 @@
     "ProjectUrl": "https://fusetools.com"
   },
   "InternalsVisibleTo": [
-    "Fuse.Android.TextRenderer"
+    "Fuse.Android.TextRenderer",
+    "Fuse.Controls.Native"
   ],
   "Packages": [
     "Uno.Collections"

--- a/Source/Fuse.Drawing/Fuse.Drawing.unoproj
+++ b/Source/Fuse.Drawing/Fuse.Drawing.unoproj
@@ -7,8 +7,7 @@
     "ProjectUrl": "https://fusetools.com"
   },
   "InternalsVisibleTo": [
-    "Fuse.Reactive",
-    "Fuse.Scripting",
+    "Fuse.Android.TextRenderer"
   ],
   "Packages": [
     "Uno.Collections"

--- a/Source/Fuse.iOS.TextRenderer/TextRenderer.uno
+++ b/Source/Fuse.iOS.TextRenderer/TextRenderer.uno
@@ -6,6 +6,7 @@ using OpenGL;
 using Fuse.Elements;
 using Fuse.Controls.Graphics;
 using Fuse.Controls;
+using Fuse.Drawing;
 
 namespace Fuse.iOS.Bindings
 {
@@ -263,8 +264,8 @@ namespace Fuse.iOS.Bindings
 				_texture = new texture2D(textureHandle, pixelSize, 1, Format.RGBA8888);
 			}
 
-			Blitter.Singleton.Blit(dc,where,_texture, 
-				_textLayout.PixelBounds.Position / _control.Viewport.PixelsPerPoint + _arrangePosition, pointSize);
+			var pointPosition = _textLayout.PixelBounds.Position / _control.Viewport.PixelsPerPoint;
+			Blitter.Singleton.Blit(_texture, new Rect(pointPosition, pointSize), dc.GetLocalToClipTransform(where), 1.0f, true);
 		}
 
 		static CGContextRef CGBitmapContextCreate(IntPtr textureBuffer, int width, int height, CGColorSpaceRef colorSpace)
@@ -336,27 +337,5 @@ namespace Fuse.iOS.Bindings
 		}
 
 		texture2D _texture;
-	}
-	
-	class Blitter
-	{
-		internal static Blitter Singleton = new Blitter();
-
-		public void Blit(DrawContext dc, Visual where, texture2D vt, float2 pos, float2 size)
-		{
-			draw
-			{
-				apply Fuse.Drawing.Planar.Image;
-				DrawContext: dc;
-				Visual: where;
-				Size: size;
-				Position: pos;
-				Texture: vt;
-				Invert: true;
-
-				apply Fuse.Drawing.PreMultipliedAlphaCompositing;
-				DepthTestEnabled: false;
-			};
-		}
 	}
 }


### PR DESCRIPTION
We blit a lot of images in Fuselibs. And draw-statements have made that very easy to open-code. However, the future of draw-statements in uno is a bit uncertain. So let's prepare a bit for moving away from them.

This PR introduce a general-purpose blitter, that has an interface that is trivial to implement with plain OpenGL code if needed.

The net-result is a reduction of 9 draw-statements, while keeping all features(*) intact.