### PR TITLE
Scripting cleanups

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/Context.uno
@@ -105,15 +105,15 @@ namespace Fuse.Scripting.JavaScript
 			var o = obj as Scripting.Object;
 			if (o != null)
 			{
-				if (o.InstanceOf(FuseJS.Observable))
+				if (o.InstanceOf(this, FuseJS.Observable))
 				{
 					return new Observable(this, (ThreadWorker)ThreadWorker, o, false);
 				}
-				else if (o.InstanceOf(FuseJS.Date))
+				else if (o.InstanceOf(this, FuseJS.Date))
 				{
 					return DateTimeConverterHelpers.ConvertDateToDateTime(this, o);
 				}
-				else if (o.InstanceOf(FuseJS.TreeObservable))
+				else if (o.InstanceOf(this, FuseJS.TreeObservable))
 				{
 					return new TreeObservable(this, o);
 				}

--- a/Source/Fuse.Scripting.JavaScript/Duktape/Function.uno
+++ b/Source/Fuse.Scripting.JavaScript/Duktape/Function.uno
@@ -33,7 +33,7 @@ namespace Fuse.Scripting.Duktape
 			return _handle.GetHashCode();
 		}
 
-		public override Fuse.Scripting.Object Construct(params object[] args)
+		public override Fuse.Scripting.Object Construct(Scripting.Context context, params object[] args)
 		{
 			_ctx.DukContext.push_heapptr(_handle);
 			var argc = args.Length;

--- a/Source/Fuse.Scripting.JavaScript/Duktape/Object.uno
+++ b/Source/Fuse.Scripting.JavaScript/Duktape/Object.uno
@@ -33,7 +33,7 @@ namespace Fuse.Scripting.Duktape
 			return _handle.GetHashCode();
 		}
 
-		public override bool InstanceOf(Fuse.Scripting.Function type)
+		public override bool InstanceOf(Scripting.Context context, Fuse.Scripting.Function type)
 		{
 			var func = type as Function;
 			if (func == null) return false;

--- a/Source/Fuse.Scripting.JavaScript/FuseJS/Http.uno
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/Http.uno
@@ -60,14 +60,24 @@ namespace Fuse.Reactive.FuseJS
 				_worker = worker;
 			}
 
-			public void Invoke(Action action)
+			class ActionClosure
 			{
-				_worker.Invoke<Action>(DoIt, action);
+				readonly Action _action;
+
+				public ActionClosure(Action action)
+				{
+					_action = action;
+				}
+
+				public void Run(Context context)
+				{
+					_action(); // drop Context, because HTTP doesn't care
+				}
 			}
 
-			public void DoIt(Scripting.Context context, Action action)
+			public void Invoke(Action action)
 			{
-				action();
+				_worker.Invoke(new ActionClosure(action).Run);
 			}
 		}
 

--- a/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Function.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Function.uno
@@ -38,8 +38,11 @@ namespace Fuse.Scripting.JavaScriptCore
 			return result;
 		}
 
-		public override Scripting.Object Construct(params object[] args)
+		public override Scripting.Object Construct(Scripting.Context context, params object[] args)
 		{
+			// Ensure this function is being called from the context/vm it belongs to
+			assert context == _context;
+
 			Scripting.Object result = null;
 			using (var vm = new Context.EnterVM(_context))
 				result = (Scripting.Object)_context.Wrap(

--- a/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Object.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Object.uno
@@ -65,7 +65,7 @@ namespace Fuse.Scripting.JavaScriptCore
 			}
 		}
 
-		public override bool InstanceOf(Scripting.Function type)
+		public override bool InstanceOf(Scripting.Context context, Scripting.Function type)
 		{
 			return type is Function
 				&& _value.GetJSValueRef().IsInstanceOfConstructor(

--- a/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
+++ b/Source/Fuse.Scripting.JavaScript/ThreadWorker.uno
@@ -160,11 +160,6 @@ namespace Fuse.Scripting.JavaScript
 			_queue.Enqueue(action);
 		}
 
-		public void Invoke<T>(Uno.Action<Scripting.Context, T> action, T arg0)
-		{
-			Invoke(new ContextClosureOneArg<T>(action, arg0).Run);
-		}
-
 		public void Invoke(Action action)
 		{
 			Invoke(new ContextIgnoringAction(action).Run);
@@ -199,23 +194,6 @@ namespace Fuse.Scripting.JavaScript
 			public void Run(Scripting.Context context)
 			{
 				_action();
-			}
-		}
-
-		class ContextClosureOneArg<T>
-		{
-			T _arg0;
-			Uno.Action<Context, T> _action;
-
-			public ContextClosureOneArg(Uno.Action<Context, T> action, T arg0)
-			{
-				_action = action;
-				_arg0 = arg0;
-			}
-
-			public void Run(Context context)
-			{
-				_action(context, _arg0);
 			}
 		}
 	}

