### PR TITLE
Fuse.Elements: unpin CacheFramebuffers on Exceptions

### DIFF
--- a/Source/Fuse.Elements/Caching/ElementAtlas.uno
+++ b/Source/Fuse.Elements/Caching/ElementAtlas.uno
@@ -137,15 +137,22 @@ namespace Fuse.Elements
 		public framebuffer PinAndValidateFramebuffer(DrawContext dc)
 		{
 			var fb = _framebuffer.Pin();
-
-			if (_invalidElements > 0)
+			try
 			{
-				Rect scissorRectInClipSpace = GetScissorRectInClipSpace(dc);
-				bool drawAll = _invalidElements == _elements.Count;
-				FillFramebuffer(dc, fb, drawAll, scissorRectInClipSpace);
-			}
+				if (_invalidElements > 0)
+				{
+					Rect scissorRectInClipSpace = GetScissorRectInClipSpace(dc);
+					bool drawAll = _invalidElements == _elements.Count;
+					FillFramebuffer(dc, fb, drawAll, scissorRectInClipSpace);
+				}
 
-			return fb;
+				return fb;
+			}
+			catch (Exception e)
+			{
+				_framebuffer.Unpin();
+				throw;
+			}
 		}
 
 		public void Unpin()


### PR DESCRIPTION
This code wasn't very exception-safe, and leaks pins on
CacheFramebuffers on errors. Let's clean up this by handling the errors
and explicitly unpinning.

In the future, it might be an idea to use an IDisposable + using pattern
to avoid having to do this manually. This is however a bit easier said
than done, as we need to pin a variable amount of CacheFramebuffers in
some cases. So let's just put a band-aid on here for now.

This was noticed while locally introducing a bug that made the device
run out of memory during rendering, causing test-failures claiming we
were unpinning while going to the background.

This PR contains:
- [ ] ~Changelog~ Has only been artificially triggered, probably not currently possible to trigger
- [ ] ~Tests~ I don't know of a good way of injecting an exception into the right location to trigger this problem.
