### PR TITLE
Fuse.Scripting: give error on unconsumed args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - The `ScriptMethod<T>` contstructor now throws if it's passed `ExecutionThread.MainThread` with Func, instead of failing to run it later on.
 - The `ScriptMethodInline` constructor that takes an `ExecutionThread` as an argument is now obsolete. Use the one without instead. JavaScript needs to run on the JavaScript thread anyway.
 - The `ScriptMethod<T>` contstructor that takes `Func` and `ExecutionThread` as arguments is now obsolete. Use the one without instead.
+- Calling script-methods that doesn't take any arguments should now consistently give an error. This was already the case for many functions. This is intended to ensure user-code is forward-compatible.
 
 
 # 1.4

--- a/Source/Fuse.Controls.Navigation/EdgeNavigator.ScriptClass.uno
+++ b/Source/Fuse.Controls.Navigation/EdgeNavigator.ScriptClass.uno
@@ -19,14 +19,8 @@ namespace Fuse.Controls
 			
 			@scriptmethod dismiss()
 		*/
-		static void dismiss(EdgeNavigator e, object[] args)
+		static void dismiss(EdgeNavigator e)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "EdgeNavigator.dismiss takes no arguments", e );
-				return;
-			}
-
 			e.Dismiss();
 		}
 		

--- a/Source/Fuse.Controls.Primitives/Image.ScriptClass.uno
+++ b/Source/Fuse.Controls.Primitives/Image.ScriptClass.uno
@@ -19,14 +19,8 @@ namespace Fuse.Controls
 			
 			@scriptmethod reload( )
 		*/
-		static void reload(Image img, object[] args)
+		static void reload(Image img)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "reload takes no parameters", img );
-				return;
-			}
-
 			var src = img.Source;
 			if (src != null)
 				src.Reload();
@@ -37,14 +31,8 @@ namespace Fuse.Controls
 			
 			@scriptmethod retry( )
 		*/
-		static void retry(Image img, object[] args)
+		static void retry(Image img)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "retry takes no parameters", img );
-				return;
-			}
-
 			var src = img.Source;
 			if (src != null && src.State == Fuse.Resources.ImageSourceState.Failed)
 				src.Reload();

--- a/Source/Fuse.Controls.ScrollView/ScrollViewPager.ScriptClass.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollViewPager.ScriptClass.uno
@@ -12,14 +12,8 @@ namespace Fuse.Controls
 				new ScriptMethod<ScrollViewPager>("check", check));
 		}
 		
-		static void check(ScrollViewPager s, object[] args)
+		static void check(ScrollViewPager s)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "`check` does not take any arguments" , s );
-				return;
-			}
-
 			//defer to allow deferred Each handling to create items
 			s.Check();
 		}

--- a/Source/Fuse.Controls.ScrollView/Triggers/Scrolled.ScriptClass.uno
+++ b/Source/Fuse.Controls.ScrollView/Triggers/Scrolled.ScriptClass.uno
@@ -20,14 +20,8 @@ namespace Fuse.Triggers
 			
 			@scriptmethod check()
 		*/
-		static void check(Scrolled s, object[] args)
+		static void check(Scrolled s)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "check takes no parameters", s );
-				return;
-			}
-			
 			//defer to after main layout to allow added/removed items to have an influence
 			UpdateManager.AddDeferredAction(s.Check, UpdateStage.Layout, LayoutPriority.Post);
 		}