--- a/Source/Fuse.Scripting.JavaScript/TypeWrapper.uno
+++ b/Source/Fuse.Scripting.JavaScript/TypeWrapper.uno
@@ -98,7 +98,7 @@ namespace Fuse.Scripting.JavaScript
 			if (sc == null) return ext;
 
 			var ctor = context.GetClass(sc);
-			var res = ctor.Construct(ext);
+			var res = ctor.Construct(context, ext);
 
 			if (so != null) so.SetScriptObject(res, context);
 			return res;

--- a/Source/Fuse.Scripting.JavaScript/TypeWrapper.uno
+++ b/Source/Fuse.Scripting.JavaScript/TypeWrapper.uno
@@ -19,7 +19,7 @@ namespace Fuse.Scripting.JavaScript
 			{
 				var sobj = (Scripting.Object)obj;
 
-				if (sobj.InstanceOf(context.FuseJS.Date))
+				if (sobj.InstanceOf(context, context.FuseJS.Date))
 				{
 					return DateTimeConverterHelpers.ConvertDateToDateTime(context, sobj);
 				}

--- a/Source/Fuse.Scripting.JavaScript/V8/Debugger.uno
+++ b/Source/Fuse.Scripting.JavaScript/V8/Debugger.uno
@@ -298,7 +298,7 @@ namespace Fuse.Scripting.V8
 							var message = new String(buffer);
 							var cxt = _parent._context._context;
 							Simple.Debug.SendCommand(cxt, message, message.Length);
-							_parent._context.ThreadWorker.Invoke<Simple.JSContext>(ProcessMessages, cxt);
+							_parent._context.ThreadWorker.Invoke(ProcessMessages);
 						}
 					}
 					else
@@ -320,8 +320,9 @@ namespace Fuse.Scripting.V8
 				return this;
 			}
 
-			void ProcessMessages(Scripting.Context uContext, Simple.JSContext sContext)
+			void ProcessMessages(Scripting.Context context)
 			{
+				var sContext = ((Context)context)._context;
 				Simple.Debug.ProcessMessages(sContext);
 			}
 

--- a/Source/Fuse.Scripting.JavaScript/V8/Function.uno
+++ b/Source/Fuse.Scripting.JavaScript/V8/Function.uno
@@ -51,7 +51,7 @@ namespace Fuse.Scripting.V8
 			return result;
 		}
 
-		public override Scripting.Object Construct(params object[] args)
+		public override Scripting.Object Construct(Scripting.Context context, params object[] args)
 		{
 			var cxt = _context._context;
 			Object result = null;

--- a/Source/Fuse.Scripting.JavaScript/V8/Object.uno
+++ b/Source/Fuse.Scripting.JavaScript/V8/Object.uno
@@ -79,7 +79,7 @@ namespace Fuse.Scripting.V8
 			}
 		}
 
