### PR TITLE
Adds object based routing to the router/NavigationControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Router
+- Added object support to `Router` script functions, such as `goto`, `push`, `bookmark`, etc. This mirrors the upcoming Model ability to use objects as path elements.
+
 ## TextView
 - Fixed iOS issue where the return key would display "next" instead of "return".
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Router
 - Added object support to `Router` script functions, such as `goto`, `push`, `bookmark`, etc. This mirrors the upcoming Model ability to use objects as path elements.
+- Added object support to `Modify/Push/GotoRoute` actions.
 
 ## TextView
 - Fixed iOS issue where the return key would display "next" instead of "return".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Router
 - Added object support to `Router` script functions, such as `goto`, `push`, `bookmark`, etc. This mirrors the upcoming Model ability to use objects as path elements.
 - Added object support to `Modify/Push/GotoRoute` actions.
+- Added `NavigationControl.modifyPath` to the JavaScript interface. This allows extended local path manipulation without using a router.
 
 ## TextView
 - Fixed iOS issue where the return key would display "next" instead of "return".

--- a/Source/Fuse.Controls.Navigation/NavigationControl.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.uno
@@ -113,7 +113,7 @@ namespace Fuse.Controls
 		
 		//the outlet page on which this control resides.
 		protected Visual AncestorPage { private set; get; }
