### PR TITLE
ScriptClass thread-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Implemented `console.error`, `console.warn` and `console.info`
 - Improved formatting for the above functions, as well as for `console.log`
 - The `ScriptMethod<T>` contstructor now throws if it's passed `ExecutionThread.MainThread` with Func, instead of failing to run it later on.
+- The `ScriptMethodInline` constructor that takes an `ExecutionThread` as an argument is now obsolete. Use the one without instead. JavaScript needs to run on the JavaScript thread anyway.
 
 
 # 1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Improved formatting for the above functions, as well as for `console.log`
 - The `ScriptMethod<T>` contstructor now throws if it's passed `ExecutionThread.MainThread` with Func, instead of failing to run it later on.
 - The `ScriptMethodInline` constructor that takes an `ExecutionThread` as an argument is now obsolete. Use the one without instead. JavaScript needs to run on the JavaScript thread anyway.
+- The `ScriptMethod<T>` contstructor that takes `Func` and `ExecutionThread` as arguments is now obsolete. Use the one without instead.
 
 
 # 1.4

--- a/Source/Fuse.Controls.Navigation/EdgeNavigator.ScriptClass.uno
+++ b/Source/Fuse.Controls.Navigation/EdgeNavigator.ScriptClass.uno
@@ -10,8 +10,8 @@ namespace Fuse.Controls
 		static EdgeNavigator()
 		{
 			ScriptClass.Register(typeof(EdgeNavigator),
-				new ScriptMethod<EdgeNavigator>("dismiss", dismiss, ExecutionThread.MainThread),
-				new ScriptMethod<EdgeNavigator>("open", open, ExecutionThread.MainThread));
+				new ScriptMethod<EdgeNavigator>("dismiss", dismiss),
+				new ScriptMethod<EdgeNavigator>("open", open));
 		}
 
 		/**
@@ -19,7 +19,7 @@ namespace Fuse.Controls
 			
 			@scriptmethod dismiss()
 		*/
