### PR TITLE
No more `texture2d.Load`

### DIFF
--- a/Source/Fuse.Controls/Tests/DockPanel.Test.uno
+++ b/Source/Fuse.Controls/Tests/DockPanel.Test.uno
@@ -201,31 +201,11 @@ namespace Fuse.Controls.Test
 		[Test]
 		public void DockAlignmentImageTest()
 		{
-			var parent = new DockPanel();
-
-			var child1 = new Image();
-			child1.Height = 441;
-			var image1Source = new TextureImageSource();
-			image1Source.Texture = texture2D.Load(import("Assets/713x441.png"));
-			image1Source.Density = 2;
-			child1.Source = image1Source;
-			DockPanel.SetDock(child1, Dock.Top);
-			parent.Children.Add(child1);
-
-			var child2 = new Image();
-			child2.Width = 46;
-			child2.Height = 109;
-			child2.StretchMode = StretchMode.Fill;
-			var image2Source = new TextureImageSource();
-			image2Source.Texture = texture2D.Load(import("Assets/92x218.png"));
-			child2.Source = image2Source;
-			DockPanel.SetDock(child2, Dock.Right);
-			parent.Children.Add(child2);
-
-			using (var root = TestRootPanel.CreateWithChild(parent, int2(736, 1038)))
+			var p = new UX.DockAlignmentImage();
+			using (var root = TestRootPanel.CreateWithChild(p, int2(736, 1038)))
 			{
-				LayoutTestHelper.TestElementLayout(child1, float2(736, 441), float2(0, 0), 0.0001f);
-				LayoutTestHelper.TestElementLayout(child2, float2(46, 109), float2(736-46, 441 + (1038-441-109)/2f), 0.0001f);
+				LayoutTestHelper.TestElementLayout(p.child1, float2(736, 441), float2(0, 0), 0.0001f);
+				LayoutTestHelper.TestElementLayout(p.child2, float2(46, 109), float2(736-46, 441 + (1038-441-109)/2f), 0.0001f);
 			}
 		}
 		

--- a/Source/Fuse.Controls/Tests/Panel.Test.uno
+++ b/Source/Fuse.Controls/Tests/Panel.Test.uno
@@ -123,22 +123,6 @@ namespace Fuse.Controls.Test
 			}
 		}
 		
