### PR TITLE
Fix notification regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## 1.4.0
 
+### Notifications
+- Fix regression causing iOS apps not to be accepted to the Store apparently due to use of push-notifications even though they are not used in the project.
+
 ### TextInput
 - Fixed issue on android where placeholder text on a `<TextInput IsPassword="true" />` would be drawn as password dots
 

--- a/Source/Fuse.LocalNotifications/Fuse.LocalNotifications.unoproj
+++ b/Source/Fuse.LocalNotifications/Fuse.LocalNotifications.unoproj
@@ -20,6 +20,7 @@
   ],
   "Includes": [
     "iOS/Impl.uno:Source",
+    "iOS/Impl.uxl:Extensions",
     "iOS/AppDelegateLocalNotify.h:CHeader:iOS",
     "iOS/AppDelegateLocalNotify.mm:CSource:iOS",
     "Android/Impl.uno:Source",

--- a/Source/Fuse.LocalNotifications/iOS/Impl.uxl
+++ b/Source/Fuse.LocalNotifications/iOS/Impl.uxl
@@ -1,0 +1,3 @@
+<Extensions Backend="CPlusPlus" Condition="iOS">
+	<Define AppDelegate.LocalNotificationMethods="1" />
+</Extensions>

--- a/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
+++ b/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
@@ -24,6 +24,7 @@
     "JS.uno:Source",
 
     "iOS/Impl.uno:Source",
+    "iOS/Impl.uxl:Extensions",
     "iOS/AppDelegatePushNotify.h:CHeader:iOS",
     "iOS/AppDelegatePushNotify.mm:CSource:iOS",
 

--- a/Source/Fuse.PushNotifications/iOS/Impl.uxl
+++ b/Source/Fuse.PushNotifications/iOS/Impl.uxl
@@ -1,0 +1,3 @@
+<Extensions Backend="CPlusPlus" Condition="iOS">
+	<Define AppDelegate.PushNotificationMethods="1" />
+</Extensions>


### PR DESCRIPTION
If you implement the notification methods on the AppDelegate then apple
detect this and require you to declare your usage of the
notification's feature, *even if* you arent actually using it,
otherwise your app does not get approved.

Uno now wraps the AppDelegate methods in `#if` so we use declare to
include those methods when neccessary

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
