### PR TITLE
Fuse.Drawing: reduce textureTransform to float3x3

### DIFF
--- a/Source/Fuse.Controls.Primitives/Image.Visual.uno
+++ b/Source/Fuse.Controls.Primitives/Image.Visual.uno
@@ -86,22 +86,22 @@ namespace Fuse.Controls
 			DrawVisualColor(dc, Color);
 		}
 
-		internal static float4x4 TransformFromImageOrientation(ImageOrientation orientation)
+		internal static float3x3 TransformFromImageOrientation(ImageOrientation orientation)
 		{
-			var transform = float4x4.Identity;
+			var transform = float3x3.Identity;
 
 			if (orientation.HasFlag(ImageOrientation.FlipVertical))
 			{
 				transform.M22 = -1;
-				transform.M42 =  1;
+				transform.M32 =  1;
 			}
 
 			if (orientation.HasFlag(ImageOrientation.Rotate180))
 			{
 				transform.M11 = -1;
 				transform.M22 = -transform.M22;
-				transform.M41 =  1;
-				transform.M42 =  1 - transform.M42;
+				transform.M31 =  1;
+				transform.M32 =  1 - transform.M32;
 			}
 
 			if (orientation.HasFlag(ImageOrientation.Rotate90))
@@ -112,9 +112,9 @@ namespace Fuse.Controls
 				transform.M21 = transform.M22;
 				transform.M22 = 0;
 
-				var tmp = transform.M41;
-				transform.M41 = transform.M42;
-				transform.M42 = 1 - tmp;
+				var tmp = transform.M31;
+				transform.M31 = transform.M32;
+				transform.M32 = 1 - tmp;
 			}
 
 			return transform;
@@ -189,7 +189,7 @@ namespace Fuse.Controls
 
 		public void Draw(DrawContext dc, Visual element, float2 offset,
 			float2 size, float2 uvPosition, float2 uvSize,
-			float4x4 imageTransform,
+			float3x3 imageTransform,
 			Texture2D tex, ResampleMode resampleMode,
 			float4 Color )
 		{

--- a/Source/Fuse.Controls.Primitives/Tests/Image.Test.uno
+++ b/Source/Fuse.Controls.Primitives/Tests/Image.Test.uno
@@ -92,7 +92,7 @@ namespace Fuse.Controls.Primitives.Test
 			}
 		}
 
-		static float4x4 TransformFromImageOrientationReference(ImageOrientation orientation)
+		static float3x3 TransformFromImageOrientationReference(ImageOrientation orientation)
 		{
 			var flip = Matrix.Scaling(1,1,1);
 			var rotation = Matrix.RotationZ(0.0f);
@@ -109,7 +109,12 @@ namespace Fuse.Controls.Primitives.Test
 
 			var translateToCenter = Matrix.Translation(0.5f,0.5f,0.0f);
 			var translateBack = Matrix.Translation(-0.5f,-0.5f,0.0f);
-			return Matrix.Mul(translateBack, flip, rotation, translateToCenter);
+			var result = Matrix.Mul(translateBack, flip, rotation, translateToCenter);
+			return float3x3(
+				result.M11, result.M12, result.M13,
+				result.M21, result.M22, result.M23,
+				result.M41, result.M42, result.M44,
+			);
 		}
 
 		public void TestImageOrientation(ImageOrientation orientation, [CallerFilePath] string filePath = "", [CallerLineNumber] int lineNumber = 0, [CallerMemberName] string memberName = "")
@@ -120,18 +125,8 @@ namespace Fuse.Controls.Primitives.Test
 			Assert.AreEqual(expected, transform, tolerance, filePath, lineNumber, memberName);
 
 			Assert.AreEqual(0, transform.M13);
-			Assert.AreEqual(0, transform.M14);
-
 			Assert.AreEqual(0, transform.M23);
-			Assert.AreEqual(0, transform.M24);
-
-			Assert.AreEqual(0, transform.M31);
-			Assert.AreEqual(0, transform.M32);
 			Assert.AreEqual(1, transform.M33);
-			Assert.AreEqual(0, transform.M34);
-
-			Assert.AreEqual(0, transform.M43);
-			Assert.AreEqual(1, transform.M44);
 		}
 
 		[Test]

--- a/Source/Fuse.Drawing/Blitter.uno
+++ b/Source/Fuse.Drawing/Blitter.uno
@@ -9,11 +9,11 @@ namespace Fuse.Drawing
 
 		public void Blit(texture2D texture, Rect rect, float4x4 localToClipTransform, float opacity = 1.0f, bool flipY = false, PolygonFace cullFace = PolygonFace.None)
 		{
-			float4x4 textureTransform = float4x4.Identity;
+			float3x3 textureTransform = float3x3.Identity;
 			if (flipY)
 			{
 				textureTransform.M22 = -1;
-				textureTransform.M42 =  1;
+				textureTransform.M32 =  1;
 			}
 
 			Blit(texture, SamplerState.LinearClamp, true,
@@ -23,7 +23,7 @@ namespace Fuse.Drawing
 		}
 
 		public void Blit(Texture2D texture, SamplerState samplerState, bool preMultiplied,
-		                 Rect textureRect, float4x4 textureTransform,
+		                 Rect textureRect, float3x3 textureTransform,
 		                 Rect localRect, float4x4 localToClipTransform,
 		                 float4 color, PolygonFace cullFace = PolygonFace.None)
 		{
@@ -74,7 +74,7 @@ namespace Fuse.Drawing
 				float2 LocalVertex: localRect.Minimum + v * localRect.Size;
 				ClipPosition: Vector.Transform(LocalVertex, localToClipTransform);
 				float2 TexCoord: textureRect.Minimum + v * textureRect.Size;
-				TexCoord: Vector.TransformCoordinate(prev, textureTransform);
+				TexCoord: Vector.Transform(float3(prev, 1.0f), textureTransform).XY;
 				PixelColor: sample(texture, TexCoord, samplerState) * color;
 			};
 		}


### PR DESCRIPTION
A float3x3 is sufficient to express all two-dimentional linear
transformations, using 4x4 is just wasteful. Let's take advantage
of this, and save some computations.