### PR TITLE
ScriptException: Truncate long source lines

### DIFF
--- a/Source/Fuse.Scripting/ScriptException.uno
+++ b/Source/Fuse.Scripting/ScriptException.uno
@@ -10,6 +10,9 @@ namespace Fuse.Scripting
 		public string SourceLine { get; private set;}
 		public string JSStackTrace { get; private set;}
 
+		const int MaxSourceLineLength = 300;
+		const string SourceLineTooLongMessage = " ... source line truncated for readability ...";
+
 		public ScriptException(
 			string name,
 			string errorMessage,
@@ -54,7 +57,15 @@ namespace Fuse.Scripting
 				if (!string.IsNullOrEmpty(SourceLine))
 				{
 					stringBuilder.Append("Source line: ");
-					stringBuilder.AppendLine(SourceLine);
+					if (SourceLine.Length > MaxSourceLineLength)
+					{
+						stringBuilder.Append(SourceLine.Substring(0, MaxSourceLineLength));
+						stringBuilder.AppendLine(SourceLineTooLongMessage);
+					}
+					else
+					{
+						stringBuilder.AppendLine(SourceLine);
+					}
 				}
 				if (!string.IsNullOrEmpty(JSStackTrace))
 				{


### PR DESCRIPTION
As this is kind of an unsolicited PR, feel free to discuss :)
In particular, the number `300` is chosen fairly arbitrarily, so we might want to be more conservative there.

My reasoning is that, if a single line of source code extends beyond 300 characters, it's either:

- A minified JavaScript library, where all the code is on a single line
- Very poorly written code

In any case, it will only clutter up the log, making the actual source of the error harder to find.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
