### PR TITLE
Feature console improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - `IMirror`'s `Reflect` now takes a `Scripting.Context`
 - IThreadWorker no longer implement IDispatcher
 - `Fuse.Scripting.JavaScript`'s `ThreadWorker` no longer blocks on construction
+- Implemented `console.error`, `console.warn` and `console.info`
+- Improved formatting for the above functions, as well as for `console.log`
+
 
 # 1.4
 


### PR DESCRIPTION
This implements console.info(), console.warn(), console.error(),
as well as making general improvements to formatting.

Previously we called `ToString()` on each argument's Uno representation.
This is okay for primitive values; but for objects and arrays I'd like
to see something more useful than "Fuse.Scripting.V8.Object" in my log.

Instead, perform the string conversion in JavaScript itself,
to take advantage of its string conversion rules.

The string representations of each argument are now joined by a space
to more closely match the behavior of other JavaScript environments.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests