### PR TITLE
Fuse.Controls.Navigation.Tests: work around #693

### DIFF
--- a/Source/Fuse.Controls.Navigation/Tests/PageControl.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/PageControl.Test.uno
@@ -46,7 +46,7 @@ namespace Fuse.Controls.Test
 				Assert.AreEqual( "Page1", p.R.Value );
 				
 				p.RouteGoto4.Pulse();
-				root.StepFrameJS();
+				root.MultiStepFrameJS(2);
 				Assert.AreEqual( 3, p.PC.ActiveIndex );
 				Assert.AreEqual( p.D, p.PC.Active );
 				Assert.AreEqual( "3", p.Q.Value );


### PR DESCRIPTION
This makes the test pass consistently for now, but should be
investigated for a proper fix.