### PR TITLE
Fuse.PushNotifications: fix project references

### DIFF
--- a/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
+++ b/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
@@ -8,16 +8,16 @@
   },
   "Packages": [
     "Uno.Collections",
-    "Uno.Threading",
-    "Fuse.Controls",
-    "Fuse.Elements",
-    "Fuse.Reactive",
-    "Fuse.Scripting",
-    "Fuse.Common"
+    "Uno.Threading"
   ],
   "Projects": [
     "../Experimental.TextureLoader/Experimental.TextureLoader.unoproj",
-    "../Fuse.Platform/Fuse.Platform.unoproj"
+    "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Controls/Fuse.Controls.unoproj",
+    "../Fuse.Elements/Fuse.Elements.unoproj",
+    "../Fuse.Platform/Fuse.Platform.unoproj",
+    "../Fuse.Reactive/Fuse.Reactive.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj"
   ],
   "Includes": [
     "Common.uno:Source",


### PR DESCRIPTION
Solves the following build errors (`uno doctor -aC`):
```
lib\fuselibs\Source\Fuse.PushNotifications\Fuse.PushNotifications.unoproj(19.70): E0000: Multiple projects or packages with the name Experimental.TextureLoader
lib\fuselibs\Source\Fuse.PushNotifications\Fuse.PushNotifications.unoproj(20.44): E0000: Multiple projects or packages with the name Fuse.Platform
```
This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
