### PR TITLE
Remove redundant _context checks during ThreadWorker creation

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
@@ -83,17 +83,15 @@ namespace Fuse.Scripting.JavaScript
 		{
 			try
 			{
+				_context = Fuse.Scripting.JavaScript.JSContext.Create();
+
 				if (_context == null)
 				{
-					_context = Fuse.Scripting.JavaScript.JSContext.Create();
-					if (_context == null)
-					{
-						throw new Exception("Could not create script context");
-					}
-					UpdateManager.AddAction(CheckAndThrow);
-
-					_fuseJS = new Fuse.Reactive.FuseJS.Builtins(_context);
+					throw new Exception("Could not create script context");
 				}
+				UpdateManager.AddAction(CheckAndThrow);
+
+				_fuseJS = new Fuse.Reactive.FuseJS.Builtins(_context);
 			}
 			finally
 			{


### PR DESCRIPTION
- `RunInner` is private and can only be run from `Run`
- `Run` is private and is only every invoked from the constructor
- _context has no default value at construction so must be null at the start of `Run` & `RunInner`

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
