### PR TITLE
Fuse.Scripting.JavaScript: do not make mirror contain JS objects

### DIFF
--- a/Source/Fuse.Navigation/RouterRequest.uno
+++ b/Source/Fuse.Navigation/RouterRequest.uno
@@ -274,7 +274,7 @@ namespace Fuse.Navigation
 		
 		static bool ValidateParameter(object arg, int depth = 0)
 		{
-			if (depth > 50)
+			if (depth > 49)
 			{
 				Fuse.Diagnostics.UserError("Route parameter must be serializeable, it contains reference loops or is too large", null);
 				return false;

--- a/Source/Fuse.Scripting.JavaScript/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/Context.uno
@@ -85,10 +85,7 @@ namespace Fuse.Scripting.JavaScript
 				_reflectionDepth--;
 			}
 
-			if (res != null)
-				return res;
-
-			return obj;
+			return res;
 		}
 
 		object IMirror.Reflect(Scripting.Context context, object obj)
@@ -140,7 +137,7 @@ namespace Fuse.Scripting.JavaScript
 				}
 			}
 
-			return null;
+			return obj;
 		}
 
 		internal Function GetClass(ScriptClass sc)


### PR DESCRIPTION
When we truncate while reflecting the JS state, we accidentally left
JS objects in the mirror, because we weren't able to tell the difference
between truncation and primitive-types. So let's rewrite the code a bit
to be able to tell the difference.

Because the mirroring gives up after 50 recursions, make the
RouterRequest validation give up after 49 instead, so we retain the
same errors even when truncating.
