### PR TITLE
Script class cleanups

### DIFF
--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -200,28 +200,28 @@ namespace Fuse.Scripting
 
 		public override object Call(Context c, object obj, object[] args)
 		{
-			if (Thread == ExecutionThread.MainThread)
+			// This block is legacy code that should only need to stay around until obsolete constructors has been removed
+			if (_oldVoidMethod != null)
 			{
-				if (_oldVoidMethod != null)
+				if (Thread == ExecutionThread.MainThread)
 					UpdateManager.PostAction(new CallClosure(c, _oldVoidMethod, (T)obj, args).Run);
 				else
 				{
-					if (args.Length != 0)
-					{
-						var name = obj.GetType().FullName + "." + Name;
-						Fuse.Diagnostics.UserError(string.Format("{0} takes no arguments, but {1} was provided", name, args.Length), obj);
-						return null;
-					}
-
-					UpdateManager.PostAction(new CallClosure(_voidMethod, (T)obj).Run);
+					_oldVoidMethod(c, (T)obj, args);
+					return null;
 				}
-
-				return null;
 			}
 
-			if (_oldVoidMethod != null)
+			if (_voidMethod != null)
 			{
-				_oldVoidMethod(c, (T)obj, args);
+				if (args.Length != 0)
+				{
+					var name = obj.GetType().FullName + "." + Name;
+					Fuse.Diagnostics.UserError(string.Format("{0} takes no arguments, but {1} was provided", name, args.Length), obj);
+					return null;
+				}
+
+				UpdateManager.PostAction(new CallClosure(_voidMethod, (T)obj).Run);
 				return null;
 			}
 			else

--- a/Source/Fuse.Scripting/ScriptClass.uno
+++ b/Source/Fuse.Scripting/ScriptClass.uno
@@ -203,7 +203,7 @@ namespace Fuse.Scripting
 			if (Thread == ExecutionThread.MainThread)
 			{
 				if (_oldVoidMethod != null)
-					UpdateManager.PostAction(new CallClosure(c, _oldVoidMethod, obj, args).Run);
+					UpdateManager.PostAction(new CallClosure(c, _oldVoidMethod, (T)obj, args).Run);
 				else
 				{
 					if (args.Length != 0)
@@ -213,7 +213,7 @@ namespace Fuse.Scripting
 						return null;
 					}
 
-					UpdateManager.PostAction(new CallClosure(_voidMethod, obj).Run);
+					UpdateManager.PostAction(new CallClosure(_voidMethod, (T)obj).Run);
 				}
 
 				return null;
@@ -233,10 +233,10 @@ namespace Fuse.Scripting
 		class CallClosure
 		{
 			readonly Action<T> _method;
-			readonly object _obj;
+			readonly T _obj;
 			readonly object[] _args;
 
-			public CallClosure(Action<T> method, object obj)
+			public CallClosure(Action<T> method, T obj)
 			{
 				_method = method;
 				_obj = obj;
@@ -244,7 +244,7 @@ namespace Fuse.Scripting
 
 			readonly Context _context;
 			readonly Action<Context, T, object[]> _oldMethod;
-			public CallClosure(Context context, Action<Context, T, object[]> method, object obj, object[] args)
+			public CallClosure(Context context, Action<Context, T, object[]> method, T obj, object[] args)
 			{
 				_context = context;
 				_oldMethod = method;
@@ -255,9 +255,9 @@ namespace Fuse.Scripting
 			public void Run()
 			{
 				if (_method != null)
-					_method((T)_obj);
+					_method(_obj);
 				else
-					_oldMethod(_context, (T)_obj, _args);
+					_oldMethod(_context, _obj, _args);
 			}
 		}
 


### PR DESCRIPTION
This PR refactors the internals of ScriptMethods a bit:
1. It removes ExecutionThread from the base-class, as this is not really a fundamental concept anymore (and never really was, but it's even less so now).
2. It moves the legacy constructor-support to be fully implemented in the constructor, plus a closure. This makes it a bit easier to maintain, at the cost of a slight decrease in performance. Since this is a legacy compatibility thing only, I think a performance degradation should be OK.
3. Some API usage errors would be noticed earlier. But since this part isn't public API, this should have no user-visible effects.