-		//This feature of two-pass panel layout has been removed
-		/*
-		[Test]
-		public void LayoutPercentDepend()
-		{
-			var p = new UX.LayoutPercentDepend();
-			using (var root = TestRootPanel.CreateWithChild(parent))
-			{
-				root.Layout(int2(500,500));
-				LayoutTestHelper.TestElementLayout(p, float2(100,25), float2((500-100)/2f,(500-25)/2f));
-				LayoutTestHelper.TestElementLayout(p.c2, float2(50,25), float2(50,0));
-				LayoutTestHelper.TestElementLayout(p.c3, float2(10,2.5f), float2(0)); //NOTE: height may actually be defined as 1 here
-			}
-		}
-		*/
-		
 		[Test]
 		public void LayoutOffset()
 		{

--- a/Source/Fuse.Controls/Tests/StackPanel.Test.uno
+++ b/Source/Fuse.Controls/Tests/StackPanel.Test.uno
@@ -140,41 +140,13 @@ namespace Fuse.Controls.Test
 		[Test]
 		public void LayoutPercentDependent()
 		{
-			var parent = new StackPanel();
-			parent.Orientation = Orientation.Vertical;
-			parent.Alignment = Alignment.Center;
-			parent.Mode = StackLayoutMode.TwoPass;
-
-			using (var root = TestRootPanel.CreateWithChild(parent))
+			var p = new UX.LayoutPercentDependent();
+			using (var root = TestRootPanel.CreateWithChild(p, int2(1000)))
 			{
-				var c1 = new Panel();
-				c1.Height = 10;
-				c1.Width = Size.Percent(50);
-				parent.Children.Add(c1);
-
-				var c2 = new Image();
-
-				c2.Width = Size.Percent(100);
-				c2.Source = new TextureImageSource{ Texture = texture2D.Load(import("Assets/200x100.png")) };
-				parent.Children.Add(c2);
-
-				var c3 = new Panel();
-				c3.Width = 400;
-				c3.Height = 5;
-				parent.Children.Add(c3);
-
-				//https://github.com/Outracks/RealtimeStudio/issues/1632
-				/*var c4 = new Panel();
-				c4.Height = 10;
-				c4.Width = Size.Percent(110);
-				parent.Children.Add(c4);*/
-
-				root.Layout(int2(1000,1000));
-
-				LayoutTestHelper.TestElementLayout(c1, float2(200,10), float2(100,0) );
-				LayoutTestHelper.TestElementLayout(c2, float2(400,200), float2(0,10) );
+				LayoutTestHelper.TestElementLayout(p.c1, float2(200,10), float2(100,0) );
+				LayoutTestHelper.TestElementLayout(p.c2, float2(400,200), float2(0,10) );
 				//LayoutTestHelper.TestElementLayout(c4, float2(440,10), float2(-20,210) );
-				LayoutTestHelper.TestElementLayout(parent, float2(400,215), float2((1000-400)/2f,(1000-215)/2f));
+				LayoutTestHelper.TestElementLayout(p, float2(400,215), float2((1000-400)/2f,(1000-215)/2f));
 			}
 		}
 		

--- a/Source/Fuse.Controls/Tests/StackPanel.Test.uno
+++ b/Source/Fuse.Controls/Tests/StackPanel.Test.uno
@@ -130,23 +130,10 @@ namespace Fuse.Controls.Test
 		[Test]
 		public void LayoutAlignmentImageTest()
 		{
-			var parent = new StackPanel();
-			parent.Orientation = Orientation.Vertical;
-
-			using (var root = TestRootPanel.CreateWithChild(parent))
+			var p = new UX.LayoutAlignmentImage();
+			using (var root = TestRootPanel.CreateWithChild(p, int2(928, 722)))
 			{
-				var child1 = new Image();
-				child1.Height = 441;
-				child1.StretchMode = StretchMode.Scale9;
-				var image1Source = new TextureImageSource();
-				image1Source.Texture = texture2D.Load(import("Assets/713x441.png"));
-				image1Source.Density = 1.3f;
-				child1.Source = image1Source;
-				child1.Alignment = Alignment.HorizontalCenter;
-				parent.Children.Add(child1);
-
-				root.Layout(int2(928, 722));
-				LayoutTestHelper.TestElementLayout(child1, float2(713, 441), float2((928-713)/2f, 0));
+				LayoutTestHelper.TestElementLayout(p.child1, float2(713, 441), float2((928-713)/2f, 0));
 			}
 		}
 

--- a/Source/Fuse.Controls/Tests/StackPanel.Test.uno
+++ b/Source/Fuse.Controls/Tests/StackPanel.Test.uno
@@ -153,32 +153,13 @@ namespace Fuse.Controls.Test
 		[Test]
 		public void LayoutPercentFixed()
 		{
-			var parent = new StackPanel();
-			parent.Orientation = Orientation.Horizontal;
-			parent.Height = 200;
-
-			using (var root = TestRootPanel.CreateWithChild(parent))
+			var p = new UX.LayoutPercentFixed();
+			using (var root = TestRootPanel.CreateWithChild(p, int2(1000)))
 			{
-				var c1 = new Panel();
-				c1.Height = Size.Percent(10);
-				c1.Width = 50;
-				c1.Alignment = Alignment.Bottom;
-				parent.Children.Add(c1);
-
-				var c2 = new Image();
-				c2.Source = new TextureImageSource{ Texture = texture2D.Load(import("Assets/200x100.png")) };
-				parent.Children.Add(c2);
-
-				var c3 = new Panel();
-				c3.Height = Size.Percent(110);
-				c3.Width = 10;
-				parent.Children.Add(c3);
-
-				root.Layout(int2(1000,1000));
-				LayoutTestHelper.TestElementLayout(c1, float2(50,20), float2(0,180) );
-				LayoutTestHelper.TestElementLayout(c2, float2(400,200), float2(50,0) );
-				LayoutTestHelper.TestElementLayout(c3, float2(10,220), float2(450,-10) );
-				LayoutTestHelper.TestElementLayout(parent, float2(1000,200), float2(0,400));
+				LayoutTestHelper.TestElementLayout(p.c1, float2(50,20), float2(0,180) );
+				LayoutTestHelper.TestElementLayout(p.c2, float2(400,200), float2(50,0) );
+				LayoutTestHelper.TestElementLayout(p.c3, float2(10,220), float2(450,-10) );
+				LayoutTestHelper.TestElementLayout(p, float2(1000,200), float2(0,400));
 			}
 		}
 		

--- a/Source/Fuse.Controls/Tests/UX/DockAligntmentImage.ux
+++ b/Source/Fuse.Controls/Tests/UX/DockAligntmentImage.ux
@@ -1,0 +1,4 @@
+<DockPanel ux:Class="UX.DockAlignmentImage">
+	<Image ux:Name="child1" Height="441" File="../Assets/713x441.png" Dock="Top" />
+	<Image ux:Name="child2" Width="46" Height="109" StretchMode="Fill" File="../Assets/92x218.png" Dock="Right" />
+</DockPanel>

--- a/Source/Fuse.Controls/Tests/UX/LayoutAlignmentImage.ux
+++ b/Source/Fuse.Controls/Tests/UX/LayoutAlignmentImage.ux
@@ -1,0 +1,3 @@
+<StackPanel ux:Class="UX.LayoutAlignmentImage" Orientation="Vertical">
+	<Image ux:Name="child1" Height="441" StretchMode="Scale9" File="../Assets/713x441.png" Density="1.3" Alignment="HorizontalCenter" />
+</StackPanel>

--- a/Source/Fuse.Controls/Tests/UX/LayoutPercentDepend.ux
+++ b/Source/Fuse.Controls/Tests/UX/LayoutPercentDepend.ux
@@ -1,7 +1,0 @@
-<Panel ux:Class='UX.LayoutPercentDepend' Alignment="Center">
-	<Panel ux:Name="c1" Width="100" Height="10"/>
-	<Image ux:Name="c2" Alignment="TopRight" Width="50%" >
-		<TextureImageSource><texture2D ux:Path="../Assets/200x100.png" /></TextureImageSource>
-	</Image>
-	<Panel ux:Name="c3" Width="10%" Height="10%" Alignment="TopLeft" />
-</Panel>

--- a/Source/Fuse.Controls/Tests/UX/LayoutPercentDependent.ux
+++ b/Source/Fuse.Controls/Tests/UX/LayoutPercentDependent.ux
@@ -1,0 +1,9 @@
+<StackPanel ux:Class="UX.LayoutPercentDependent" Orientation="Vertical" Alignment="Center" Mode="TwoPass">
+	<Panel ux:Name="c1" Width="50%" Height="10" />
+	<Image ux:Name="c2" Width="100%" File="../Assets/200x100.png" />
+	<Panel Width="400" Height="5" />
+<!--
+	https://github.com/Outracks/RealtimeStudio/issues/1632
+	<Panel ux:Name="c4" Width="110%" Height="10" />
+-->
+</StackPanel>

--- a/Source/Fuse.Controls/Tests/UX/LayoutPercentFixed.ux
+++ b/Source/Fuse.Controls/Tests/UX/LayoutPercentFixed.ux
@@ -1,0 +1,5 @@
+<StackPanel ux:Class="UX.LayoutPercentFixed" Orientation="Horizontal" Height="200">
+	<Panel ux:Name="c1" Width="50" Height="10%" Alignment="Bottom" />
+	<Image ux:Name="c2" File="../Assets/200x100.png" />
+	<Panel ux:Name="c3" Width="10" Height="110%" />
+</StackPanel>


### PR DESCRIPTION
We don't really need texture2D.Load any more, so let's get rid of a few usages.