-		public override bool InstanceOf(Scripting.Function type)
+		public override bool InstanceOf(Scripting.Context context, Scripting.Function type)
 		{
 			var f = type as Function;
 			return (bool)_context._instanceOf.Call(_context, this, type);

--- a/Source/Fuse.Scripting/AppInitialized.uno
+++ b/Source/Fuse.Scripting/AppInitialized.uno
@@ -16,15 +16,15 @@ namespace Fuse.Scripting
 	{
 		static bool _initialized;
 
-		public static void On(IThreadWorker worker, Action action)
+		public static void On(Context context, Action<Scripting.Context> action)
 		{
 			if (_initialized)
 			{
-				action();
+				action(context);
 			}
 			else
 			{
-				UpdateManager.Dispatcher.Invoke(new Closure(worker, action).Run);
+				UpdateManager.Dispatcher.Invoke(new Closure(context.ThreadWorker, action).Run);
 			}
 		}
 
@@ -36,9 +36,9 @@ namespace Fuse.Scripting
 		class Closure
 		{
 			readonly IThreadWorker _worker;
-			readonly Action _action;
+			readonly Action<Scripting.Context> _action;
 
-			public Closure(IThreadWorker worker, Action action)
+			public Closure(IThreadWorker worker, Action<Scripting.Context> action)
 			{
 				_worker = worker;
 				_action = action;
@@ -46,13 +46,13 @@ namespace Fuse.Scripting
 
 			public void Run()
 			{
-				_worker.Invoke<Action>(RunJS, _action);
+				_worker.Invoke(RunJS);
 			}
 
-			static void RunJS(Scripting.Context context, Action action)
+			void RunJS(Scripting.Context context)
 			{
 				_initialized = true;
-				action();
+				_action(context);
 			}
 		}
 	}

--- a/Source/Fuse.Scripting/Context.uno
+++ b/Source/Fuse.Scripting/Context.uno
@@ -131,7 +131,7 @@ namespace Fuse.Scripting
 		public Object NewError(params object[] args)
 		{
 			_newError = GlobalObject["Error"] as Function;
-			return _newError.Construct(args);
+			return _newError.Construct(this, args);
 		}
 
 		public abstract object Evaluate(string fileName, string code);

--- a/Source/Fuse.Scripting/Context.uno
+++ b/Source/Fuse.Scripting/Context.uno
@@ -10,7 +10,6 @@ namespace Fuse.Scripting
 	public interface IThreadWorker
 	{
 		void Invoke(Uno.Action<Scripting.Context> action);
-		void Invoke<T>(Uno.Action<Scripting.Context, T> action, T arg0);
 	}
 
 	public abstract class Context: Uno.IDisposable

--- a/Source/Fuse.Scripting/NativeEventEmitterModule.uno
+++ b/Source/Fuse.Scripting/NativeEventEmitterModule.uno
@@ -49,7 +49,7 @@ namespace Fuse.Scripting
 			lock (_mutex)
 				foreach (var l in _listeningCallbacks)
 					Dispatch(new OnClosure(l.Item1, l.Item2).On, true);
-			AppInitialized.On(_context.ThreadWorker, OnAppInitialized);
+			AppInitialized.On(context, OnAppInitialized);
 		}
 
 		override object CreateExportsObject(Context c)
@@ -57,12 +57,12 @@ namespace Fuse.Scripting
 			_context = c;
 			_this = EventEmitterModule.GetConstructor(_context).Construct(_eventNames);
 
-			AppInitialized.On(c.ThreadWorker, OnAppInitialized);
+			AppInitialized.On(c, OnAppInitialized);
 
 			return _this;
 		}
 
