### PR TITLE
Move FuseJS field from ThreadWorker to JSContext

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/Context.uno
@@ -14,6 +14,8 @@ namespace Fuse.Scripting.JavaScript
 		Function _setSuperclass;
 		int _reflectionDepth;
 
+		internal Fuse.Reactive.FuseJS.Builtins FuseJS { private set; get;}
+
 		public override Fuse.Scripting.IThreadWorker ThreadWorker
 		{
 			get
@@ -32,10 +34,18 @@ namespace Fuse.Scripting.JavaScript
 
 		internal static JSContext Create()
 		{
-			if defined(USE_JAVASCRIPTCORE) return new Fuse.Scripting.JavaScriptCore.Context();
-			else if defined(USE_V8) return new Fuse.Scripting.V8.Context();
-			else if defined(USE_DUKTAPE) return new Fuse.Scripting.Duktape.Context();
+			JSContext result;
+
+			if defined(USE_JAVASCRIPTCORE) result = new Fuse.Scripting.JavaScriptCore.Context();
+			else if defined(USE_V8) result = new Fuse.Scripting.V8.Context();
+			else if defined(USE_DUKTAPE) result = new Fuse.Scripting.Duktape.Context();
 			else throw new Exception("No JavaScript VM available for this platform");
+
+			// The reason for populating FuseJS here and not in the constructor is that if the
+			// context is not fully constructed when passed to `new Builtins` a segmentation fault
+			// occurs on (at least some) c++ backends
+			result.FuseJS = new Fuse.Reactive.FuseJS.Builtins(result);
+			return result;
 		}
 
 		public override object Wrap(object obj)
@@ -95,15 +105,15 @@ namespace Fuse.Scripting.JavaScript
 			var o = obj as Scripting.Object;
 			if (o != null)
 			{
-				if (o.InstanceOf(Fuse.Scripting.JavaScript.ThreadWorker.FuseJS.Observable))
+				if (o.InstanceOf(FuseJS.Observable))
 				{
 					return new Observable(this, (ThreadWorker)ThreadWorker, o, false);
 				}
-				else if (o.InstanceOf(Fuse.Scripting.JavaScript.ThreadWorker.FuseJS.Date))
+				else if (o.InstanceOf(FuseJS.Date))
 				{
 					return DateTimeConverterHelpers.ConvertDateToDateTime(this, o);
 				}
-				else if (o.InstanceOf(Fuse.Scripting.JavaScript.ThreadWorker.FuseJS.TreeObservable))
+				else if (o.InstanceOf(FuseJS.TreeObservable))
 				{
 					return new TreeObservable(this, o);
 				}

--- a/Source/Fuse.Scripting.JavaScript/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/Context.uno
@@ -14,7 +14,7 @@ namespace Fuse.Scripting.JavaScript
 		Function _setSuperclass;
 		int _reflectionDepth;
 
-		internal Fuse.Reactive.FuseJS.Builtins FuseJS { private set; get;}
+		Fuse.Reactive.FuseJS.Builtins FuseJS { private set; internal get;}
 
 		public override Fuse.Scripting.IThreadWorker ThreadWorker
 		{
@@ -157,7 +157,7 @@ namespace Fuse.Scripting.JavaScript
 				if (inlineMethod != null)
 				{
 					var m = (Function)Evaluate(sc.Type.FullName + "." + inlineMethod.Name + " (ScriptMethod)", "(function(cl, Observable) { cl.prototype." + inlineMethod.Name + " = " + inlineMethod.Code + "; })");
-					m.Call(this, cl, ((ThreadWorker)ThreadWorker).Observable);
+					m.Call(this, cl, FuseJS.Observable);
 					continue;
 				}
 

--- a/Source/Fuse.Scripting.JavaScript/Observable.uno
+++ b/Source/Fuse.Scripting.JavaScript/Observable.uno
@@ -257,7 +257,8 @@ namespace Fuse.Scripting.JavaScript
 
 		internal static Observable Create(Scripting.Context context, ThreadWorker worker)
 		{
-			return new Observable(context, worker, (Scripting.Object)worker.Observable.Call(context), true);
+			var jsContext = (JSContext)context;
+			return new Observable(context, worker, (Scripting.Object)jsContext.FuseJS.Observable.Call(context), true);
 		}
 
 		int ToInt(object obj)

--- a/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
@@ -14,12 +14,9 @@ namespace Fuse.Scripting.JavaScript
 
 	class ThreadWorker: IDisposable, IThreadWorker
 	{
-		public Function Observable { get { return FuseJS.Observable; } }
+		public Function Observable { get { return _context.FuseJS.Observable; } }
 
 		JSContext _context;
-
-		static Fuse.Reactive.FuseJS.Builtins _fuseJS;
-		public static Fuse.Reactive.FuseJS.Builtins FuseJS { get { return _fuseJS; } }
 
 		readonly Thread _thread;
 
@@ -90,8 +87,6 @@ namespace Fuse.Scripting.JavaScript
 					throw new Exception("Could not create script context");
 				}
 				UpdateManager.AddAction(CheckAndThrow);
-
-				_fuseJS = new Fuse.Reactive.FuseJS.Builtins(_context);
 			}
 			finally
 			{
@@ -136,7 +131,7 @@ namespace Fuse.Scripting.JavaScript
 
 				try
 				{
-					_fuseJS.UpdateModules(_context);
+					_context.FuseJS.UpdateModules(_context);
 				}
 				catch (Exception e)
 				{

--- a/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
@@ -14,8 +14,6 @@ namespace Fuse.Scripting.JavaScript
 
 	class ThreadWorker: IDisposable, IThreadWorker
 	{
-		public Function Observable { get { return _context.FuseJS.Observable; } }
-
 		JSContext _context;
 
 		readonly Thread _thread;

--- a/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
@@ -79,11 +79,6 @@ namespace Fuse.Scripting.JavaScript
 			try
 			{
 				_context = Fuse.Scripting.JavaScript.JSContext.Create();
-
-				if (_context == null)
-				{
-					throw new Exception("Could not create script context");
-				}
 				UpdateManager.AddAction(CheckAndThrow);
 			}
 			finally

--- a/Source/Fuse.Scripting.JavaScript/TypeWrapper.uno
+++ b/Source/Fuse.Scripting.JavaScript/TypeWrapper.uno
@@ -19,7 +19,7 @@ namespace Fuse.Scripting.JavaScript
 			{
 				var sobj = (Scripting.Object)obj;
 
-				if (sobj.InstanceOf(ThreadWorker.FuseJS.Date))
+				if (sobj.InstanceOf(context.FuseJS.Date))
 				{
 					return DateTimeConverterHelpers.ConvertDateToDateTime(context, sobj);
 				}
@@ -51,7 +51,7 @@ namespace Fuse.Scripting.JavaScript
 			else if (dc is int2) return ToArray(context, (int2)dc);
 			else if (dc is int3) return ToArray(context, (int3)dc);
 			else if (dc is int4) return ToArray(context, (int4)dc);
-			else if (dc is DateTime) return DateTimeConverterHelpers.ConvertDateTimeToJSDate(context, (DateTime)dc, ThreadWorker.FuseJS.DateCtor);
+			else if (dc is DateTime) return DateTimeConverterHelpers.ConvertDateTimeToJSDate(context, (DateTime)dc, context.FuseJS.DateCtor);
 			else if (dc.GetType().IsClass) return WrapScriptClass(context, dc);
 			else if (dc.GetType().IsEnum) return dc.ToString();
 			else return dc;


### PR DESCRIPTION
The `FuseJS.Builtins` object is constructed with a specific context and so is tied to it. This means it is only safe to use from that context. Due to this we move it to the context and make it non-static.

Also we are trying to make the thread worker more focused on the thread communication so fits with that goal.

No changelog as it only effects an internal field

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
