### PR TITLE
removes invalid test for type

### DIFF
--- a/Source/Fuse.Controls/Tests/StatusBarBackground.Test.uno
+++ b/Source/Fuse.Controls/Tests/StatusBarBackground.Test.uno
@@ -17,13 +17,5 @@ namespace Fuse.Controls.Test
 			var s = new TopFrameBackground();
 			ElementPropertyTester.All(s);
 		}
-
-		[Test]
-		public void AllLayoutTets()
-		{
-			var s = new TopFrameBackground();
-			ElementLayoutTester.All(s);
-		}
-
 	}
 }


### PR DESCRIPTION
fixes https://github.com/fusetools/fuselibs-public/issues/691

This test isn't valid for TopFrameBackground, or any other "frame" that adapts to OS system size.

This PR contains:
- [ ] ~Changelog~ internal test change
- [ ] ~Documentation~
- [ ] ~Tests~ Removes an invalid one