-		static void dismiss(Context c, EdgeNavigator e, object[] args)
+		static void dismiss(EdgeNavigator e, object[] args)
 		{
 			if (args.Length != 0)
 			{
@@ -36,7 +36,7 @@ namespace Fuse.Controls
 			@scriptmethod open(edge)
 			@param edge The enum name of the edge to open @Fuse.Navigation.NavigationEdge
 		*/
-		static void open(Context c, EdgeNavigator e, object[] args)
+		static void open(EdgeNavigator e, object[] args)
 		{
 			if (args.Length != 1)
 			{

--- a/Source/Fuse.Controls.Navigation/NavigationControl.ScriptClass.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.ScriptClass.uno
@@ -11,9 +11,9 @@ namespace Fuse.Controls
 		static NavigationControl()
 		{
 			ScriptClass.Register(typeof(NavigationControl),
-				new ScriptMethod<NavigationControl>("gotoPath", gotoPath, ExecutionThread.MainThread),
-				new ScriptMethod<NavigationControl>("seekToPath", seekToPath, ExecutionThread.MainThread),
-				new ScriptMethod<NavigationControl>("modifyPath", modifyPath, ExecutionThread.MainThread));
+				new ScriptMethod<NavigationControl>("gotoPath", gotoPath),
+				new ScriptMethod<NavigationControl>("seekToPath", seekToPath),
+				new ScriptMethod<NavigationControl>("modifyPath", modifyPath));
 		}
 		
 		/**
@@ -25,9 +25,9 @@ namespace Fuse.Controls
 			@param path the name of the path to use
 			@param parameter an optional parameter for the page
 		*/
-		static void gotoPath(Context c, NavigationControl nav, object[] args)
+		static void gotoPath(NavigationControl nav, object[] args)
 		{
-			alterPath(c, nav, args, "gotoPath", NavigationGotoMode.Transition);
+			alterPath(nav, args, "gotoPath", NavigationGotoMode.Transition);
 		}
 		
 		/**
@@ -39,12 +39,12 @@ namespace Fuse.Controls
 			@param path the name of the path to use
 			@param parameter an optional parameter for the page
 		*/
-		static void seekToPath(Context c, NavigationControl nav, object[] args)
+		static void seekToPath(NavigationControl nav, object[] args)
 		{
-			alterPath(c, nav, args, "seekToPath", NavigationGotoMode.Bypass);
+			alterPath(nav, args, "seekToPath", NavigationGotoMode.Bypass);
 		}
 		
-		static void alterPath(Context c, NavigationControl nav, object[] args, string opName,
+		static void alterPath(NavigationControl nav, object[] args, string opName,
 			NavigationGotoMode gotoMode)
 		{
 			if (args.Length < 1 || args.Length > 2)
@@ -99,7 +99,7 @@ namespace Fuse.Controls
 					- `Bypass`: A bypass transtiion that skips animation.
 				- `style`: The style of the operation, which can be used as a matching criteria in transitions.
 		*/
-		static void modifyPath(Context c, NavigationControl nav, object[] args)
+		static void modifyPath(NavigationControl nav, object[] args)
 		{
 			if (args.Length != 1)
 			{

--- a/Source/Fuse.Controls.Navigation/PageControl.uno
+++ b/Source/Fuse.Controls.Navigation/PageControl.uno
@@ -82,7 +82,7 @@ namespace Fuse.Controls
 		static PageControl()
 		{
 			ScriptClass.Register(typeof(PageControl),
-				new ScriptMethod<PageControl>("goto", gotoPage, ExecutionThread.MainThread));
+				new ScriptMethod<PageControl>("goto", gotoPage));
 		}
 
 		/**
@@ -91,13 +91,13 @@ namespace Fuse.Controls
 			@scriptmethod goto(node)
 			@param node The @Visual object of target page. Typically a `ux:Name` variable.
 		*/
-		static void gotoPage(Context c, PageControl pc, object[] args)
+		static void gotoPage(PageControl pc, object[] args)
 		{
 			var target = args[0] as Visual;
 			if (target != null) pc.Active = target;
 			else Diagnostics.UserError("PageControl.goto() : Argument must be a node object", pc);
 		}
-		
+
 		new internal Fuse.Navigation.DynamicLinearNavigation Navigation
 		{
 			get { return ((NavigationControl)this).Navigation as Fuse.Navigation.DynamicLinearNavigation; }

--- a/Source/Fuse.Controls.Primitives/Image.ScriptClass.uno
+++ b/Source/Fuse.Controls.Primitives/Image.ScriptClass.uno
@@ -10,8 +10,8 @@ namespace Fuse.Controls
 		static Image()
 		{
 			ScriptClass.Register(typeof(Image),
-				new ScriptMethod<Image>("reload", reload, ExecutionThread.MainThread),
-				new ScriptMethod<Image>("retry", retry, ExecutionThread.MainThread));
+				new ScriptMethod<Image>("reload", reload),
+				new ScriptMethod<Image>("retry", retry));
 		}
 		
 		/**
@@ -19,7 +19,7 @@ namespace Fuse.Controls
 			
 			@scriptmethod reload( )
 		*/
-		static void reload(Context c, Image img, object[] args)
+		static void reload(Image img, object[] args)
 		{
 			if (args.Length != 0)
 			{
@@ -37,7 +37,7 @@ namespace Fuse.Controls
 			
 			@scriptmethod retry( )
 		*/
-		static void retry(Context c, Image img, object[] args)
+		static void retry(Image img, object[] args)
 		{
 			if (args.Length != 0)
 			{

--- a/Source/Fuse.Controls.ScrollView/ScrollView.ScriptClass.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollView.ScriptClass.uno
@@ -10,10 +10,10 @@ namespace Fuse.Controls
 		static ScrollViewBase()
 		{
 			ScriptClass.Register(typeof(ScrollViewBase),
-				new ScriptMethod<ScrollViewBase>("goto", goto_, ExecutionThread.MainThread),
-				new ScriptMethod<ScrollViewBase>("gotoRelative", gotoRelative, ExecutionThread.MainThread),
-				new ScriptMethod<ScrollViewBase>("seekTo", seekTo, ExecutionThread.MainThread),
-				new ScriptMethod<ScrollViewBase>("seekToRelative", seekToRelative, ExecutionThread.MainThread));
+				new ScriptMethod<ScrollViewBase>("goto", goto_),
+				new ScriptMethod<ScrollViewBase>("gotoRelative", gotoRelative),
+				new ScriptMethod<ScrollViewBase>("seekTo", seekTo),
+				new ScriptMethod<ScrollViewBase>("seekToRelative", seekToRelative));
 		}
 
 		static bool getParams(ScrollViewBase s,object[] args, string func, out float2 pos)
@@ -37,7 +37,7 @@ namespace Fuse.Controls
 			@scriptmethod goto(absolutePosition)
 			@scriptmethod goto(absoluteX, absoluteY)
 		*/
-		static void goto_(Context c, ScrollViewBase s, object[] args)
+		static void goto_(ScrollViewBase s, object[] args)
 		{
 			float2 pos;
 			if (!getParams(s, args, "goto", out pos))
@@ -51,7 +51,7 @@ namespace Fuse.Controls
 			@scriptmethod gotoRelative(relativePosition)
 			@scriptmethod gotoRelative(relativeX, relativeY)
 		*/
-		static void gotoRelative(Context c, ScrollViewBase s, object[] args)
+		static void gotoRelative(ScrollViewBase s, object[] args)
 		{
 			float2 pos;
 			if (!getParams(s, args, "gotoToRelative", out pos))
@@ -65,7 +65,7 @@ namespace Fuse.Controls
 			@scriptmethod seekTo(absolutePosition)
 			@scriptmethod seekTo(absoluteX, absoluteY)
 		*/
-		static void seekTo(Context c, ScrollViewBase s, object[] args)
+		static void seekTo(ScrollViewBase s, object[] args)
 		{
 			float2 pos;
 			if (!getParams(s, args, "seekTo", out pos))
@@ -79,7 +79,7 @@ namespace Fuse.Controls
 			@scriptmethod seekToRelative(relativePosition)
 			@scriptmethod seekToRelative(relativeX, relativeY)
 		*/
-		static void seekToRelative(Context c, ScrollViewBase s, object[] args)
+		static void seekToRelative(ScrollViewBase s, object[] args)
 		{
 			float2 pos;
 			if (!getParams(s, args, "seekToRelative", out pos))

--- a/Source/Fuse.Controls.ScrollView/ScrollViewPager.ScriptClass.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollViewPager.ScriptClass.uno
@@ -9,10 +9,10 @@ namespace Fuse.Controls
 		static ScrollViewPager()
 		{
 			ScriptClass.Register(typeof(ScrollViewPager),
-				new ScriptMethod<ScrollViewPager>("check", check, ExecutionThread.MainThread));
+				new ScriptMethod<ScrollViewPager>("check", check));
 		}
 		
-		static void check(Context c, ScrollViewPager s, object[] args)
+		static void check(ScrollViewPager s, object[] args)
 		{
 			if (args.Length != 0)
 			{

--- a/Source/Fuse.Controls.ScrollView/Triggers/Scrolled.ScriptClass.uno
+++ b/Source/Fuse.Controls.ScrollView/Triggers/Scrolled.ScriptClass.uno
@@ -10,7 +10,7 @@ namespace Fuse.Triggers
 		static Scrolled()
 		{
 			ScriptClass.Register(typeof(Scrolled),
-				new ScriptMethod<Scrolled>("check", check, ExecutionThread.MainThread));
+				new ScriptMethod<Scrolled>("check", check));
 		}
 		
 		/**
@@ -20,7 +20,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod check()
 		*/
-		static void check(Context c, Scrolled s, object[] args)
+		static void check(Scrolled s, object[] args)
 		{
 			if (args.Length != 0)
 			{

--- a/Source/Fuse.Controls.Video/Video.ScriptClass.uno
+++ b/Source/Fuse.Controls.Video/Video.ScriptClass.uno
@@ -10,7 +10,7 @@ namespace Fuse.Controls
 		static Video()
 		{
 			ScriptClass.Register(typeof(Video),
-				new ScriptMethod<Video>("getDuration", getDuration, ExecutionThread.JavaScript),
+				new ScriptMethod<Video>("getDuration", getDuration),
 				new ScriptMethod<Video>("resume", resume, ExecutionThread.MainThread),
 				new ScriptMethod<Video>("pause", pause, ExecutionThread.MainThread),
 				new ScriptMethod<Video>("stop", stop, ExecutionThread.MainThread));

--- a/Source/Fuse.Controls.Video/Video.ScriptClass.uno
+++ b/Source/Fuse.Controls.Video/Video.ScriptClass.uno
@@ -11,9 +11,9 @@ namespace Fuse.Controls
 		{
 			ScriptClass.Register(typeof(Video),
 				new ScriptMethod<Video>("getDuration", getDuration),
-				new ScriptMethod<Video>("resume", resume, ExecutionThread.MainThread),
-				new ScriptMethod<Video>("pause", pause, ExecutionThread.MainThread),
-				new ScriptMethod<Video>("stop", stop, ExecutionThread.MainThread));
+				new ScriptMethod<Video>("resume", resume),
+				new ScriptMethod<Video>("pause", pause),
+				new ScriptMethod<Video>("stop", stop));
 		}
 
 		object _durationMutex = new object();
@@ -45,7 +45,7 @@ namespace Fuse.Controls
 
 			@scriptmethod resume()
 		*/
-		static void resume(Context c, Video v, object[] args)
+		static void resume(Video v, object[] args)
 		{
 			if (args.Length != 0)
 				Fuse.Diagnostics.UserError("resume takes 0 arguments, but " + args.Length + " was supplied", v);
@@ -58,7 +58,7 @@ namespace Fuse.Controls
 
 			@scriptmethod pause()
 		*/
-		static void pause(Context c, Video v, object[] args)
+		static void pause(Video v, object[] args)
 		{
 			if (args.Length != 0)
 				Fuse.Diagnostics.UserError("pause takes 0 arguments, but " + args.Length + " was supplied", v);
@@ -71,7 +71,7 @@ namespace Fuse.Controls
 
 			@scriptmethod stop()
 		*/
-		static void stop(Context c, Video v, object[] args)
+		static void stop(Video v, object[] args)
 		{
 			if (args.Length != 0)
 				Fuse.Diagnostics.UserError("stop takes 0 arguments, but " + args.Length + " was supplied", v);

--- a/Source/Fuse.Controls.WebView/WebView.ScriptClass.uno
+++ b/Source/Fuse.Controls.WebView/WebView.ScriptClass.uno
@@ -15,13 +15,13 @@ namespace Fuse.Controls
 		static WebView()
 		{
 			ScriptClass.Register(typeof(WebView),
-				new ScriptMethod<WebView>("goto", setUrl, ExecutionThread.MainThread),
-				new ScriptMethod<WebView>("goBack", goBack, ExecutionThread.MainThread),
-				new ScriptMethod<WebView>("goForward", goForward, ExecutionThread.MainThread),
-				new ScriptMethod<WebView>("reload", reload, ExecutionThread.MainThread),
-				new ScriptMethod<WebView>("stop", stop, ExecutionThread.MainThread),
-				new ScriptMethod<WebView>("loadHtml", loadHtml, ExecutionThread.MainThread),
-				new ScriptMethod<WebView>("setBaseUrl", setBaseUrl, ExecutionThread.MainThread));
+				new ScriptMethod<WebView>("goto", setUrl),
+				new ScriptMethod<WebView>("goBack", goBack),
+				new ScriptMethod<WebView>("goForward", goForward),
+				new ScriptMethod<WebView>("reload", reload),
+				new ScriptMethod<WebView>("stop", stop),
+				new ScriptMethod<WebView>("loadHtml", loadHtml),
+				new ScriptMethod<WebView>("setBaseUrl", setBaseUrl));
 		}
 
 		/**
@@ -32,7 +32,7 @@ namespace Fuse.Controls
 			@param html The document to load into the WebView.
 			@param baseUrl Specifies the base URL used to resolve relative locations in the @html parameter.
 		*/
-		static void loadHtml(Context c, WebView view, object[] args)
+		static void loadHtml(WebView view, object[] args)
 		{
 
 			switch(args.Length)
@@ -55,7 +55,7 @@ namespace Fuse.Controls
 
 			@scriptmethod goBack()
 		*/
-		static void goBack(Context c, WebView view, object[] args)
+		static void goBack(WebView view, object[] args)
 		{
 			switch(args.Length)
 			{
@@ -73,7 +73,7 @@ namespace Fuse.Controls
 
 			@scriptmethod goForward()
 		*/
-		static void goForward(Context c, WebView view, object[] args)
+		static void goForward(WebView view, object[] args)
 		{
 			switch(args.Length)
 			{
@@ -91,7 +91,7 @@ namespace Fuse.Controls
 
 			@scriptmethod reload()
 		*/
-		static void reload(Context c, WebView view, object[] args)
+		static void reload(WebView view, object[] args)
 		{
 			switch(args.Length)
 			{
@@ -110,7 +110,7 @@ namespace Fuse.Controls
 
 			@scriptmethod stop()
 		*/
-		static void stop(Context c, WebView view, object[] args)
+		static void stop(WebView view, object[] args)
 		{
 			switch(args.Length)
 			{
@@ -129,7 +129,7 @@ namespace Fuse.Controls
 			@scriptmethod goto(url)
 			@param url The location to load.
 		*/
-		static void setUrl(Context c, WebView view, object[] args)
+		static void setUrl(WebView view, object[] args)
 		{
 			switch(args.Length)
 			{
@@ -148,7 +148,7 @@ namespace Fuse.Controls
 			@scriptmethod setBaseUrl(baseUrl)
 			@param baseUrl The base URL used to resolve relative locations.
 		*/
-		static void setBaseUrl(Context c, WebView view, object[] args)
+		static void setBaseUrl(WebView view, object[] args)
 		{
 			switch(args.Length)
 			{

--- a/Source/Fuse.Maps/MapView.ScriptClass.uno
+++ b/Source/Fuse.Maps/MapView.ScriptClass.uno
@@ -11,11 +11,11 @@ namespace Fuse.Controls
 		static MapView()
 		{
 			ScriptClass.Register(typeof(MapView),
-				new ScriptMethod<MapView>("setLocation", setLocation, ExecutionThread.MainThread),
-				new ScriptMethod<MapView>("setBearing", setBearing, ExecutionThread.MainThread),
-				new ScriptMethod<MapView>("setTilt", setTilt, ExecutionThread.MainThread),
-				new ScriptMethod<MapView>("setZoom", setZoom, ExecutionThread.MainThread),
-				new ScriptMethod<MapView>("setMarkers", setMarkers, ExecutionThread.MainThread));
+				new ScriptMethod<MapView>("setLocation", setLocation),
+				new ScriptMethod<MapView>("setBearing", setBearing),
+				new ScriptMethod<MapView>("setTilt", setTilt),
+				new ScriptMethod<MapView>("setZoom", setZoom),
+				new ScriptMethod<MapView>("setMarkers", setMarkers));
 		}
 
 		/** Sets the geographical location the MapView is focused on.
@@ -24,7 +24,7 @@ namespace Fuse.Controls
 			@param latitude (number) The latitude coordinate to pan to.
 			@param longitude (number) The longitude coordinate to pan to.
 		*/
-		static void setLocation(Context c, MapView view, object[] args)
+		static void setLocation(MapView view, object[] args)
 		{
 			switch(args.Length)
 			{
@@ -43,7 +43,7 @@ namespace Fuse.Controls
 			@scriptmethod setBearing(bearing)
 			@param bearing (number) The desired [Bearing](api:fuse/controls/mapview/bearing).
 		*/
-		static void setBearing(Context c, MapView view, object[] args)
+		static void setBearing(MapView view, object[] args)
 		{
 			switch(args.Length)
 			{
@@ -61,7 +61,7 @@ namespace Fuse.Controls
 			@scriptmethod setTilt(tilt)
 			@param tilt (number) The desired [Tilt](api:fuse/controls/mapview/tilt) angle.
 		*/
-		static void setTilt(Context c, MapView view, object[] args)
+		static void setTilt(MapView view, object[] args)
 		{
 			switch(args.Length)
 			{
@@ -79,7 +79,7 @@ namespace Fuse.Controls
 			@scriptmethod setZoom(zoom)
 			@param zoom (number) The desired [Zoom](api:fuse/controls/mapview/zoom) level.
 		*/
-		static void setZoom(Context c, MapView view, object[] args)
+		static void setZoom(MapView view, object[] args)
 		{
 			switch(args.Length)
 			{
@@ -120,7 +120,7 @@ namespace Fuse.Controls
 				</JavaScript>
 					
 		*/
-		static void setMarkers(Context c, MapView view, object[] args)
+		static void setMarkers(MapView view, object[] args)
 		{
 			view._markers.Clear();
 			switch(args.Length)

--- a/Source/Fuse.Navigation/Router.ScriptClass.uno
+++ b/Source/Fuse.Navigation/Router.ScriptClass.uno
@@ -192,7 +192,7 @@ namespace Fuse.Navigation
 				return;
 			}
 			
-			var request = new ScriptRouterRequest();
+			var request = new RouterRequest(RouterRequest.Flags.FlatRoute);
 			
 			var keys = obj.Keys;
 			for (int i=0; i < keys.Length; ++i)
@@ -203,18 +203,6 @@ namespace Fuse.Navigation
 			}
 
 			request.MakeRequest(r);
-		}
-
-		class ScriptRouterRequest : RouterRequest
-		{
-			public ScriptRouterRequest() : base(Flags.FlatRoute)
-			{
-			}
-			
-			protected override Node ParseNode(object value)
-			{
-				return value as Node;
-			}
 		}
 
 		/**

--- a/Source/Fuse.Navigation/Router.ScriptClass.uno
+++ b/Source/Fuse.Navigation/Router.ScriptClass.uno
@@ -7,14 +7,14 @@ namespace Fuse.Navigation
 		static Router()
 		{
 			ScriptClass.Register(typeof(Router),
-				new ScriptMethod<Router>("bookmark", Bookmark, ExecutionThread.MainThread),
+				new ScriptMethod<Router>("bookmark", Bookmark),
 				new ScriptMethod<Router>("getRoute", GetRoute, ExecutionThread.MainThread),
-				new ScriptMethod<Router>("goBack", GoBack, ExecutionThread.MainThread),
-				new ScriptMethod<Router>("goto", Goto, ExecutionThread.MainThread),
-				new ScriptMethod<Router>("gotoRelative", GotoRelative, ExecutionThread.MainThread),
-				new ScriptMethod<Router>("modify", Modify, ExecutionThread.MainThread),
-				new ScriptMethod<Router>("push", Push, ExecutionThread.MainThread),
-				new ScriptMethod<Router>("pushRelative", PushRelative, ExecutionThread.MainThread));
+				new ScriptMethod<Router>("goBack", GoBack),
+				new ScriptMethod<Router>("goto", Goto),
+				new ScriptMethod<Router>("gotoRelative", GotoRelative),
+				new ScriptMethod<Router>("modify", Modify),
+				new ScriptMethod<Router>("push", Push),
+				new ScriptMethod<Router>("pushRelative", PushRelative));
 		}
 
 		/**
@@ -31,7 +31,7 @@ namespace Fuse.Navigation
 			This specifies a three-level path. The first two levels, `home` and `contact` do not have any property.
 			The third level `view` specifies the `id` of the user that will be viewed.
 		*/
-		static void Goto(Context c, Router r, object[] args)
+		static void Goto( Router r, object[] args)
 		{
 			if (!r.IsRootingCompleted) return;
 
@@ -67,9 +67,9 @@ namespace Fuse.Navigation
 			
 			@see fuse/navigation/router/goto
 		*/
-		static void GotoRelative(Context c, Router r, object[] args)
+		static void GotoRelative(Router r, object[] args)
 		{
-			var route = GetRelative(c, r, args);
+			var route = GetRelative(r, args);
 			if (route != null)
 				r.Modify( ModifyRouteHow.Goto, route, NavigationGotoMode.Transition, "" );
 		}
@@ -82,14 +82,14 @@ namespace Fuse.Navigation
 			@see fuse/navigation/router/push
 			@see fuse/navigation/router/gotoRelative
 		*/
-		static void PushRelative(Context c, Router r, object[] args)
+		static void PushRelative(Router r, object[] args)
 		{
-			var route = GetRelative(c, r, args);
+			var route = GetRelative(r, args);
 			if (route != null)
 				r.Modify( ModifyRouteHow.Push, route, NavigationGotoMode.Transition, "" );
 		}
 		
-		static RouterPageRoute GetRelative(Context c, Router r, object[] args)
+		static RouterPageRoute GetRelative(Router r, object[] args)
 		{
 			if (args.Length < 1)
 			{
@@ -118,7 +118,7 @@ namespace Fuse.Navigation
 			This specifies a three-level path. The first two levels, `home` and `contact` do not have any property.
 			The third level `view` specifies the `id` of the user that will be viewed.
 		*/
-		static void Push(Context c, Router r, object[] args)
+		static void Push(Router r, object[] args)
 		{
 			if (!r.IsRootingCompleted) return;
 
@@ -132,7 +132,7 @@ namespace Fuse.Navigation
 			
 			@scriptmethod goBack()
 		*/
-		static void GoBack(Context c, Router r, object[] args)
+		static void GoBack(Router r, object[] args)
 		{
 			if (!r.IsRootingCompleted) return;
 
@@ -175,7 +175,7 @@ namespace Fuse.Navigation
 				- `relative`: An optional node that indicates the path is relative to this router outlet. The path is specified like in `gotoRelative`
 				- `style`: The style of the operation, which can be used as a matching criteria in transitions.
 		*/
-		static void Modify(Context c, Router r, object[] args)
+		static void Modify(Router r, object[] args)
 		{
 			if (!r.IsRootingCompleted) return;
 			
@@ -192,7 +192,7 @@ namespace Fuse.Navigation
 				return;
 			}
 			
-			var request = new ScriptRouterRequest(c);
+			var request = new ScriptRouterRequest();
 			
 			var keys = obj.Keys;
 			for (int i=0; i < keys.Length; ++i)
@@ -201,22 +201,19 @@ namespace Fuse.Navigation
 				if (!request.AddArgument(key, obj[key]))
 					return;
 			}
+
 			request.MakeRequest(r);
 		}
-		
+
 		class ScriptRouterRequest : RouterRequest
 		{
-			Context _context;
-
-			public ScriptRouterRequest( Context context ) :
-				base( Flags.FlatRoute )
+			public ScriptRouterRequest() : base(Flags.FlatRoute)
 			{
-				_context = context;
 			}
 			
 			protected override Node ParseNode(object value)
 			{
-				return _context.Wrap(value) as Node;
+				return value as Node;
 			}
 		}
 
@@ -237,7 +234,7 @@ namespace Fuse.Navigation
 			
 			
 		*/
-		static void Bookmark(Context c, Router r, object[] args)
+		static void Bookmark(Router r, object[] args)
 		{
 			if (!r.IsRootingCompleted) return;
 			

--- a/Source/Fuse.Navigation/Router.ScriptClass.uno
+++ b/Source/Fuse.Navigation/Router.ScriptClass.uno
@@ -97,7 +97,7 @@ namespace Fuse.Navigation
 				return null;
 			}
 			
-			var node = c.Wrap(args[0]) as Node;
+			var node = args[0] as Node;
 			//null is actually okay for `where`
 			var where = RouterRequest.ParseFlatRoute(args, 1);
 			
@@ -185,7 +185,7 @@ namespace Fuse.Navigation
 				return;
 			}
 			
-			var obj = args[0] as Fuse.Scripting.Object;
+			var obj = args[0] as IObject;
 			if (obj == null)
 			{
 				Fuse.Diagnostics.UserError( "`Router.modify` should be passed an object", r );
@@ -247,7 +247,7 @@ namespace Fuse.Navigation
 				return;
 			}
 			
-			var obj = args[0] as Fuse.Scripting.Object;
+			var obj = args[0] as IObject;
 			if (obj == null)
 			{
 				Fuse.Diagnostics.UserError( "`Router.bookmark` should be passed an object", r );
@@ -271,8 +271,8 @@ namespace Fuse.Navigation
 				}
 				else if (p =="relative")
 				{
-					var node = c.Wrap(o);
-					relative = r.FindOutletUp(node as Node);
+					var node = o as Node;
+					relative = r.FindOutletUp(node);
 					if (relative == null)
 					{
 						Fuse.Diagnostics.UserError( "Could not find an outlet from the `relative` node", r );
@@ -281,7 +281,7 @@ namespace Fuse.Navigation
 				}
 				else if (p == "path")
 				{
-					var path = o as Array;
+					var path = o as IArray;
 					if (path == null)
 					{
 						Fuse.Diagnostics.UserError( "`path` should be an array", r );

--- a/Source/Fuse.Navigation/RouterRequest.uno
+++ b/Source/Fuse.Navigation/RouterRequest.uno
@@ -82,7 +82,7 @@ namespace Fuse.Navigation
 			
 			if (name == "relative")
 			{
-				Relative = ParseNode(value);
+				Relative = value as Node;
 			}
 			else if (name == "transition")
 			{
@@ -315,12 +315,6 @@ namespace Fuse.Navigation
 
 			return true;
 		}
-		
-		protected virtual Node ParseNode(object value)
-		{
-			return value as Node;
-		}
-		
 	}
 
 }

--- a/Source/Fuse.Navigation/RouterRequest.uno
+++ b/Source/Fuse.Navigation/RouterRequest.uno
@@ -283,12 +283,6 @@ namespace Fuse.Navigation
 			if (arg is IObject)
 			{
 				var obj = (IObject)arg;
-				if (obj is Fuse.Reactive.IObservable)
-				{
-					Fuse.Diagnostics.UserError("Route parameter must be serializeable, cannot contain Observables.", null);		
-					return false;
-				}
-
 				var keys = obj.Keys;
 				for (var i = 0; i < keys.Length; i++)
 				{
@@ -310,6 +304,12 @@ namespace Fuse.Navigation
 			    arg is Reactive.IEventHandler)
 			{
 				Fuse.Diagnostics.UserError("Route parameter must be serializeable, cannot contain functions.", null);
+				return false;
+			}
+
+			if (arg is Fuse.Reactive.IObservable)
+			{
+				Fuse.Diagnostics.UserError("Route parameter must be serializeable, cannot contain Observables.", null);
 				return false;
 			}
 

--- a/Source/Fuse.Navigation/RouterRequest.uno
+++ b/Source/Fuse.Navigation/RouterRequest.uno
@@ -280,9 +280,9 @@ namespace Fuse.Navigation
 				return false;
 			}
 
-			if (arg is Scripting.Object)
+			if (arg is IObject)
 			{
-				var obj = (Scripting.Object)arg;
+				var obj = (IObject)arg;
 				if (obj is Fuse.Reactive.IObservable)
 				{
 					Fuse.Diagnostics.UserError("Route parameter must be serializeable, cannot contain Observables.", null);		
@@ -297,16 +297,17 @@ namespace Fuse.Navigation
 				}
 			}
 
-			if (arg is Scripting.Array)
+			if (arg is IArray)
 			{
-				var arr = (Scripting.Array)arg;
+				var arr = (IArray)arg;
 				for (var i = 0; i < arr.Length; i++)
 				{
 					if (!ValidateParameter(arr[i], depth+1)) return false;
 				}
 			}
 
-			if (arg is Scripting.Function) 
+			if (arg is Scripting.Function ||
+			    arg is Reactive.IEventHandler)
 			{
 				Fuse.Diagnostics.UserError("Route parameter must be serializeable, cannot contain functions.", null);
 				return false;

--- a/Source/Fuse.Navigation/Tests/RouteParamValidation.Test.uno
+++ b/Source/Fuse.Navigation/Tests/RouteParamValidation.Test.uno
@@ -95,11 +95,13 @@ namespace Fuse.Navigation.Test
 				root.StepFrameJS();
 
 				var diagnostics = dg.DequeueAll();
-				Assert.AreEqual(2, diagnostics.Count);
-				Assert.AreEqual(DiagnosticType.UserError, diagnostics[0].Type);
-				Assert.Contains("Route parameter must be serializeable, it contains reference loops or is too large", diagnostics[0].Message);
+				Assert.AreEqual(3, diagnostics.Count);
+				Assert.AreEqual(DiagnosticType.UserWarning, diagnostics[0].Type);
+				Assert.Contains("JavaScript data model contains circular references or is too deep. Some data may not display correctly.", diagnostics[0].Message);
 				Assert.AreEqual(DiagnosticType.UserError, diagnostics[1].Type);
-				Assert.Contains("Router.goto(): invalid route provided", diagnostics[1].Message);
+				Assert.Contains("Route parameter must be serializeable, it contains reference loops or is too large", diagnostics[1].Message);
+				Assert.AreEqual(DiagnosticType.UserError, diagnostics[2].Type);
+				Assert.Contains("Router.goto(): invalid route provided", diagnostics[2].Message);
 			}
 		}
 

--- a/Source/Fuse.Navigation/Tests/RouteParamValidation.Test.uno
+++ b/Source/Fuse.Navigation/Tests/RouteParamValidation.Test.uno
@@ -84,6 +84,26 @@ namespace Fuse.Navigation.Test
 		}
 
 		[Test]
+		public void BadParam3()
+		{
+			var p = new UX.RouteParamValidation();
+
+			using (var root = TestRootPanel.CreateWithChild(p, int2(100)))
+			using (var dg = new RecordDiagnosticGuard())
+			{
+				p.GotoTest6.Perform();
+				root.StepFrameJS();
+
+				var diagnostics = dg.DequeueAll();
+				Assert.AreEqual(2, diagnostics.Count);
+				Assert.AreEqual(DiagnosticType.UserError, diagnostics[0].Type);
+				Assert.Contains("Route parameter must be serializeable, cannot contain Observables.", diagnostics[0].Message);
+				Assert.AreEqual(DiagnosticType.UserError, diagnostics[1].Type);
+				Assert.Contains("Router.goto(): invalid route provided", diagnostics[1].Message);
+			}
+		}
+
+		[Test]
 		public void NestedObjects()
 		{
 			var p = new UX.RouteParamValidation();

--- a/Source/Fuse.Navigation/Tests/UX/RouteParamValidation.ux
+++ b/Source/Fuse.Navigation/Tests/UX/RouteParamValidation.ux
@@ -32,6 +32,15 @@
 			router.goto("page5", big_object);
 		};
 
+		module.exports.goto_test6 = function () {
+			var x = {
+				hello:"w3rld",
+				number:1338,
+				o: Observable(),
+			}
+			router.goto("page4", x);
+		};
+
 		function make_deep_object(depth) {
 			var o = {};
 			var n = o;
@@ -51,6 +60,7 @@
 	<FuseTest.Invoke Handler="{goto_test3}" ux:Name="GotoTest3" />
 	<FuseTest.Invoke Handler="{goto_test4}" ux:Name="GotoTest4" />
 	<FuseTest.Invoke Handler="{goto_test5}" ux:Name="GotoTest5" />
+	<FuseTest.Invoke Handler="{goto_test6}" ux:Name="GotoTest6" />
 
 	<Navigator Dock="Fill" ux:Name="_navigator">
 		<RouterPanel router="router" ux:Template="page1" />

--- a/Source/Fuse.Navigation/VisualNavigation.uno
+++ b/Source/Fuse.Navigation/VisualNavigation.uno
@@ -13,7 +13,7 @@ namespace Fuse.Navigation
 		static VisualNavigation()
 		{
 			ScriptClass.Register(typeof(VisualNavigation),
-				new ScriptMethod<VisualNavigation>("goto", gotoNode, ExecutionThread.MainThread));
+				new ScriptMethod<VisualNavigation>("goto", gotoNode));
 		}
 
 		/**
@@ -23,7 +23,7 @@ namespace Fuse.Navigation
 			@param node The `Visual` target for the transition. For most navigation types this must already be
 				 a child of the navigation panel.
 		*/
-		static void gotoNode(Context c, VisualNavigation nav, object[] args)
+		static void gotoNode(VisualNavigation nav, object[] args)
 		{
 			var target = args[0] as Visual;
 			if (target != null) nav.Goto(target);

--- a/Source/Fuse.Nodes/Node.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Node.ScriptClass.uno
@@ -13,7 +13,7 @@ namespace Fuse
 			ScriptClass.Register(typeof(Node),
 				new ScriptMethod<Node>("_createWatcher", _createWatcher, ExecutionThread.JavaScript),
 				new ScriptMethod<Node>("_destroyWatcher", _destroyWatcher, ExecutionThread.JavaScript),
-				new ScriptMethodInline("findData", ExecutionThread.JavaScript, "function(key) { return Observable._getDataObserver(this, key); }"));
+				new ScriptMethodInline("findData", "function(key) { return Observable._getDataObserver(this, key); }"));
 		}
 
 		static object _createWatcher(Context c, Node n, object[] args)

--- a/Source/Fuse.Nodes/Node.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Node.ScriptClass.uno
@@ -12,7 +12,7 @@ namespace Fuse
 		{
 			ScriptClass.Register(typeof(Node),
 				new ScriptMethod<Node>("_createWatcher", _createWatcher),
-				new ScriptMethod<Node>("_destroyWatcher", _destroyWatcher, ExecutionThread.JavaScript),
+				new ScriptMethod<Node>("_destroyWatcher", _destroyWatcher),
 				new ScriptMethodInline("findData", "function(key) { return Observable._getDataObserver(this, key); }"));
 		}
 
@@ -23,13 +23,15 @@ namespace Fuse
 			return new External(new DataWatcher(n, c, callback, key));			
 		}
 
-		static void _destroyWatcher(Context c, Node n, object[] args)
+		static object _destroyWatcher(Context c, Node n, object[] args)
 		{
 			if (args[0] != null)
 			{
 				var watcher = (DataWatcher)((External)args[0]).Object;
 				watcher.Dispose();
 			}
+
+			return null;
 		}
 
 		class DataWatcher: Node.DataFinder, IDataListener

--- a/Source/Fuse.Nodes/Node.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Node.ScriptClass.uno
@@ -11,7 +11,7 @@ namespace Fuse
 		static Node()
 		{
 			ScriptClass.Register(typeof(Node),
-				new ScriptMethod<Node>("_createWatcher", _createWatcher, ExecutionThread.JavaScript),
+				new ScriptMethod<Node>("_createWatcher", _createWatcher),
 				new ScriptMethod<Node>("_destroyWatcher", _destroyWatcher, ExecutionThread.JavaScript),
 				new ScriptMethodInline("findData", "function(key) { return Observable._getDataObserver(this, key); }"));
 		}

--- a/Source/Fuse.Nodes/Visual.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Visual.ScriptClass.uno
@@ -12,8 +12,8 @@ namespace Fuse
 		{
 			ScriptClass.Register(typeof(Visual), 
 				new ScriptProperty<Visual, string>("Parameter", getParameterProperty, ".notNull().parseJson()"),
-				new ScriptMethod<Visual>("onParameterChanged", onParameterChanged, ExecutionThread.MainThread),
-				new ScriptMethod<Visual>("bringIntoView", bringIntoView, ExecutionThread.MainThread));
+				new ScriptMethod<Visual>("onParameterChanged", onParameterChanged),
+				new ScriptMethod<Visual>("bringIntoView", bringIntoView));
 		}
 
 		class ParameterProperty: Property<string>
@@ -40,7 +40,7 @@ namespace Fuse
 			
 			@scriptmethod bringIntoView()
 		*/
-		static void bringIntoView(Context c, Visual n, object[] args)
+		static void bringIntoView(Visual n)
 		{
 			n.BringIntoView();
 		}
@@ -66,7 +66,7 @@ namespace Fuse
 			@param callback The script method to call when the parameter changes. This is guaranted to be
 				called at least once at registration time; you don't need to lookup the parameter another way.
 		*/
-		static void onParameterChanged(Context c, Visual v, object[] args)
+		static void onParameterChanged(Visual v, object[] args)
 		{
 			v.AddParameterChangedListener((Scripting.Function)args[0]);
 		}

--- a/Source/Fuse.Scripting.JavaScript/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/Context.uno
@@ -58,7 +58,7 @@ namespace Fuse.Scripting.JavaScript
 			return TypeWrapper.Unwrap(this, obj);
 		}
 
-		public object Reflect(Scripting.Context context, object obj)
+		public object Reflect(object obj)
 		{
 			var e = obj as Scripting.External;
 			if (e != null) return e.Object;
@@ -89,6 +89,14 @@ namespace Fuse.Scripting.JavaScript
 				return res;
 
 			return obj;
+		}
+
+		object IMirror.Reflect(Scripting.Context context, object obj)
+		{
+			if (context != this)
+				Fuse.Diagnostics.InternalError("IMirror.Reflect with inconsistent context", this);
+
+			return Reflect(obj);
 		}
 
 		object CreateMirror(object obj)

--- a/Source/Fuse.Scripting.JavaScript/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/Context.uno
@@ -58,7 +58,7 @@ namespace Fuse.Scripting.JavaScript
 			return TypeWrapper.Unwrap(this, obj);
 		}
 
-		public object Reflect(object obj)
+		public sealed override object Reflect(object obj)
 		{
 			var e = obj as Scripting.External;
 			if (e != null) return e.Object;

--- a/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
+++ b/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
@@ -41,7 +41,7 @@ namespace Fuse.Scripting.JavaScript
 			}
 
 			_js.ScriptModule.Dependencies = deps;
-			_dc = ctx.Reflect(context, EvaluateExports(ctx));
+			_dc = ctx.Reflect(EvaluateExports(ctx));
 			UpdateManager.PostAction(SetDataContext);
 		}
 

--- a/Source/Fuse.Scripting.JavaScript/Observable.uno
+++ b/Source/Fuse.Scripting.JavaScript/Observable.uno
@@ -279,7 +279,7 @@ namespace Fuse.Scripting.JavaScript
 
 			if (op == "set")
 			{
-				UpdateManager.PostAction(new Set(this, ctx.Reflect(context, args[3]), origin).Perform);
+				UpdateManager.PostAction(new Set(this, ctx.Reflect(args[3]), origin).Perform);
 			}
 			else if (op == "clear") 
 			{
@@ -287,15 +287,15 @@ namespace Fuse.Scripting.JavaScript
 			}
 			else if (op == "newAt")
 			{
-				UpdateManager.PostAction(new NewAt(this, ToInt(args[3]), ctx.Reflect(context, args[4])).Perform);
+				UpdateManager.PostAction(new NewAt(this, ToInt(args[3]), ctx.Reflect(args[4])).Perform);
 			}
 			else if (op == "newAll") 
 			{
-				UpdateManager.PostAction(new NewAll(this, (ArrayMirror)ctx.Reflect(context, args[3]), origin).Perform);
+				UpdateManager.PostAction(new NewAll(this, (ArrayMirror)ctx.Reflect(args[3]), origin).Perform);
 			}
 			else if (op == "add") 
 			{
-				UpdateManager.PostAction(new Add(this, ctx.Reflect(context, args[3])).Perform);
+				UpdateManager.PostAction(new Add(this, ctx.Reflect(args[3])).Perform);
 			}
 			else if (op == "removeAt")
 			{
@@ -303,7 +303,7 @@ namespace Fuse.Scripting.JavaScript
 			}
 			else if (op == "insertAt")
 			{
-				UpdateManager.PostAction(new InsertAt(this, ToInt(args[3]), ctx.Reflect(context, args[4])).Perform);
+				UpdateManager.PostAction(new InsertAt(this, ToInt(args[3]), ctx.Reflect(args[4])).Perform);
 			}
 			else if (op == "removeRange")
 			{
@@ -311,7 +311,7 @@ namespace Fuse.Scripting.JavaScript
 			}
 			else if (op == "insertAll") 
 			{
-				UpdateManager.PostAction(new InsertAll(this, ToInt(args[3]), (ArrayMirror)ctx.Reflect(context, args[4])).Perform);
+				UpdateManager.PostAction(new InsertAll(this, ToInt(args[3]), (ArrayMirror)ctx.Reflect(args[4])).Perform);
 			}
 			else if (op == "failed")
 			{

--- a/Source/Fuse.Scripting.JavaScript/Tests/DateMarshalTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/DateMarshalTest.uno
@@ -39,14 +39,14 @@ namespace Fuse.Reactive.Test
 		static DateMarshalTestScriptClass()
 		{
 			ScriptClass.Register(typeof(DateMarshalTestScriptClass),
-				new ScriptMethod<DateMarshalTestScriptClass>("setDateTime", SetDateTime, ExecutionThread.MainThread));
+				new ScriptMethod<DateMarshalTestScriptClass>("setDateTime", SetDateTime));
 		}
 
 		public DateTime DateTime { get; set; }
 
-		static void SetDateTime(Context c, DateMarshalTestScriptClass self, object[] args)
+		static void SetDateTime(DateMarshalTestScriptClass self, object[] args)
 		{
-			self.DateTime = (DateTime)c.Wrap(args[0]);
+			self.DateTime = (DateTime)args[0];
 		}
 	}
 

--- a/Source/Fuse.Scripting.JavaScript/Tests/JsOrderingTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/JsOrderingTest.uno
@@ -111,10 +111,10 @@ namespace FuseTest
 		static Ordering()
 		{
 			ScriptClass.Register(typeof(Ordering),
-				new ScriptMethod<Ordering>("go", go, ExecutionThread.MainThread));
+				new ScriptMethod<Ordering>("go", go));
 		}
 		
-		static void go(Context c, Ordering o, object[] args)
+		static void go(Ordering o, object[] args)
 		{
 			o.AddAction( "G", Marshal.ToType<string>(args[0]));
 		}

--- a/Source/Fuse.Scripting/Context.uno
+++ b/Source/Fuse.Scripting/Context.uno
@@ -64,6 +64,8 @@ namespace Fuse.Scripting
 
 		public abstract object Wrap(object obj);
 		public abstract object Unwrap(object obj);
+		public abstract object Reflect(object obj);
+
 
 		public void Invoke(Uno.Action<Scripting.Context> action)
 		{

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -126,6 +126,7 @@ namespace Fuse.Scripting
 		{
 		}
 
+		[Obsolete("Use ScriptMethod<T>(string, Uno.Action<T)>), ScriptMethod<T>(string, Uno.Action<T, object[])>) or ScriptMethod<T>(string, Uno.Func<Fuse.Scripting.Context, T, object[], object)>) instead")]
 		public ScriptMethod(string name, Action<Context, T, object[]> method, ExecutionThread thread): base(name, thread)
 		{
 			if (method == null)

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -78,7 +78,13 @@ namespace Fuse.Scripting
 	{
 		public readonly string Code;
 
+		[Obsolete("Use ScriptMethodInline(string, string) instead")]
 		public ScriptMethodInline(string name, ExecutionThread thread, string code): base(name, thread)
+		{
+			Code = code;
+		}
+
+		public ScriptMethodInline(string name, string code): base(name, ExecutionThread.JavaScript)
 		{
 			Code = code;
 		}

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -100,7 +100,7 @@ namespace Fuse.Scripting
 		readonly Func<Context, T, object[], object> _method;
 		readonly Action<Context, T, object[]> _voidMethod;
 
-		public ScriptMethod(string name, Func<Context, T, object[], object> method, ExecutionThread thread): base(name, thread)
+		ScriptMethod(string name, Func<Context, T, object[], object> method, ExecutionThread thread, bool dummy): base(name, thread)
 		{
 			if (method == null)
 				throw new ArgumentNullException(nameof(method));
@@ -109,6 +109,15 @@ namespace Fuse.Scripting
 				throw new ArgumentException("Cannot call a non-void method asynchronously", nameof(thread));
 
 			_method = method;
+		}
+
+		[Obsolete("Use ScriptMethod<T>(string, Uno.Func<Fuse.Scripting.Context, T, object[], object)>) instead")]
+		public ScriptMethod(string name, Func<Context, T, object[], object> method, ExecutionThread thread): this(name, method, thread, true)
+		{
+		}
+
+		public ScriptMethod(string name, Func<Context, T, object[], object> method): this(name, method, ExecutionThread.JavaScript, true)
+		{
 		}
 
 		public ScriptMethod(string name, Action<Context, T, object[]> method, ExecutionThread thread): base(name, thread)

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -7,9 +7,9 @@ namespace Fuse.Scripting
 {
 	public enum ExecutionThread
 	{
-		Any,
 		JavaScript,
-		MainThread
+		MainThread,
+		Any = JavaScript
 	}
 
 	public abstract class ScriptMember

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -98,7 +98,8 @@ namespace Fuse.Scripting
 	public class ScriptMethod<T>: ScriptMethod
 	{
 		readonly Func<Context, T, object[], object> _method;
-		readonly Action<Context, T, object[]> _voidMethod;
+		readonly Action<Context, T, object[]> _oldVoidMethod;
+		readonly Action<T> _voidMethod;
 
 		ScriptMethod(string name, Func<Context, T, object[], object> method, ExecutionThread thread, bool dummy): base(name, thread)
 		{
@@ -116,6 +117,11 @@ namespace Fuse.Scripting
 		{
 		}
 
+		/** Create a ScriptMethod that will run on the script-thread
+
+			@param name Name of method
+			@param method The native implementation of the method
+		*/
 		public ScriptMethod(string name, Func<Context, T, object[], object> method): this(name, method, ExecutionThread.JavaScript, true)
 		{
 		}
@@ -125,20 +131,87 @@ namespace Fuse.Scripting
 			if (method == null)
 				throw new ArgumentNullException(nameof(method));
 
+			_oldVoidMethod = method;
+		}
+
+		/** Create an argument-less ScriptMethod that will run on the UI-thread
+
+			@param name Name of method
+			@param method The native implementation of the method
+		*/
+		public ScriptMethod(string name, Action<T> method): base(name, ExecutionThread.MainThread)
+		{
+			if (method == null)
+				throw new ArgumentNullException(nameof(method));
+
 			_voidMethod = method;
+		}
+
+		/** Create a ScriptMethod that will run on the UI-thread
+
+			@param name Name of method
+			@param method The native implementation of the method
+		*/
+		public ScriptMethod(string name, Action<T, object[]> method): base(name, ExecutionThread.JavaScript)
+		{
+			if (method == null)
+				throw new ArgumentNullException(nameof(method));
+
+			_method = new ArgumentMirrorClosure<T>(method).Run;
+		}
+
+		class ArgumentMirrorClosure<T>
+		{
+			readonly Action<T, object[]> _action;
+			public ArgumentMirrorClosure(Action<T, object[]> action)
+			{
+				_action = action;
+			}
+
+			public object Run(Context c, T obj, object[] args)
+			{
+				var marshalledArguments = new List<object>();
+				foreach (var arg in args)
+					marshalledArguments.Add(c.Reflect(arg));
+
+				UpdateManager.PostAction(new CallWithArgumentsClosure(_action, obj, marshalledArguments.ToArray()).Run);
+				return null;
+			}
+
+			class CallWithArgumentsClosure
+			{
+				readonly Action<T, object[]> _action;
+				readonly T _obj;
+				readonly object[] _args;
+				public CallWithArgumentsClosure(Action<T, object[]> action, T obj, object[] args)
+				{
+					_action = action;
+					_obj = obj;
+					_args = args;
+				}
+
+				public void Run()
+				{
+					_action(_obj, _args);
+				}
+			}
 		}
 
 		public override object Call(Context c, object obj, object[] args)
 		{
 			if (Thread == ExecutionThread.MainThread)
 			{
-				UpdateManager.PostAction(new CallClosure(_voidMethod, c, obj, args).Run);
+				if (_oldVoidMethod != null)
+					UpdateManager.PostAction(new CallClosure(c, _oldVoidMethod, obj, args).Run);
+				else
+					UpdateManager.PostAction(new CallClosure(_voidMethod, obj).Run);
+
 				return null;
 			}
-			
-			if (_voidMethod != null)
+
+			if (_oldVoidMethod != null)
 			{
-				_voidMethod(c, (T)obj, args);
+				_oldVoidMethod(c, (T)obj, args);
 				return null;
 			}
 			else
@@ -149,22 +222,32 @@ namespace Fuse.Scripting
 		
 		class CallClosure
 		{
-			readonly Action<Context, T, object[]> _method;
+			readonly Action<T> _method;
 			readonly object _obj;
-			readonly Context _context;
 			readonly object[] _args;
 
-			public CallClosure(Action<Context, T, object[]> method, Context c, object obj, object[] args)
+			public CallClosure(Action<T> method, object obj)
 			{
 				_method = method;
-				_context = c;
+				_obj = obj;
+			}
+
+			readonly Context _context;
+			readonly Action<Context, T, object[]> _oldMethod;
+			public CallClosure(Context context, Action<Context, T, object[]> method, object obj, object[] args)
+			{
+				_context = context;
+				_oldMethod = method;
 				_obj = obj;
 				_args = args;
 			}
 
 			public void Run()
 			{
-				_method(_context, (T)_obj, _args);
+				if (_method != null)
+					_method((T)_obj);
+				else
+					_oldMethod(_context, (T)_obj, _args);
 			}
 		}
 

--- a/Source/Fuse.Scripting/Tests/ScriptMethod.Test.uno
+++ b/Source/Fuse.Scripting/Tests/ScriptMethod.Test.uno
@@ -1,0 +1,127 @@
+using Uno;
+using Uno.Testing;
+using Uno.Threading;
+using Uno.Collections;
+
+using Fuse;
+using Fuse.Reactive;
+using Fuse.Scripting;
+using FuseTest;
+
+public class MyScriptClass : Node
+{
+	static MyScriptClass()
+	{
+		ScriptClass.Register(typeof(MyScriptClass),
+			new ScriptMethod<MyScriptClass>("jsThreadMethod", jsThreadMethod),
+			new ScriptMethod<MyScriptClass>("uiThreadMethod", uiThreadMethod),
+			);
+	}
+
+	public int JSThreadFuncCalls { get; private set; }
+	static object jsThreadMethod(Context c, MyScriptClass self, object[] args)
+	{
+		self.JSThreadFuncCalls = self.JSThreadFuncCalls + 1;
+
+		Assert.AreEqual(4, args.Length);
+		Assert.AreEqual("foo", args[0]);
+
+		// validate object-argument
+		Assert.IsTrue(args[1] is Fuse.Scripting.Object);
+		var obj = (Fuse.Scripting.Object)args[1];
+		Assert.IsTrue(obj.ContainsKey("foo"));
+		Assert.AreEqual("bar", obj["foo"]);
+
+		// validate array-argument
+		Assert.IsTrue(args[2] is Fuse.Scripting.Array);
+		var arr = (Fuse.Scripting.Array)args[2];
+		Assert.AreEqual(2, arr.Length);
+		Assert.AreEqual("foo", arr[0]);
+		Assert.AreEqual("bar", arr[1]);
+
+		// validate function-argument
+		Assert.IsTrue(args[3] is Fuse.Scripting.Function);
+
+		return "baz";
+	}
+
+	public int UIThreadFuncCalls { get; private set; }
+	static void uiThreadMethod(MyScriptClass self, object[] args)
+	{
+		self.UIThreadFuncCalls = self.UIThreadFuncCalls + 1;
+
+		Assert.AreEqual(4, args.Length);
+		Assert.AreEqual("foo", args[0]);
+
+		// validate object-argument
+		Assert.IsFalse(args[1] is Fuse.Scripting.Object);
+		Assert.IsTrue(args[1] is IObject);
+		var obj = (IObject)args[1];
+		Assert.IsTrue(obj.ContainsKey("foo"));
+		Assert.AreEqual("bar", obj["foo"]);
+
+		// validate array-argument
+		Assert.IsFalse(args[2] is Fuse.Scripting.Array);
+		Assert.IsTrue(args[2] is IArray);
+		var arr = (IArray)args[2];
+		Assert.AreEqual(2, arr.Length);
+		Assert.AreEqual("foo", arr[0]);
+		Assert.AreEqual("bar", arr[1]);
+
+		// validate function-argument
+		Assert.IsFalse(args[3] is Fuse.Scripting.Function);
+		Assert.IsTrue(args[3] is IEventHandler);
+	}
+}
+
+
+namespace Fuse.Scripting.Test
+{
+	public class ScriptMethodTest : TestBase
+	{
+		[Test]
+		public void JSThreadMethod()
+		{
+			var p =  new UX.ScriptMethod();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+
+				Assert.AreEqual(0, p.ScriptClass.JSThreadFuncCalls);
+				p.CallJSThreadMethod.Perform();
+
+				// simply waiting should be sufficient for methods on the JS thread
+				var fence = Fuse.Reactive.JavaScript.Worker.PostFence();
+				while (!fence.IsSignaled)
+					Thread.Sleep(100);
+
+				Assert.AreEqual(1, p.ScriptClass.JSThreadFuncCalls);
+
+				root.MultiStepFrameJS(2); // ensure any exceptions have been thrown
+			}
+		}
+
+		[Test]
+		public void UIThreadMethod()
+		{
+			var p =  new UX.ScriptMethod();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+
+				Assert.AreEqual(0, p.ScriptClass.UIThreadFuncCalls);
+				p.CallUIThreadMethod.Perform();
+
+				// sleeping should *not* cause the function to run
+				Thread.Sleep(100);
+				Assert.AreEqual(0, p.ScriptClass.UIThreadFuncCalls);
+
+				// ...but StepFrameJS should
+				root.StepFrameJS();
+				Assert.AreEqual(1, p.ScriptClass.UIThreadFuncCalls);
+
+				root.MultiStepFrameJS(2); // ensure any exceptions have been thrown
+			}
+		}
+	}
+}

--- a/Source/Fuse.Scripting/Tests/UX/ScriptMethod.ux
+++ b/Source/Fuse.Scripting/Tests/UX/ScriptMethod.ux
@@ -1,0 +1,27 @@
+<Panel ux:Class="UX.ScriptMethod">
+	<JavaScript>
+		module.exports = {
+			callJSThreadMethod: function() {
+				var result = ScriptClass.jsThreadMethod(
+					"foo",
+					{"foo": "bar"},
+					["foo", "bar"],
+					function() { return "foo"; });
+				if (result !== "baz")
+					throw new Error('Unexpected result');
+			},
+			callUIThreadMethod: function() {
+				var result = ScriptClass.uiThreadMethod(
+					"foo",
+					{"foo": "bar"},
+					["foo", "bar"],
+					function() { return "foo"; });
+				if (result !== null)
+					throw new Error('Unexpected result');
+			}
+		};
+	</JavaScript>
+	<MyScriptClass ux:Name="ScriptClass" />
+	<FuseTest.Invoke ux:Name="CallJSThreadMethod" Handler="{callJSThreadMethod}" />
+	<FuseTest.Invoke ux:Name="CallUIThreadMethod" Handler="{callUIThreadMethod}" />
+</Panel>

--- a/Source/Fuse.Selection/Selectable.ScriptClass.uno
+++ b/Source/Fuse.Selection/Selectable.ScriptClass.uno
@@ -11,9 +11,9 @@ namespace Fuse.Selection
 		static Selectable()
 		{
 			ScriptClass.Register(typeof(Selectable),
-				new ScriptMethod<Selectable>("add", add, ExecutionThread.MainThread),
-				new ScriptMethod<Selectable>("remove", remove, ExecutionThread.MainThread),
-				new ScriptMethod<Selectable>("toggle", toggle, ExecutionThread.MainThread));
+				new ScriptMethod<Selectable>("add", add),
+				new ScriptMethod<Selectable>("remove", remove),
+				new ScriptMethod<Selectable>("toggle", toggle));
 		}
 
 		/**
@@ -21,7 +21,7 @@ namespace Fuse.Selection
 			
 			This follows the high level selection rules (such as MaxCount and Replace).
 		*/
-		static void add(Context c, Selectable s, object[] args )
+		static void add(Selectable s, object[] args )
 		{
 			if (args.Length != 0)
 			{
@@ -39,7 +39,7 @@ namespace Fuse.Selection
 			
 			If the Selectable is not currently selected then nothing is removed.
 		*/
-		static void remove(Context c, Selectable s, object[] args )
+		static void remove(Selectable s, object[] args )
 		{
 			if (args.Length != 0)
 			{
@@ -55,7 +55,7 @@ namespace Fuse.Selection
 			
 			This follows the high level selection rules (such as MaxCount/MinCount).
 		*/
-		static void toggle(Context c, Selectable s, object[] args )
+		static void toggle(Selectable s, object[] args )
 		{
 			if (args.Length != 0)
 			{

--- a/Source/Fuse.Selection/Selection.ScriptClass.uno
+++ b/Source/Fuse.Selection/Selection.ScriptClass.uno
@@ -11,12 +11,12 @@ namespace Fuse.Selection
 		static Selection()
 		{
 			ScriptClass.Register(typeof(Selection),
-				new ScriptMethod<Selection>("clear", clear, ExecutionThread.MainThread),
-				new ScriptMethod<Selection>("add", add, ExecutionThread.MainThread),
-				new ScriptMethod<Selection>("remove", remove, ExecutionThread.MainThread),
-				new ScriptMethod<Selection>("forceAdd", forceAdd, ExecutionThread.MainThread),
-				new ScriptMethod<Selection>("forceRemove", forceRemove, ExecutionThread.MainThread),
-				new ScriptMethod<Selection>("toggle", toggle, ExecutionThread.MainThread));
+				new ScriptMethod<Selection>("clear", clear),
+				new ScriptMethod<Selection>("add", add),
+				new ScriptMethod<Selection>("remove", remove),
+				new ScriptMethod<Selection>("forceAdd", forceAdd),
+				new ScriptMethod<Selection>("forceRemove", forceRemove),
+				new ScriptMethod<Selection>("toggle", toggle));
 		}
 		
 		/**
@@ -24,7 +24,7 @@ namespace Fuse.Selection
 			
 			This does not respect restrictions, such as `MinCount`, and results in 0 items being selected.
 		*/
-		static void clear(Context c, Selection s, object[] args)
+		static void clear(Selection s, object[] args)
 		{
 			if (args.Length != 0)
 			{
@@ -42,7 +42,7 @@ namespace Fuse.Selection
 			
 			This cannot verify that there is actually a @Selectable with this value.
 		*/
-		static void add(Context c, Selection s, object[] args)
+		static void add(Selection s, object[] args)
 		{
 			if (args.Length != 1)
 			{
@@ -60,7 +60,7 @@ namespace Fuse.Selection
 			
 			If the value is not in the selection then nothing is removed.
 		*/
-		static void remove(Context c, Selection s, object[] args)
+		static void remove(Selection s, object[] args)
 		{
 			if (args.Length != 1)
 			{
@@ -74,7 +74,7 @@ namespace Fuse.Selection
 		/**
 			Adds a string value to the selection even if it would violate the high level selection rules. A duplicate value will however not be added.
 		*/
-		static void forceAdd(Context c, Selection s, object[] args)
+		static void forceAdd(Selection s, object[] args)
 		{
 			if (args.Length != 1)
 			{
@@ -88,7 +88,7 @@ namespace Fuse.Selection
 		/**
 			Removes a string value from the selection even if it would violate the high level selection rules.
 		*/
-		static void forceRemove(Context c, Selection s, object[] args)
+		static void forceRemove(Selection s, object[] args)
 		{
 			if (args.Length != 1)
 			{
@@ -104,7 +104,7 @@ namespace Fuse.Selection
 			
 			This follows the high level selection rules (such as MaxCount/MinCount).
 		*/
-		static void toggle(Context c, Selection s, object[] args)
+		static void toggle(Selection s, object[] args)
 		{
 			if (args.Length != 1)
 			{

--- a/Source/Fuse.Triggers/Busy.ScriptClass.uno
+++ b/Source/Fuse.Triggers/Busy.ScriptClass.uno
@@ -10,8 +10,8 @@ namespace Fuse.Triggers
 		static Busy()
 		{
 			ScriptClass.Register(typeof(Busy), 
-				new ScriptMethod<Busy>("activate", activate, ExecutionThread.MainThread),
-				new ScriptMethod<Busy>("deactivate", deactivate, ExecutionThread.MainThread)
+				new ScriptMethod<Busy>("activate", activate),
+				new ScriptMethod<Busy>("deactivate", deactivate)
 			);
 		}
 		
@@ -22,7 +22,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod activate()
 		*/
-		static void activate(Context c, Busy b, object[] args)
+		static void activate(Busy b, object[] args)
 		{
 			if (args.Length != 0)
 			{
@@ -40,7 +40,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod deactivate()
 		*/
-		static void deactivate(Context c, Busy b, object[] args)
+		static void deactivate(Busy b, object[] args)
 		{
 			if (args.Length != 0)
 			{

--- a/Source/Fuse.Triggers/BusyTask.uno
+++ b/Source/Fuse.Triggers/BusyTask.uno
@@ -228,7 +228,7 @@ namespace Fuse.Triggers
 		static BusyTask()
 		{
 			ScriptClass.Register(typeof(BusyTask), 
-				new ScriptMethod<BusyTask>("done", done, ExecutionThread.MainThread));
+				new ScriptMethod<BusyTask>("done", done));
 		}
 
 		/**
@@ -236,7 +236,7 @@ namespace Fuse.Triggers
 			
 			Completes a [BusyTask](/docs/fuse/triggers/busytaskmodule).
 		*/
-		static void done(Context c, BusyTask bt, object[] args)
+		static void done(BusyTask bt)
 		{
 			bt.Done();
 		}

--- a/Source/Fuse.Triggers/Completed.ScriptClass.uno
+++ b/Source/Fuse.Triggers/Completed.ScriptClass.uno
@@ -10,7 +10,7 @@ namespace Fuse.Triggers
 		static Completed()
 		{
 			ScriptClass.Register(typeof(Completed),
-				new ScriptMethod<Completed>("reset", reset, ExecutionThread.MainThread)
+				new ScriptMethod<Completed>("reset", reset)
 			);
 		}
 		
@@ -21,7 +21,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod reset()
 		*/
-		static void reset(Context c, Completed cp, object[] args)
+		static void reset(Completed cp, object[] args)
 		{
 			if (args.Length != 0)
 			{

--- a/Source/Fuse.Triggers/State.ScriptClass.uno
+++ b/Source/Fuse.Triggers/State.ScriptClass.uno
@@ -10,7 +10,7 @@ namespace Fuse.Triggers
 		static State()
 		{
 			ScriptClass.Register(typeof(State),
-				new ScriptMethod<State>("goto", goto_, ExecutionThread.MainThread)
+				new ScriptMethod<State>("goto", goto_)
 			);
 		}
 			
@@ -21,7 +21,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod goto()
 		*/
-		static void goto_(Context c, State n, object[] args)
+		static void goto_(State n)
 		{
 			n.Goto();
 		}

--- a/Source/Fuse.Triggers/StateGroup.ScriptClass.uno
+++ b/Source/Fuse.Triggers/StateGroup.ScriptClass.uno
@@ -10,8 +10,8 @@ namespace Fuse.Triggers
 		static StateGroup()
 		{
 			ScriptClass.Register(typeof(StateGroup), 
-				new ScriptMethod<StateGroup>("goto", goto_, ExecutionThread.MainThread),
-				new ScriptMethod<StateGroup>("gotoNext", gotoNext, ExecutionThread.MainThread)
+				new ScriptMethod<StateGroup>("goto", goto_),
+				new ScriptMethod<StateGroup>("gotoNext", gotoNext)
 			);
 		}
 
@@ -20,7 +20,7 @@ namespace Fuse.Triggers
 			return o is State;
 		}
 
-		static void gotoName(Context c, StateGroup n, string name)
+		static void gotoName(StateGroup n, string name)
 		{
 			var state = n.FindObjectByName(name, StateAcceptor) as State;
 			if (state == null)
@@ -41,7 +41,7 @@ namespace Fuse.Triggers
 			@param state The state object for the target state. This must be a @State that already 
 				exists in this @StateGroup.
 		*/
-		static void goto_(Context c, StateGroup n, object[] args)
+		static void goto_(StateGroup n, object[] args)
 		{
 			if (args.Length != 1)
 			{
@@ -50,7 +50,7 @@ namespace Fuse.Triggers
 			}
 			
 			if (args[0] is string)
-				gotoName(c, n, args[0] as string);
+				gotoName(n, args[0] as string);
 			else
 				n.Goto(args[0] as State);
 		}
@@ -61,7 +61,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod gotoNext()
 		*/
-		static void gotoNext(Context c, StateGroup n, object[] args)
+		static void gotoNext(StateGroup n, object[] args)
 		{
 			n.GotoNextState();
 		}

--- a/Source/Fuse.Triggers/Timeline.ScriptClass.uno
+++ b/Source/Fuse.Triggers/Timeline.ScriptClass.uno
@@ -10,15 +10,15 @@ namespace Fuse.Triggers
 		static Timeline()
 		{
 			ScriptClass.Register(typeof(Timeline),
-				new ScriptMethod<Timeline>("pause", pause, ExecutionThread.MainThread),
-				new ScriptMethod<Timeline>("pulse", pulse, ExecutionThread.MainThread),
-				new ScriptMethod<Timeline>("pulseBackward", pulseBackward, ExecutionThread.MainThread),
-				new ScriptMethod<Timeline>("pulseForward", pulseForward, ExecutionThread.MainThread),
-				new ScriptMethod<Timeline>("play", resume, ExecutionThread.MainThread),
-				new ScriptMethod<Timeline>("playTo", playTo, ExecutionThread.MainThread),
-				new ScriptMethod<Timeline>("resume", resume, ExecutionThread.MainThread),
-				new ScriptMethod<Timeline>("seek", seek, ExecutionThread.MainThread),
-				new ScriptMethod<Timeline>("stop", stop, ExecutionThread.MainThread)
+				new ScriptMethod<Timeline>("pause", pause),
+				new ScriptMethod<Timeline>("pulse", pulse),
+				new ScriptMethod<Timeline>("pulseBackward", pulseBackward),
+				new ScriptMethod<Timeline>("pulseForward", pulseForward),
+				new ScriptMethod<Timeline>("play", resume),
+				new ScriptMethod<Timeline>("playTo", playTo),
+				new ScriptMethod<Timeline>("resume", resume),
+				new ScriptMethod<Timeline>("seek", seek),
+				new ScriptMethod<Timeline>("stop", stop)
 			);
 		}
 
@@ -27,7 +27,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod pulse()
 		*/
-		static void pulse(Context c, Timeline n, object[] args)
+		static void pulse(Timeline n)
 		{
 			n.Pulse();
 		}
@@ -37,7 +37,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod pulseForward()
 		*/
-		static void pulseForward(Context c, Timeline n, object[] args)
+		static void pulseForward(Timeline n)
 		{
 			n.PulseForward();
 		}
@@ -47,7 +47,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod pulseBackward()
 		*/
-		static void pulseBackward(Context c, Timeline n, object[] args)
+		static void pulseBackward(Timeline n)
 		{
 			n.PulseBackward();
 		}
@@ -60,7 +60,7 @@ namespace Fuse.Triggers
 			
 			@param progress The relative position (0..1) to play to.
 		*/
-		static void playTo(Context c, Timeline n, object[] args)
+		static void playTo(Timeline n, object[] args)
 		{
 			if (args.Length != 1)
 			{
@@ -77,7 +77,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod stop()
 		*/
-		static void stop(Context c, Timeline n, object[] args)
+		static void stop(Timeline n)
 		{
 			n.Stop();
 		}
@@ -88,7 +88,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod resume()
 		*/
-		static void resume(Context c, Timeline n, object[] args)
+		static void resume(Timeline n)
 		{
 			n.Resume();
 		}
@@ -98,7 +98,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod pause()
 		*/
-		static void pause(Context c, Timeline n, object[] args)
+		static void pause(Timeline n)
 		{
 			n.Pause();
 		}
@@ -109,7 +109,7 @@ namespace Fuse.Triggers
 			@scriptmethod seek( progress )
 			@param progress The relative position (0..1) to seek to.
 		*/
-		static void seek(Context c, Timeline n, object[] args)
+		static void seek(Timeline n, object[] args)
 		{
 			if (args.Length != 1)
 			{

--- a/Source/Fuse.UserEvents/UserEvent.ScriptClass.uno
+++ b/Source/Fuse.UserEvents/UserEvent.ScriptClass.uno
@@ -11,7 +11,7 @@ namespace Fuse
 		static UserEvent()
 		{
 			ScriptClass.Register(typeof(UserEvent),
-				new ScriptMethod<UserEvent>("raise", raise, ExecutionThread.MainThread)
+				new ScriptMethod<UserEvent>("raise", raise)
 			);
 		}
 
@@ -63,7 +63,7 @@ namespace Fuse
 				</JavaScript>
 			
 		**/
-		static void raise(Context c, UserEvent n, object[] args)
+		static void raise(UserEvent n, object[] args)
 		{
 			if (args.Length == 0)
 			{


### PR DESCRIPTION
Our current ScriptMethod API is handing a loaded gun to the user:
- `ScriptMethod(..., ExecutionThread.MainThread)` pass Context and args down that aren't thread-safe to do anything with, because the user-code does not execute on the JavaScript-thread.
- `ScriptMethod(..., ExecutionThread.Any)` is quite pointless; running a method on a thread takes time away from that thread. We should always care about what thread we do this to. So instead, methods who don't care about what thread they're on should simply create their own thread. With blackjack and... yeah.

The end result here is that we no longer peek on Fuse.Scripting.Object / Fuse.Scripting.Array on the UI-thread. This means a bunch of smaller threading-issues in our script-classes are fixed now.

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