--- a/Source/Fuse.Controls.Video/Video.ScriptClass.uno
+++ b/Source/Fuse.Controls.Video/Video.ScriptClass.uno
@@ -34,7 +34,10 @@ namespace Fuse.Controls
 		static object getDuration(Context c, Video v, object[] args)
 		{
 			if (args.Length != 0)
+			{
 				Fuse.Diagnostics.UserError("getDuration takes 0 arguments, but " + args.Length + " was supplied", v);
+				return null;
+			}
 
 			lock (v._durationMutex)
 				return (object)v._outDuration;
@@ -45,11 +48,8 @@ namespace Fuse.Controls
 
 			@scriptmethod resume()
 		*/
-		static void resume(Video v, object[] args)
+		static void resume(Video v)
 		{
-			if (args.Length != 0)
-				Fuse.Diagnostics.UserError("resume takes 0 arguments, but " + args.Length + " was supplied", v);
-
 			v.Resume();
 		}
 
@@ -58,11 +58,8 @@ namespace Fuse.Controls
 
 			@scriptmethod pause()
 		*/
-		static void pause(Video v, object[] args)
+		static void pause(Video v)
 		{
-			if (args.Length != 0)
-				Fuse.Diagnostics.UserError("pause takes 0 arguments, but " + args.Length + " was supplied", v);
-
 			v.Pause();
 		}
 
@@ -71,11 +68,8 @@ namespace Fuse.Controls
 
 			@scriptmethod stop()
 		*/
-		static void stop(Video v, object[] args)
+		static void stop(Video v)
 		{
-			if (args.Length != 0)
-				Fuse.Diagnostics.UserError("stop takes 0 arguments, but " + args.Length + " was supplied", v);
-
 			v.Stop();
 		}
 	}

--- a/Source/Fuse.Controls.WebView/WebView.ScriptClass.uno
+++ b/Source/Fuse.Controls.WebView/WebView.ScriptClass.uno
@@ -55,17 +55,9 @@ namespace Fuse.Controls
 
 			@scriptmethod goBack()
 		*/
-		static void goBack(WebView view, object[] args)
+		static void goBack(WebView view)
 		{
-			switch(args.Length)
-			{
-				case 0:
-					view.GoBack();
-					return;
-				default:
-					Fuse.Diagnostics.UserError( "WebView.goBack does not take any arguments", view);
-					return;
-			}
+			view.GoBack();
 		}
 
 		/**
@@ -73,17 +65,9 @@ namespace Fuse.Controls
 
 			@scriptmethod goForward()
 		*/
-		static void goForward(WebView view, object[] args)
+		static void goForward(WebView view)
 		{
-			switch(args.Length)
-			{
-				case 0:
-					view.GoForward();
-					return;
-				default:
-					Fuse.Diagnostics.UserError( "WebView.goForward does not take any arguments", view);
-					return;
-			}
+			view.GoForward();
 		}
 
 		/**
@@ -91,17 +75,9 @@ namespace Fuse.Controls
 
 			@scriptmethod reload()
 		*/
-		static void reload(WebView view, object[] args)
+		static void reload(WebView view)
 		{
-			switch(args.Length)
-			{
-				case 0:
-					view.Reload();
-					return;
-				default:
-					Fuse.Diagnostics.UserError( "WebView.reload does not take any arguments", view);
-					return;
-			}
+			view.Reload();
 		}
 
 
@@ -110,17 +86,9 @@ namespace Fuse.Controls
 
 			@scriptmethod stop()
 		*/
-		static void stop(WebView view, object[] args)
+		static void stop(WebView view)
 		{
-			switch(args.Length)
-			{
-				case 0:
-					view.Stop();
-					return;
-				default:
-					Fuse.Diagnostics.UserError( "WebView.stop does not take any arguments", view);
-					return;
-			}
+			view.Stop();
 		}
 
 		/**

--- a/Source/Fuse.Navigation/Router.ScriptClass.uno
+++ b/Source/Fuse.Navigation/Router.ScriptClass.uno
@@ -132,15 +132,10 @@ namespace Fuse.Navigation
 			
 			@scriptmethod goBack()
 		*/
-		static void GoBack(Router r, object[] args)
+		static void GoBack(Router r)
 		{
 			if (!r.IsRootingCompleted) return;
 
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "Router.goBack takes no parameters", r );
-				return;
-			}
 			r.GoBack();
 		}
 		

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -205,7 +205,16 @@ namespace Fuse.Scripting
 				if (_oldVoidMethod != null)
 					UpdateManager.PostAction(new CallClosure(c, _oldVoidMethod, obj, args).Run);
 				else