-		protected RouterPage AncestorRouterPage { private set; get; }
+		internal protected RouterPage AncestorRouterPage { private set; get; }
 
 		/* 
 			This affects the structure of navigation, in particular by associating PageData.RouterPage's

--- a/Source/Fuse.Controls.Navigation/Tests/Navigator.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Navigator.Test.uno
@@ -741,6 +741,67 @@ namespace Fuse.Navigation.Test
 			}
 		}
 		
+		[Test]
+		public void ModifyPath()
+		{
+			var p = new UX.Navigator.ModifyPath();
+			p.nav._testInterceptGoto = TestInterceptGoto;
+			ResetInterceptGoto();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				
+				var rootPage = p.nav.AncestorRouterPage;
+				
+				p.gotoOne.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "1.5", GetRecursiveText(p.nav.Active));
+				Assert.AreEqual( "one", _lastPage.Path );
+				Assert.AreEqual( NavigationGotoMode.Transition, _lastGotoMode );
+				Assert.AreEqual( RoutingOperation.Goto, _lastOperation );
+				Assert.AreEqual( 1, rootPage.ChildRouterPages.Count );
+				Assert.AreEqual( _lastPage, rootPage.ChildRouterPages[0] );
+				
+				p.pushTwo.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "2.6", GetRecursiveText(p.nav.Active));
+				Assert.AreEqual( "two", _lastPage.Path );
+				Assert.AreEqual( NavigationGotoMode.Bypass, _lastGotoMode );
+				Assert.AreEqual( RoutingOperation.Push, _lastOperation );
+				Assert.AreEqual( 2, rootPage.ChildRouterPages.Count );
+				Assert.AreEqual( _lastPage, rootPage.ChildRouterPages[1] );
+				
+				p.replaceThree.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "3.7", GetRecursiveText(p.nav.Active));
+				Assert.AreEqual( "three", _lastPage.Path );
+				Assert.AreEqual( NavigationGotoMode.Transition, _lastGotoMode );
+				Assert.AreEqual( "quick", _lastOperationStyle );
+				Assert.AreEqual( RoutingOperation.Replace, _lastOperation );
+				Assert.AreEqual( 2, rootPage.ChildRouterPages.Count );
+				Assert.AreEqual( _lastPage, rootPage.ChildRouterPages[1] );
+				
+				p.goBack.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "1.5", GetRecursiveText(p.nav.Active));
+				Assert.AreEqual( "one", _lastPage.Path );
+				Assert.AreEqual( NavigationGotoMode.Transition, _lastGotoMode );
+				Assert.AreEqual( RoutingOperation.Pop, _lastOperation );
+				Assert.AreEqual( 1, rootPage.ChildRouterPages.Count );
+				Assert.AreEqual( _lastPage, rootPage.ChildRouterPages[0] );
+				
+				//override back page, and check a few safety special conditions
+				p.goBackTwo.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "2.8", GetRecursiveText(p.nav.Active));
+				Assert.AreEqual( "two", _lastPage.Path );
+				Assert.AreEqual( NavigationGotoMode.Transition, _lastGotoMode );
+				Assert.AreEqual( RoutingOperation.Pop, _lastOperation );
+				Assert.AreEqual( 1, rootPage.ChildRouterPages.Count );
+				Assert.AreEqual( _lastPage, rootPage.ChildRouterPages[0] );
+			}
+		}
+		
 		RouterPage _lastPage;
 		string _lastOperationStyle;
 		NavigationGotoMode _lastGotoMode;

--- a/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
@@ -677,6 +677,41 @@ namespace Fuse.Navigation.Test
 				Assert.AreEqual( "5", GetText(p.nav.Active));
 			}
 		}
+		
+		[Test]
+		public void ModifyObject()
+		{
+			var p = new UX.Router.ModifyObject();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				p.gotoR.Pulse();
+				root.StepFrame();
+				Assert.AreEqual( "5", GetText(p.nav.Active));
+				
+				p.pushSecond.Pulse();
+				root.StepFrame(5); //complete animation
+				Assert.AreEqual( "!6,2.happy", GetRecursiveText(p.nav.Active));
+				
+				p.pushFirst.Pulse();
+				root.StepFrameJS();
+				root.StepFrame(5);
+				Assert.AreEqual( "!7,1.joyous", GetRecursiveText(p.nav.Active));
+				
+				p.router.GoBack();
+				root.StepFrame(5);
+				Assert.AreEqual( "!6,2.happy", GetRecursiveText(p.nav.Active));
+				
+				p.pushFirstBits.Pulse();
+				root.StepFrameJS();
+				root.StepFrame(5);
+				Assert.AreEqual( "!7,1.joyous", GetRecursiveText(p.nav.Active));
+				
+				p.pushThird.Pulse();
+				root.StepFrameJS();
+				root.StepFrame(5);
+				Assert.AreEqual( "?9,ii.bub", GetRecursiveText(p.nav.Active));
+			}
+		}
 	}
 }
 	

--- a/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
@@ -646,6 +646,37 @@ namespace Fuse.Navigation.Test
 				Assert.AreEqual( "1,2,3", p.history.Value );
 			}
 		}
+		
+		[Test]
+		public void ObjectPath()
+		{
+			var p = new UX.Router.ObjectPath();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				
+				p.callGoto.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "5", GetText(p.nav.Active));
+				
+				p.push.Pulse();
+				root.StepFrame();
+				Assert.AreEqual( "!6,2.happy", GetRecursiveText(p.nav.Active));
+			
+				((ROPTwo)p.nav.Active).callPushRelative.Perform();
+				root.StepFrameJS();
+				root.StepFrame(5); //finish animation
+				Assert.AreEqual( "!6,1.joyous", GetRecursiveText(p.nav.Active));
+				
+				p.router.GoBack();
+				root.StepFrame(5);
+				Assert.AreEqual( "!6,2.happy", GetRecursiveText(p.nav.Active));
+				
+				p.router.GoBack();
+				root.StepFrame();
+				Assert.AreEqual( "5", GetText(p.nav.Active));
+			}
+		}
 	}
 }
 	

--- a/Source/Fuse.Controls.Navigation/Tests/UX/Navigator.ModifyPath.ux
+++ b/Source/Fuse.Controls.Navigation/Tests/UX/Navigator.ModifyPath.ux
@@ -1,0 +1,69 @@
+<Panel ux:Class="UX.Navigator.ModifyPath">
+	<JavaScript>
+		exports.gotoOne = function() {
+			nav.modifyPath({
+				how: "Goto",
+				path: [{
+					$path: "one",
+					id: 5,
+				}]
+			})
+		}
+		
+		exports.pushTwo = function() {
+			nav.modifyPath({
+				how: "Push",
+				transition: "Bypass",
+				path: [{
+					$path: "two",
+					id: 6,
+				}]
+			})
+		}
+		
+		exports.replaceThree = function() {
+			nav.modifyPath({
+				how: "Replace",
+				style: "quick",
+				path: [{
+					$path: "three",
+					id: 7,
+				}]
+			})
+		}
+		
+		exports.goBack = function() {
+			nav.modifyPath({
+				how: "GoBack",
+			})
+		}
+		
+		exports.goBackTwo = function() {
+			nav.modifyPath({
+				how: "GoBack",
+				path: [{
+					$path: "two",
+					id: 8,
+				}]
+			})
+		}
+	</JavaScript>
+	
+	<Navigator ux:Name="nav" Transition="None">
+		<Panel ux:Template="one">
+			<Text Value="1.{id}"/>
+		</Panel>
+		<Panel ux:Template="two">
+			<Text Value="2.{id}"/>
+		</Panel>
+		<Panel ux:Template="three">
+			<Text Value="3.{id}"/>
+		</Panel>
+	</Navigator>
+	
+	<FuseTest.Invoke Handler="{gotoOne}" ux:Name="gotoOne"/>
+	<FuseTest.Invoke Handler="{pushTwo}" ux:Name="pushTwo"/>
+	<FuseTest.Invoke Handler="{replaceThree}" ux:Name="replaceThree"/>
+	<FuseTest.Invoke Handler="{goBack}" ux:Name="goBack"/>
+	<FuseTest.Invoke Handler="{goBackTwo}" ux:Name="goBackTwo"/>
+</Panel>

--- a/Source/Fuse.Controls.Navigation/Tests/UX/Router.ModifyObject.ux
+++ b/Source/Fuse.Controls.Navigation/Tests/UX/Router.ModifyObject.ux
@@ -1,0 +1,76 @@
+<Panel ux:Class="UX.Router.ModifyObject">
+	<Router ux:Name="router"/>
+	<JavaScript>
+		var Observable = require("FuseJS/Observable")
+		
+		exports.firstPath = [{
+			$path: "two",
+			id: 7,
+		}, {
+			$path: "first",
+			title: "joyous",
+		}]
+		
+		exports.thirdPath = Observable({
+			$path: "three",
+			id: 9,
+		},{
+			$path: "second",
+			title: "bub",
+		})
+	</JavaScript>
+	<Navigator ux:Name="nav" Transition="None">
+		<Panel ux:Template="one">
+			<Text Value="{id}"/>
+		</Panel>
+		
+		<Panel ux:Template="two">
+			<Text Value="!{id}"/>
+			<PageControl>
+				<Panel ux:Name="first">
+					<WhileActive>
+						<Text Value="1.{title}"/>
+					</WhileActive>
+				</Panel>
+				<Panel ux:Name="second">
+					<WhileActive>
+						<Text Value="2.{title}"/>
+					</WhileActive>
+				</Panel>
+			</PageControl>
+		</Panel>
+		
+		<Panel ux:Template="three">
+			<Text Value="?{id}"/>
+			<PageControl>
+				<Panel ux:Name="first">
+					<WhileActive>
+						<Text Value="i.{title}"/>
+					</WhileActive>
+				</Panel>
+				<Panel ux:Name="second">
+					<WhileActive>
+						<Text Value="ii.{title}"/>
+					</WhileActive>
+				</Panel>
+			</PageControl>
+		</Panel>
+	</Navigator>
+	
+	<Timeline ux:Name="gotoR">
+		<GotoRoute Path="( '$path': 'one', id: 5)"/>
+	</Timeline>
+	<Timeline ux:Name="pushSecond">
+		<PushRoute Path="( '$path': 'two', id: 6 ), ( '$path': 'second', title: 'happy' )"/>
+	</Timeline>
+	<Timeline ux:Name="pushFirst">
+		<PushRoute Path="{firstPath}"/>
+	</Timeline>
+	<Timeline ux:Name="pushFirstBits">
+		<PushRoute Path="{firstPath[0]}, {firstPath[1]}"/>
+	</Timeline>
+	<Timeline ux:Name="pushThird">
+		<PushRoute Path="{thirdPath}"/>
+	</Timeline>
+	
+</Panel>

--- a/Source/Fuse.Controls.Navigation/Tests/UX/Router.ObjectPath.ux
+++ b/Source/Fuse.Controls.Navigation/Tests/UX/Router.ObjectPath.ux
@@ -1,0 +1,62 @@
+<Panel ux:Class="UX.Router.ObjectPath">
+	<Router ux:Name="router"/>
+	<JavaScript>
+		router.bookmark({
+			name: "two",
+			path: [{
+				$path: "two",
+				id: 6,
+			}, {
+				$path: "second",
+				title: "happy",
+			}]
+		})
+		
+		exports.goto = function() {
+			router.goto({
+				$path: "one",
+				id: 5,
+			})
+		}
+	</JavaScript>
+	<Navigator ux:Name="nav" Transition="None">
+		<Panel ux:Template="one">
+			<Text Value="{id}"/>
+		</Panel>
+		
+		<Panel ux:Class="ROPTwo">
+			<Router ux:Dependency="router"/>
+			<Text Value="!{id}"/>
+			<PageControl ux:Name="pc">
+				<JavaScript>
+					exports.pushRelative = function() {
+						router.pushRelative( pc, { 
+							$path: "first",
+							title: "joyous",
+						})
+					}
+				</JavaScript>
+				
+				<Panel ux:Name="first">
+					<WhileActive>
+						<Text Value="1.{title}"/>
+					</WhileActive>
+				</Panel>
+				<Panel ux:Name="second">
+					<WhileActive>
+						<Text Value="2.{title}"/>
+					</WhileActive>
+				</Panel>
+				
+				<FuseTest.Invoke Handler="{pushRelative}" ux:Name="callPushRelative"/>
+			</PageControl>
+		</Panel>
+		
+		<ROPTwo ux:Name="two" router="router"/>
+	</Navigator>
+	
+	<FuseTest.Invoke Handler="{goto}" ux:Name="callGoto"/>
+	<Timeline ux:Name="push">
+		<PushRoute Bookmark="two"/>
+	</Timeline>
+</Panel>

--- a/Source/Fuse.Navigation/RouterModify.uno
+++ b/Source/Fuse.Navigation/RouterModify.uno
@@ -190,7 +190,7 @@ namespace Fuse.Navigation
 			try
 			{
 				RouterPageRoute route = null;
-				if (!RouterRequest.ParseNVPRoute(value, out route))
+				if (!RouterRequest.ParseUXRoute(value, out route))
 					return;
 				
 				PerformRoute( (_pathSub as IContext).Node, route);

--- a/Source/Fuse.Navigation/RouterPage.uno
+++ b/Source/Fuse.Navigation/RouterPage.uno
@@ -99,13 +99,21 @@ namespace Fuse.Navigation
 		{
 			string path = null;
 			var obj = data as IObject;
-			//TODO: Until the Model is merged this shouldn't work, and it shouldn't be $template
+			//TODO: Until the Model is merged this shouldn't work, and it shouldn't be $template (adding line conflict to ensure HasObjectPath is updated)
 			//if (obj != null && obj.ContainsKey("$template")) //set implicitly by Model API
 			//	path = Marshal.ToType<string>(obj["$template"]);
 			if (obj != null && obj.ContainsKey("$path"))
 				path = Marshal.ToType<string>(obj["$path"]);
 				
 			return path;
+		}
+		
+		static public bool HasObjectPath( object data )
+		{
+			var obj = data as IObject;
+			if (obj != null && obj.ContainsKey("$path"))
+				return true;
+			return false;
 		}
 
 		public event ChildRouterPagesUpdated Updated;

--- a/Source/Fuse.Navigation/RouterRequest.uno
+++ b/Source/Fuse.Navigation/RouterRequest.uno
@@ -60,7 +60,7 @@ namespace Fuse.Navigation
 					return false;
 				}
 				
-				//TODO: conver to bool form like ParseNVPRoute
+				//TODO: convert to bool form like ParseNVPRoute
 				Route = ParseFlatRoute(path);
 			}
 			else
@@ -166,7 +166,71 @@ namespace Fuse.Navigation
 			}
 		}
 		
-		static public bool ParseNVPRoute(object value, out RouterPageRoute route)
+		/**
+			This function decides whether to parse an ObjectRoute or a NVPRoute. It needs to employ a bit of trickery since the UX parser doesn't retain some syntax information, like the different between:
+				a:b, c:d
+			and
+				(a:b, c:d)
+			They both end up as the same IObject, which also exposes IArray.
+			
+			Here we'll assume if the first object, or the first element of the array, contains a path marker, then it's an object path.
+		*/
+		static internal bool ParseUXRoute(object value, out RouterPageRoute route)
+		{
+			if (IsObjectRoute(value))
+				return ParseObjectRoute(value, out route);
+			return ParseNVPRoute(value, out route);
+		}
+		
+		static bool IsObjectRoute(object value)
+		{
+			var array = value as IArray;
+			var isProperArray = array != null && !(value is IObject);
+			if (isProperArray && array.Length > 0 && PagesMap.HasObjectPath(array[0]))
+				return true;
+				
+			if (!isProperArray && PagesMap.HasObjectPath(value))
+				return true;
+				
+			return false;
+		}
+		
+		static internal bool ParseObjectRoute(object value, out RouterPageRoute route)
+		{
+			route = null;
+			
+			var array = value as IArray;
+			var isProperArray = array != null && !(value is IObject);
+			if (isProperArray)
+			{
+				for (int i = array.Length - 1; i >=0; --i)
+				{
+					if (!ParseObjectComponent(array[i], ref route))
+						return false;
+				}
+				
+				return true;
+			}
+			else
+			{
+				return ParseObjectComponent(value, ref route);
+			}
+		}
+		
+		static bool ParseObjectComponent(object value, ref RouterPageRoute route)
+		{
+			var path = PagesMap.GetObjectPath(value);
+			if (path == null)
+			{
+				Fuse.Diagnostics.UserError( "Object does not contain a $path", null);
+				return false;
+			}
+			
+			route = new RouterPageRoute( new RouterPage( path, null, value), route);
+			return true;
+		}
+		
+		static internal bool ParseNVPRoute(object value, out RouterPageRoute route)
 		{
 			route = null;
 

--- a/Source/Fuse.Navigation/RouterRequest.uno
+++ b/Source/Fuse.Navigation/RouterRequest.uno
@@ -143,17 +143,27 @@ namespace Fuse.Navigation
 		static public RouterPageRoute ParseFlatRoute(object[] args, int pos = 0)
 		{
 			if (args.Length <= pos) return null;
-			if (args.Length <= pos+1) return new RouterPageRoute(
-				new RouterPage( args[pos] as string ), null );
-
-			var arg = args[pos+1];
-
-			if (!ValidateParameter(arg, 0)) return null;
-
+			
 			var path = args[pos] as string;
-			var parameter = Json.Stringify(arg, true);
-			return new RouterPageRoute( 
-				new RouterPage( path, parameter ), ParseFlatRoute(args, pos+2));
+			if (path != null)
+			{
+				if (args.Length <= pos+1) return new RouterPageRoute(
+					new RouterPage( args[pos] as string ), null );
+
+				var arg = args[pos+1];
+
+				if (!ValidateParameter(arg, 0)) return null;
+
+				var parameter = Json.Stringify(arg, true);
+				return new RouterPageRoute( 
+					new RouterPage( path, parameter ), ParseFlatRoute(args, pos+2));
+			}
+			else
+			{
+				return new RouterPageRoute(
+					new RouterPage( PagesMap.GetObjectPath(args[pos]), null, args[pos] ), 
+						ParseFlatRoute(args, pos+1));
+			}
 		}
 		
 		static public bool ParseNVPRoute(object value, out RouterPageRoute route)

--- a/Source/Fuse.Reactive/Fuse.Reactive.unoproj
+++ b/Source/Fuse.Reactive/Fuse.Reactive.unoproj
@@ -30,6 +30,7 @@
     "Fuse.Selection",
     "Fuse.Common.Test.Helpers",
     "Fuse.Controls.Navigation",
+    "Fuse.Controls.Navigation.Test",
     "Fuse.Charting",
     "Fuse.Charting.Test",
     "FuseTest",


### PR DESCRIPTION
This exposes some of the internal ability to use objects in the routing.

This PR contains:
- [x] Changelog
- [x] Documentation - but only `modifyPath`. Most of this feature is meant to be used in conjunction with Models, so there's no need to draw attention to it yet.
- [x] Tests
