### PR TITLE
ThreadWorker's public api is safe so we can remove the _ready event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `DateTimeConverterHelpers` moved to its own uno file.
 - `IMirror`'s `Reflect` now takes a `Scripting.Context`
 - IThreadWorker no longer implement IDispatcher
+- `Fuse.Scripting.JavaScript`'s `ThreadWorker` no longer blocks on construction
 
 # 1.4
 

--- a/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
@@ -18,7 +18,6 @@ namespace Fuse.Scripting.JavaScript
 
 		readonly Thread _thread;
 
-		readonly ManualResetEvent _ready = new ManualResetEvent(false);
 		readonly ManualResetEvent _idle = new ManualResetEvent(true);
 		readonly ManualResetEvent _terminate = new ManualResetEvent(false);
 
@@ -38,8 +37,6 @@ namespace Fuse.Scripting.JavaScript
 			}
 
 			_thread.Start();
-			_ready.WaitOne();
-			_ready.Dispose();
 		}
 
 		void OnTerminating(Fuse.Platform.ApplicationState newState)
@@ -76,15 +73,8 @@ namespace Fuse.Scripting.JavaScript
 
 		void RunInner()
 		{
-			try
-			{
-				_context = Fuse.Scripting.JavaScript.JSContext.Create();
-				UpdateManager.AddAction(CheckAndThrow);
-			}
-			finally
-			{
-				_ready.Set();
-			}
+			_context = Fuse.Scripting.JavaScript.JSContext.Create();
+			UpdateManager.AddAction(CheckAndThrow);
 
 			double t = Uno.Diagnostics.Clock.GetSeconds();
 


### PR DESCRIPTION
Previously there were a number of public fields that would be
initialized during RunInner and so we couldnt trust other code to use
the ThreadWorker without potentially causing issues.

Now the public api revolves around Invoke with is a `ConcurrentQueue`,
thus I think we are in a good place to loosen the construction time
blocking we had previously

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