-		void OnAppInitialized()
+		void OnAppInitialized(Context c)
 		{
 			lock (_mutex)
 			{

--- a/Source/Fuse.Scripting/NativeEventEmitterModule.uno
+++ b/Source/Fuse.Scripting/NativeEventEmitterModule.uno
@@ -55,7 +55,7 @@ namespace Fuse.Scripting
 		override object CreateExportsObject(Context c)
 		{
 			_context = c;
-			_this = EventEmitterModule.GetConstructor(_context).Construct(_eventNames);
+			_this = EventEmitterModule.GetConstructor(c).Construct(c, _eventNames);
 
 			AppInitialized.On(c, OnAppInitialized);
 

--- a/Source/Fuse.Scripting/NativeEventEmitterModule.uno
+++ b/Source/Fuse.Scripting/NativeEventEmitterModule.uno
@@ -124,6 +124,23 @@ namespace Fuse.Scripting
 			return new object[] { "error", context.NewError(reason) };
 		}
 
+		class ActionClosure
+		{
+			readonly Action<Context, Scripting.Object> _action;
+			readonly Scripting.Object _arg;
+
+			public ActionClosure(Action<Context, Scripting.Object> action, Scripting.Object arg)
+			{
+				_action = action;
+				_arg = arg;
+			}
+
+			public void Run(Context context)
+			{
+				_action(context, _arg);
+			}
+		}
+
 		void Dispatch(Action<Context, Scripting.Object> action, bool alwaysQueueEventBeforeInit = false)
 		{
 			lock (_mutex)
@@ -137,7 +154,8 @@ namespace Fuse.Scripting
 					return;
 				}
 			}
-			_context.ThreadWorker.Invoke<Scripting.Object>(action, _this);
+
+			_context.ThreadWorker.Invoke(new ActionClosure(action, _this).Run);
 		}
 
 		/** Connect a @NativeEvent to an event.

--- a/Source/Fuse.Scripting/NativePromise.uno
+++ b/Source/Fuse.Scripting/NativePromise.uno
@@ -86,63 +86,63 @@ namespace Fuse.Scripting
 				return promise.Construct((Callback)new PromiseClosure(_c, future, _converter).Run);
 			}
 		}
-			
-	    class PromiseClosure
-	    {
+
+		class PromiseClosure
+		{
 			Context _c;
-	    	Future<T> _promise;
-	    	Function _resolve = null;
-	    	Function _reject = null;
-	    	ResultConverter<T, TJSResult> _converter;
+			Future<T> _promise;
+			Function _resolve = null;
+			Function _reject = null;
+			ResultConverter<T, TJSResult> _converter;
 			T _result = default(T);
 			Exception _reason;
 
-	    	public PromiseClosure(Context context, Future<T> promise, ResultConverter<T, TJSResult> converter)
-	    	{
+			public PromiseClosure(Context context, Future<T> promise, ResultConverter<T, TJSResult> converter)
+			{
 				_c = context;
-	    		_promise = promise;
-	    		_converter = converter;
-	    	}
+				_promise = promise;
+				_converter = converter;
+			}
 
-	    	public object Run(Context context, object[] args)
-	    	{
-		    	if (args.Length > 0)
-		    		_resolve = args[0] as Function;
+			public object Run(Context context, object[] args)
+			{
+				if (args.Length > 0)
+					_resolve = args[0] as Function;
 
-		    	if (args.Length > 1)
-		    		_reject = args[1] as Function;
+				if (args.Length > 1)
+					_reject = args[1] as Function;
 
-		    	_promise.Then(Resolve, Reject);
+				_promise.Then(Resolve, Reject);
 
-		    	return null;
-	    	}
+				return null;
+			}
 
-	    	void Resolve(T result)
-	    	{
-	    		_result = result;
-	    		if(_resolve != null)
-	    			_c.ThreadWorker.Invoke(this.InternalResolve);
-	    	}
+			void Resolve(T result)
+			{
+				_result = result;
+				if(_resolve != null)
+					_c.ThreadWorker.Invoke(this.InternalResolve);
+			}
 
-	    	void InternalResolve(Scripting.Context context)
-    		{
-    			if(_converter != null)
-    				_resolve.Call(context, _converter(context, _result));
-    			else
-    				_resolve.Call(context, _result);
-    		}
+			void InternalResolve(Scripting.Context context)
+			{
+				if(_converter != null)
+					_resolve.Call(context, _converter(context, _result));
+				else
+					_resolve.Call(context, _result);
+			}
 
-	    	void Reject(Exception reason)
-	    	{
-	    		_reason = reason;
-	    		if(_reject != null)
-	    			_c.ThreadWorker.Invoke(this.InternalReject);
-	    	}
+			void Reject(Exception reason)
+			{
+				_reason = reason;
+				if(_reject != null)
+					_c.ThreadWorker.Invoke(this.InternalReject);
+			}
 
-	    	void InternalReject(Scripting.Context context)
-	    	{
-	    		_reject.Call(context, _reason.Message);
-	    	}
-	    }
+			void InternalReject(Scripting.Context context)
+			{
+				_reject.Call(context, _reason.Message);
+			}
+		}
 	}
 }

--- a/Source/Fuse.Scripting/NativePromise.uno
+++ b/Source/Fuse.Scripting/NativePromise.uno
@@ -82,7 +82,7 @@ namespace Fuse.Scripting
 			{
 				var promise = (Function)context.GlobalObject["Promise"]; // HACK - TODO: get rid of this
 				var future = _factory(args);
-				return promise.Construct((Callback)new PromiseClosure(context.ThreadWorker, future, _converter).Run);
+				return promise.Construct(context, (Callback)new PromiseClosure(context.ThreadWorker, future, _converter).Run);
 			}
 		}
 

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -194,7 +194,7 @@ namespace Fuse.Scripting
 			else
 				promiseClosure.OnFutureReady(InvokeFutureFactory(c, self, args));
 
-			return promise.Construct((Callback)promiseClosure.Run);
+			return promise.Construct(c, (Callback)promiseClosure.Run);
 		}
 
 		class FutureClosure

--- a/Source/Fuse.Scripting/Tests/Scripting.Test.uno
+++ b/Source/Fuse.Scripting/Tests/Scripting.Test.uno
@@ -80,10 +80,10 @@ namespace Fuse.Scripting.Test
 				Assert.AreEqual(25, AsInt(callResult));
 				Assert.IsTrue(
 					(((Scripting.Object)context.Evaluate("Objects instanceof", "new Date()")))
-					.InstanceOf((Scripting.Function)context.Evaluate("Objects instanceof 2", "Date")));
+					.InstanceOf(context, (Scripting.Function)context.Evaluate("Objects instanceof 2", "Date")));
 				Assert.IsFalse(
 					obj
-					.InstanceOf((Scripting.Function)context.Evaluate("Objects instanceof 3", "Date")));
+					.InstanceOf(context,(Scripting.Function)context.Evaluate("Objects instanceof 3", "Date")));
 			}
 		}
 

--- a/Source/Fuse.Scripting/Tests/Scripting.Test.uno
+++ b/Source/Fuse.Scripting/Tests/Scripting.Test.uno
@@ -135,7 +135,7 @@ namespace Fuse.Scripting.Test
 				var str = context.Evaluate("Functions construct", "String") as Scripting.Function;
 				Assert.IsFalse(str == null);
 				Assert.IsFalse(fun.Equals(str));
-				var obj = str.Construct(new object[] { "abc 123" });
+				var obj = str.Construct(context, new object[] { "abc 123" });
 				Assert.IsFalse(obj == null);
 				var i = obj.CallMethod(context, "indexOf", new object[] { "1" });
 				Assert.AreEqual(4, AsInt(i));
@@ -230,7 +230,7 @@ namespace Fuse.Scripting.Test
 				var f = context.Evaluate(
 					"CallbackAsConstructor",
 					"(function(f) { return new f(12, 13); })") as Scripting.Function;
-				var res = f.Construct(new object[] { new Scripting.Callback(new ContextObjectFactory().Callback) });
+				var res = f.Construct(context, new object[] { new Scripting.Callback(new ContextObjectFactory().Callback) });
 				Assert.IsTrue(res is Scripting.Object);
 				Assert.IsTrue(res.ContainsKey("x"));
 				Assert.IsTrue(res.ContainsKey("y"));

--- a/Source/Fuse.Scripting/Types.uno
+++ b/Source/Fuse.Scripting/Types.uno
@@ -64,7 +64,7 @@ namespace Fuse.Scripting
 			Call(context, args);
 		}
 
-		public abstract Scripting.Object Construct(params object[] args);
+		public abstract Scripting.Object Construct(Context context, params object[] args);
 		public abstract bool Equals(Function f);
 
 		public override bool Equals(object o)

--- a/Source/Fuse.Scripting/Types.uno
+++ b/Source/Fuse.Scripting/Types.uno
@@ -34,7 +34,7 @@ namespace Fuse.Scripting
 		/** @advanced */
 		public abstract object this[string key] { get; set; }
 		public abstract string[] Keys { get; }
-		public abstract bool InstanceOf(Function type);
+		public abstract bool InstanceOf(Context context, Function type);
 		public abstract object CallMethod(Context context, string name, params object[] args);
 		public abstract bool ContainsKey(string key);
 		public abstract bool Equals(Object o);


### PR DESCRIPTION
Here's a bunch of cleanups to Fuse.Scripting / Fuse.Scripting.JavaScript to try to ensure that things won't get called on the wrong thread.

This particular patch doesn't really change any threading, it's just cleanups.