### PR TITLE
Revert "Avoid code duplication on Android + minor formatting fix"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### WebView
 - Exported the methods goBack, goForward, reload and stop for use in FuseJS
+- Fixed regression in 1.3 that broke WebView when using URISchemeHandler
 
 ### ScrollViewPager
 - Fixed a NullReferenceError that could happen while using ScrollViewPager in preview

--- a/Source/Fuse.Controls.WebView/Android/WebView.uno
+++ b/Source/Fuse.Controls.WebView/Android/WebView.uno
@@ -45,29 +45,20 @@ namespace Fuse.Android.Controls
 			_webChromeClientHandle = _webViewHandle.CreateAndSetWebChromeClient(OnProgressChanged);				
 			_webViewClientHandle = _webViewHandle.CreateAndSetWebViewClient(
 				OnPageLoaded, 
-				OnBeginLoading, 
-				OnUrlChanged,
-				MatchedURISchemeHandler
+				OnBeginloading, 
+				OnUrlChanged, 
+				OnCustomURI, 
+				schemes, 
+				HasURISchemeHandler
 			);
 			_uriSchemes = schemes;
 
 			_webViewHost.WebViewClient = this;
 		}
 		
-		public bool MatchedURISchemeHandler(string url)
+		public bool HasURISchemeHandler()
 		{
-			if(URISchemeHandler!=null){
-					return true;
-					foreach(string uri in _uriSchemes)
-					{
-						if(url.IndexOf(uri) == 0)
-						{
-							OnCustomURI(url);
-							return true;
-						}
-					}
-			}
-			return false;
+			return URISchemeHandler!=null;
 		}
 		
 		void OnCustomURI(string url)
@@ -82,7 +73,7 @@ namespace Fuse.Android.Controls
 				PageLoaded(this, EventArgs.Empty);
 		}
 		
-		void OnBeginLoading()
+		void OnBeginloading()
 		{
 			if(BeginLoading!=null)
 				BeginLoading(this, EventArgs.Empty);
@@ -182,8 +173,17 @@ namespace Fuse.Android.Controls
 		{
 			if (url == null || url== "") url = "about:blank";
 			//This extra check is needed on android since setting the Url directly doesn't trigger shouldOverrideUrlLoading
-			if(MatchedURISchemeHandler(url))
-				return;
+			if(HasURISchemeHandler())
+			{
+				foreach(string uri in _uriSchemes)
+				{
+					if(url.IndexOf(uri) == 0)
+					{
+						OnCustomURI(url);
+						return;
+					}
+				}
+			}
 			_webViewHandle.LoadUrl(url);
 			OnHistoryChanged();
 		}

--- a/Source/Fuse.Controls.WebView/Android/WebViewForeign.uno
+++ b/Source/Fuse.Controls.WebView/Android/WebViewForeign.uno
@@ -43,9 +43,9 @@ namespace Fuse.Android.Controls.WebViewUtils
 		@}
 		
 		[Foreign(Language.Java)]
-		public extern (Android) static Java.Object CreateAndSetWebViewClient(this Java.Object webViewHandle, Action loaded, Action started, Action changed, Func<string, bool> matchedUriSchemeHandler)
+		public extern (Android) static Java.Object CreateAndSetWebViewClient(this Java.Object webViewHandle, Action loaded, Action started, Action changed, Action<string> onCustomURI, string[] customURIs, Func<bool> hasUriSchemeHandler)
 		@{
-			FuseWebViewClient client = new FuseWebViewClient(loaded, started, changed, matchedUriSchemeHandler);
+			FuseWebViewClient client = new FuseWebViewClient(loaded, started, changed, onCustomURI, customURIs, hasUriSchemeHandler);
 			((WebView)webViewHandle).setWebViewClient(client);
 			return client;
 		@}


### PR DESCRIPTION
This reverts commit df7e740c2b6607004c955c5f0d87f04a21809e7c, which
broke WebView when used with URISchemeHandler.

Fixes https://github.com/fusetools/fuselibs-public/issues/617.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
