### PR TITLE
add missing references to Fuse.Controls

### DIFF
--- a/Source/Fuse.Controls.DatePicker/Fuse.Controls.DatePicker.unoproj
+++ b/Source/Fuse.Controls.DatePicker/Fuse.Controls.DatePicker.unoproj
@@ -8,6 +8,7 @@
   },
   "Projects": [
     "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Controls/Fuse.Controls.unoproj",
     "../Fuse.Controls.Native/Fuse.Controls.Native.unoproj",
     "../Fuse.Controls.Panels/Fuse.Controls.Panels.unoproj",
     "../Fuse.Controls.Primitives/Fuse.Controls.Primitives.unoproj",

--- a/Source/Fuse.Controls.TimePicker/Fuse.Controls.TimePicker.unoproj
+++ b/Source/Fuse.Controls.TimePicker/Fuse.Controls.TimePicker.unoproj
@@ -8,6 +8,7 @@
   },
   "Projects": [
     "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Controls/Fuse.Controls.unoproj",
     "../Fuse.Controls.Native/Fuse.Controls.Native.unoproj",
     "../Fuse.Controls.Panels/Fuse.Controls.Panels.unoproj",
     "../Fuse.Controls.Primitives/Fuse.Controls.Primitives.unoproj",


### PR DESCRIPTION
This solves compiler errors on uno/feature/lazy-dotnet:
```
lib\fuselibs\Source\Fuse.Controls.DatePicker\.uno\ux13\Fuse.Controls.DatePicker.g.uno(35): E0000: 'Fuse.Controls.Control.set_Background(Fuse.Drawing.Brush)' is not accessible from 'Fuse.Controls.DatePicker.Template.New()' because Fuse.Controls isn't referenced by Fuse.Controls.DatePicker
lib\fuselibs\Source\Fuse.Controls.DatePicker\DatePicker.uno(132): E0000: 'Fuse.Controls.Control.get_NativeView()' is not accessible from 'Fuse.Controls.DatePickerBase.get_DatePickerView()' because Fuse.Controls isn't referenced by Fuse.Controls.DatePicker
lib\fuselibs\Source\Fuse.Controls.TimePicker\.uno\ux13\Fuse.Controls.TimePicker.g.uno(35): E0000: 'Fuse.Controls.Control.set_Background(Fuse.Drawing.Brush)' is not accessible from 'Fuse.Controls.TimePicker.Template.New()' because Fuse.Controls isn't referenced by Fuse.Controls.TimePicker
lib\fuselibs\Source\Fuse.Controls.TimePicker\TimePicker.uno(100): E0000: 'Fuse.Controls.Control.get_NativeView()' is not accessible from 'Fuse.Controls.TimePickerBase.get_TimePickerView()' because Fuse.Controls isn't referenced by Fuse.Controls.TimePicker
```

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