+				{
+					if (args.Length != 0)
+					{
+						var name = obj.GetType().FullName + "." + Name;
+						Fuse.Diagnostics.UserError(string.Format("{0} takes no arguments, but {1} was provided", name, args.Length), obj);
+						return null;
+					}
+
 					UpdateManager.PostAction(new CallClosure(_voidMethod, obj).Run);
+				}
 
 				return null;
 			}

--- a/Source/Fuse.Selection/Selectable.ScriptClass.uno
+++ b/Source/Fuse.Selection/Selectable.ScriptClass.uno
@@ -21,14 +21,8 @@ namespace Fuse.Selection
 			
 			This follows the high level selection rules (such as MaxCount and Replace).
 		*/
-		static void add(Selectable s, object[] args )
+		static void add(Selectable s)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "add requires 0 arguments", s );
-				return;
-			}
-			
 			s.Add();
 		}
 		
@@ -39,14 +33,8 @@ namespace Fuse.Selection
 			
 			If the Selectable is not currently selected then nothing is removed.
 		*/
-		static void remove(Selectable s, object[] args )
+		static void remove(Selectable s)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "remove requires 0 arguments", s );
-				return;
-			}
-			
 			s.Remove();
 		}
 		
@@ -55,14 +43,8 @@ namespace Fuse.Selection
 			
 			This follows the high level selection rules (such as MaxCount/MinCount).
 		*/
-		static void toggle(Selectable s, object[] args )
+		static void toggle(Selectable s)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "toggle requires 0 arguments", s );
-				return;
-			}
-			
 			s.Toggle();
 		}
 		

--- a/Source/Fuse.Selection/Selection.ScriptClass.uno
+++ b/Source/Fuse.Selection/Selection.ScriptClass.uno
@@ -24,14 +24,8 @@ namespace Fuse.Selection
 			
 			This does not respect restrictions, such as `MinCount`, and results in 0 items being selected.
 		*/
-		static void clear(Selection s, object[] args)
+		static void clear(Selection s)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "clear requires 0 arguments", s );
-				return;
-			}
-			
 			s.Clear();
 		}
 

--- a/Source/Fuse.Triggers/Busy.ScriptClass.uno
+++ b/Source/Fuse.Triggers/Busy.ScriptClass.uno
@@ -22,14 +22,8 @@ namespace Fuse.Triggers
 			
 			@scriptmethod activate()
 		*/
-		static void activate(Busy b, object[] args)
+		static void activate(Busy b)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "Busy.activate takes no arguments", b );
-				return;
-			}
-			
 			b.IsActive = true;
 		}
 		
@@ -40,14 +34,8 @@ namespace Fuse.Triggers
 			
 			@scriptmethod deactivate()
 		*/
-		static void deactivate(Busy b, object[] args)
+		static void deactivate(Busy b)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "Busy.deactivate takes no arguments", b );
-				return;
-			}
-			
 			b.IsActive = false;
 		}
 	}

--- a/Source/Fuse.Triggers/Completed.ScriptClass.uno
+++ b/Source/Fuse.Triggers/Completed.ScriptClass.uno
@@ -21,14 +21,8 @@ namespace Fuse.Triggers
 			
 			@scriptmethod reset()
 		*/
-		static void reset(Completed cp, object[] args)
+		static void reset(Completed cp)
 		{
-			if (args.Length != 0)
-			{
-				Fuse.Diagnostics.UserError( "Completed.reset takes no arguments", cp );
-				return;
-			}
-			
 			cp.Reset();
 		}
 	}

--- a/Source/Fuse.Triggers/StateGroup.ScriptClass.uno
+++ b/Source/Fuse.Triggers/StateGroup.ScriptClass.uno
@@ -61,7 +61,7 @@ namespace Fuse.Triggers
 			
 			@scriptmethod gotoNext()
 		*/
-		static void gotoNext(StateGroup n, object[] args)
+		static void gotoNext(StateGroup n)
 		{
 			n.GotoNextState();
 		}


### PR DESCRIPTION
In the argument-less case, we can make a generic error if arguments
were passed to a method that doesn't care about arguments.

This ensures calling code is forward-compatible in the case where we
want to add arguments to existing methods.
