### PR TITLE
clean up packages/projects/usings

### DIFF
--- a/Source/Fuse.Alerts/Fuse.Alerts.unoproj
+++ b/Source/Fuse.Alerts/Fuse.Alerts.unoproj
@@ -8,10 +8,11 @@
   },
   "Packages": [
     "Uno.Collections",
-    "Uno.Threading",
-    "Fuse.Scripting"
+    "Uno.Threading"
   ],
-  "Projects": [],
+  "Projects": [
+    "../Fuse.Scripting/Fuse.Scripting.unoproj"
+  ],
   "Includes": [
     "*"
   ]

--- a/Source/Fuse.Audio/Fuse.Audio.unoproj
+++ b/Source/Fuse.Audio/Fuse.Audio.unoproj
@@ -9,8 +9,10 @@
   },
   "Packages": [
     "Uno.Threading",
-    "Uno.Permissions",
-    "Fuse"
+    "Uno.Permissions"
+  ],
+  "Projects": [
+    "../Fuse/Fuse.unoproj"
   ],
   "Includes": [
     "*",

--- a/Source/Fuse.GeoLocation/Fuse.GeoLocation.unoproj
+++ b/Source/Fuse.GeoLocation/Fuse.GeoLocation.unoproj
@@ -9,11 +9,13 @@
   "Packages": [
     "Uno.Collections",
     "Uno.Threading",
-    "Uno.Permissions",
-    "Fuse.Common",
-    "Fuse.Marshal",
-    "Fuse.Scripting",
-    "Fuse.iOS.LocationPermissions"
+    "Uno.Permissions"
+  ],
+  "Projects": [
+    "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Marshal/Fuse.Marshal.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.iOS.LocationPermissions/Fuse.iOS.LocationPermissions.unoproj"
   ],
   "Includes": [
     "Android/UpdateListener.java:Java:Android",

--- a/Source/Fuse.Launcher.Email/Email/EmailLauncher.uno
+++ b/Source/Fuse.Launcher.Email/Email/EmailLauncher.uno
@@ -1,12 +1,10 @@
 using Uno;
 using Uno.Text;
-using Uno.IO;
-using Uno.Collections;
 using Uno.Compiler.ExportTargetInterop;
 using Uno.Permissions;
 using Uno.Net.Http;
-using Fuse.iOS.Bindings;
 using Fuse.Android.Bindings;
+using Fuse.iOS.Bindings;
 
 namespace Fuse.LauncherImpl
 {

--- a/Source/Fuse.Launcher.Email/Email/EmailTrigger.uno
+++ b/Source/Fuse.Launcher.Email/Email/EmailTrigger.uno
@@ -1,9 +1,4 @@
-using Uno;
-using Uno.Collections;
 using Uno.UX;
-using Uno.Net.Http;
-using Fuse.Animations;
-using Fuse.Triggers.Actions;
 
 namespace Fuse.Triggers.Actions
 {

--- a/Source/Fuse.Launcher.Email/Email/JS.uno
+++ b/Source/Fuse.Launcher.Email/Email/JS.uno
@@ -1,5 +1,4 @@
 using Uno.UX;
-using Uno.Collections;
 using Fuse.Scripting;
 
 namespace Fuse.Reactive.FuseJS

--- a/Source/Fuse.Launcher.Email/Fuse.Launcher.Email.unoproj
+++ b/Source/Fuse.Launcher.Email/Fuse.Launcher.Email.unoproj
@@ -9,16 +9,13 @@
   "Packages": [
     "Uno.Net.Http",
     "Uno.Permissions",
-    "UnoCore",
-    "Fuse.Platform",
-    "Fuse.Animations",
-    "Fuse.Designer",
-    "Fuse.Triggers",
-    "Fuse.Common",
-    "Fuse.Nodes",
-    "Fuse.Scripting",
-    "Fuse.Android",
-    "Fuse.iOS"
+  ],
+  "Projects": [
+    "../Fuse.Triggers/Fuse.Triggers.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Android/Fuse.Android.unoproj",
+    "../Fuse.iOS/Fuse.iOS.unoproj"
   ],
   "Includes": [
     "Email/EmailLauncher.uno",

--- a/Source/Fuse.Launcher.InterApp/Fuse.Launcher.InterApp.unoproj
+++ b/Source/Fuse.Launcher.InterApp/Fuse.Launcher.InterApp.unoproj
@@ -8,17 +8,15 @@
   },
   "Packages": [
     "Uno.Net.Http",
-    "Uno.Permissions",
-    "UnoCore",
-    "Fuse.Platform",
-    "Fuse.Animations",
-    "Fuse.Designer",
-    "Fuse.Triggers",
-    "Fuse.Common",
-    "Fuse.Nodes",
-    "Fuse.Scripting",
-    "Fuse.Android",
-    "Fuse.iOS"
+    "Uno.Permissions"
+  ],
+  "Projects": [
+    "../Fuse.Platform/Fuse.Platform.unoproj",
+    "../Fuse.Triggers/Fuse.Triggers.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Android/Fuse.Android.unoproj",
+    "../Fuse.iOS/Fuse.iOS.unoproj"
   ],
   "Includes": [
     "InterApp/InterAppLauncher.uno",

--- a/Source/Fuse.Launcher.InterApp/InterApp/InterAppLauncher.uno
+++ b/Source/Fuse.Launcher.InterApp/InterApp/InterAppLauncher.uno
@@ -1,7 +1,4 @@
 using Uno;
-using Uno.Text;
-using Uno.IO;
-using Uno.Collections;
 using Uno.Compiler.ExportTargetInterop;
 using Uno.Permissions;
 using Uno.Net.Http;

--- a/Source/Fuse.Launcher.InterApp/InterApp/InterAppTrigger.uno
+++ b/Source/Fuse.Launcher.InterApp/InterApp/InterAppTrigger.uno
@@ -1,9 +1,5 @@
 using Uno;
-using Uno.Collections;
-using Uno.UX;
 using Uno.Net.Http;
-using Fuse.Animations;
-using Fuse.Triggers.Actions;
 
 namespace Fuse.Triggers.Actions
 {

--- a/Source/Fuse.Launcher.InterApp/InterApp/JS.uno
+++ b/Source/Fuse.Launcher.InterApp/InterApp/JS.uno
@@ -1,6 +1,5 @@
 using Uno.UX;
 using Fuse.Scripting;
-using Uno.Collections;
 
 namespace Fuse.Reactive.FuseJS
 {

--- a/Source/Fuse.Launcher.Maps/Fuse.Launcher.Maps.unoproj
+++ b/Source/Fuse.Launcher.Maps/Fuse.Launcher.Maps.unoproj
@@ -8,18 +8,15 @@
   },
   "Packages": [
     "Uno.Net.Http",
-    "Uno.Permissions",
-    "UnoCore",
-    "Fuse.Platform",
-    "Fuse.Animations",
-    "Fuse.Designer",
-    "Fuse.Triggers",
-    "Fuse.Common",
-    "Fuse.Nodes",
-    "Fuse.Marshal",
-    "Fuse.Scripting",
-    "Fuse.Android",
-    "Fuse.iOS"
+    "Uno.Permissions"
+  ],
+  "Projects": [
+    "../Fuse.Triggers/Fuse.Triggers.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Marshal/Fuse.Marshal.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Android/Fuse.Android.unoproj",
+    "../Fuse.iOS/Fuse.iOS.unoproj"
   ],
   "Includes": [
     "Maps/MapsLauncher.uno",

--- a/Source/Fuse.Launcher.Maps/Maps/JS.uno
+++ b/Source/Fuse.Launcher.Maps/Maps/JS.uno
@@ -1,6 +1,5 @@
 using Uno.UX;
 using Fuse.Scripting;
-using Uno.Collections;
 
 namespace Fuse.Reactive.FuseJS
 {

--- a/Source/Fuse.Launcher.Maps/Maps/MapsLauncher.uno
+++ b/Source/Fuse.Launcher.Maps/Maps/MapsLauncher.uno
@@ -1,7 +1,4 @@
 using Uno;
-using Uno.Text;
-using Uno.IO;
-using Uno.Collections;
 using Uno.Compiler.ExportTargetInterop;
 using Uno.Permissions;
 using Uno.Net.Http;

--- a/Source/Fuse.Launcher.Maps/Maps/MapsTrigger.uno
+++ b/Source/Fuse.Launcher.Maps/Maps/MapsTrigger.uno
@@ -1,9 +1,5 @@
 using Uno;
-using Uno.Collections;
-using Uno.UX;
 using Uno.Net.Http;
-using Fuse.Animations;
-using Fuse.Triggers.Actions;
 
 namespace Fuse.Triggers.Actions
 {

--- a/Source/Fuse.Launcher.Phone/Fuse.Launcher.Phone.unoproj
+++ b/Source/Fuse.Launcher.Phone/Fuse.Launcher.Phone.unoproj
@@ -8,17 +8,14 @@
   },
   "Packages": [
     "Uno.Net.Http",
-    "Uno.Permissions",
-    "UnoCore",
-    "Fuse.Platform",
-    "Fuse.Animations",
-    "Fuse.Designer",
-    "Fuse.Triggers",
-    "Fuse.Common",
-    "Fuse.Nodes",
-    "Fuse.Scripting",
-    "Fuse.Android",
-    "Fuse.iOS"
+    "Uno.Permissions"
+  ],
+  "Projects": [
+    "../Fuse.Triggers/Fuse.Triggers.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Android/Fuse.Android.unoproj",
+    "../Fuse.iOS/Fuse.iOS.unoproj"
   ],
   "Includes": [
     "Phone/PhoneLauncher.uno",

--- a/Source/Fuse.Launcher.Phone/Phone/JS.uno
+++ b/Source/Fuse.Launcher.Phone/Phone/JS.uno
@@ -1,6 +1,5 @@
 using Uno.UX;
 using Fuse.Scripting;
-using Uno.Collections;
 
 namespace Fuse.Reactive.FuseJS
 {

--- a/Source/Fuse.Launcher.Phone/Phone/PhoneLauncher.uno
+++ b/Source/Fuse.Launcher.Phone/Phone/PhoneLauncher.uno
@@ -1,12 +1,7 @@
-using Uno;
-using Uno.Text;
-using Uno.IO;
-using Uno.Collections;
 using Uno.Compiler.ExportTargetInterop;
 using Uno.Permissions;
-using Uno.Net.Http;
-using Fuse.iOS.Bindings;
 using Fuse.Android.Bindings;
+using Fuse.iOS.Bindings;
 
 namespace Fuse.LauncherImpl
 {

--- a/Source/Fuse.Launcher.Phone/Phone/PhoneTrigger.uno
+++ b/Source/Fuse.Launcher.Phone/Phone/PhoneTrigger.uno
@@ -1,10 +1,3 @@
-using Uno;
-using Uno.Collections;
-using Uno.UX;
-using Uno.Net.Http;
-using Fuse.Animations;
-using Fuse.Triggers.Actions;
-
 namespace Fuse.Triggers.Actions
 {
 	/** Calls a phone number

--- a/Source/Fuse.Launcher.Phone/Phone/PhoneUriHelper.uno
+++ b/Source/Fuse.Launcher.Phone/Phone/PhoneUriHelper.uno
@@ -1,4 +1,3 @@
-using Uno;
 using Uno.Text;
 using Uno.Net.Http;
 

--- a/Source/Fuse.Launcher/Fuse.Launcher.unoproj
+++ b/Source/Fuse.Launcher/Fuse.Launcher.unoproj
@@ -9,16 +9,7 @@
   "IsTransitive": true,
   "Packages": [
     "Uno.Net.Http",
-    "Uno.Permissions",
-    "UnoCore",
-    "Fuse.Platform",
-    "Fuse.Animations",
-    "Fuse.Designer",
-    "Fuse.Triggers",
-    "Fuse.Common",
-    "Fuse.Nodes",
-    "Fuse.Marshal",
-    "Fuse.Scripting"
+    "Uno.Permissions"
   ],
   "Projects": [
     "../Fuse.Launcher.Email/Fuse.Launcher.Email.unoproj",

--- a/Source/Fuse.Maps/Fuse.Maps.unoproj
+++ b/Source/Fuse.Maps/Fuse.Maps.unoproj
@@ -9,15 +9,12 @@
   "IsTransitive":true,
   "Packages": [
     "Uno.Collections",
-    "Uno.Permissions",
-    "Fuse",
-    "Fuse.iOS.LocationPermissions",
-    "Fuse.Common",
-    "Fuse.Marshal",
-    "Fuse.Nodes",
-    "Fuse.ImageTools"
+    "Uno.Permissions"
   ],
-  "Projects": [],
+  "Projects": [
+    "../Fuse.ImageTools/Fuse.ImageTools.unoproj",
+    "../Fuse/Fuse.unoproj"
+  ],
   "Includes": [
     "MapMarker.uno:Source",
     "MapView.uno:Source",

--- a/Source/Fuse.Vibration/Fuse.Vibration.unoproj
+++ b/Source/Fuse.Vibration/Fuse.Vibration.unoproj
@@ -7,14 +7,13 @@
     "ProjectUrl": "https://fusetools.com"
   },
   "Packages": [
-    "Fuse.Animations",
-    "Fuse.Designer",
-    "Fuse.Triggers",
-    "Fuse.Scripting",
-    "Fuse.Common",
-    "Fuse.Nodes",
-    "Fuse.Marshal",
     "Uno.Permissions"
+  ],
+  "Projects": [
+    "../Fuse.Triggers/Fuse.Triggers.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Marshal/Fuse.Marshal.unoproj"
   ],
   "Includes": [
     "Vibration.uno:Source",

--- a/Source/Fuse.Vibration/Vibrate.uno
+++ b/Source/Fuse.Vibration/Vibrate.uno
@@ -1,7 +1,4 @@
-using Uno;
-using Uno.Collections;
 using Uno.UX;
-using Fuse.Animations;
 using Fuse.Triggers.Actions;
 
 namespace Fuse.Vibration

--- a/Source/Fuse.WebSockets/Fuse.WebSockets.unoproj
+++ b/Source/Fuse.WebSockets/Fuse.WebSockets.unoproj
@@ -6,10 +6,10 @@
   },
   "Description": "A client for the WebSocket protocol",
   "Publisher": "Fusetools AS",
-  "Packages": [
-    "Fuse.Common",
-    "Fuse.Scripting",
-    "Fuse.Reactive"
+  "Projects": [
+    "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Reactive/Fuse.Reactive.unoproj"
   ],
   "Includes": [
     "WebSocketClient.uno",

--- a/Source/FuseJS/FuseJS.unoproj
+++ b/Source/FuseJS/FuseJS.unoproj
@@ -10,18 +10,18 @@
   "Packages": [
     "Uno.Collections",
     "Uno.Net.Http",
-    "Uno.Threading",
-    "Fuse.Common",
-    "Fuse.Nodes",
-    "Fuse.Platform",
-    "Fuse.Reactive",
-    "Fuse.Scripting",
-    "Fuse.Storage",
-    "Fuse.Android",
-    "Fuse.iOS",
-    "Fuse.UserEvents",
+    "Uno.Threading"
   ],
   "Projects": [
+    "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Platform/Fuse.Platform.unoproj",
+    "../Fuse.Reactive/Fuse.Reactive.unoproj",
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Storage/Fuse.Storage.unoproj",
+    "../Fuse.Android/Fuse.Android.unoproj",
+    "../Fuse.iOS/Fuse.iOS.unoproj",
+    "../Fuse.UserEvents/Fuse.UserEvents.unoproj",
     "../Polyfills.Window/Polyfills.Window.unoproj",
   ],
   "Includes": [

--- a/Source/Polyfills.Window/Polyfills.Window.unoproj
+++ b/Source/Polyfills.Window/Polyfills.Window.unoproj
@@ -6,12 +6,12 @@
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },
-  "Packages": [
-    "Fuse.Scripting",
-    "Fuse.Common",
-    "Fuse.Nodes",
-    "Fuse.Storage",
-    "Fuse.WebSockets"
+  "Projects": [
+    "../Fuse.Scripting/Fuse.Scripting.unoproj",
+    "../Fuse.Common/Fuse.Common.unoproj",
+    "../Fuse.Nodes/Fuse.Nodes.unoproj",
+    "../Fuse.Storage/Fuse.Storage.unoproj",
+    "../Fuse.WebSockets/Fuse.WebSockets.unoproj"
   ],
   "IsTransitive": true,
   "Includes": [
@@ -20,4 +20,3 @@
   ]
 
 }
-


### PR DESCRIPTION
There's two things going on here:
- reduction of using-statements
- switching from package-references to project references.

The former should in theory improve complilation-speeds a tad.

The latter is about correctness. If the user has a newer fuselibs
package installed than the in-tree version, the uno package manager
will try to resolve this with the newer one, which is not what we
want. So internal references in the fuselibs-repo should always be
project-references, not package-references.

This is a big, nasty commit, but untangling this without breaking
rebaseablitly is silly much work for little gain, so I'd prefer to
do it in one go.