### PR TITLE
Script exception sanity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - `ScriptException.Message` no longer includes all details about the script-exception, only the message itself. If you want the extra information, use `ScriptException.ToString()`, or check the specific fields.
 - `Fuse.IScriptException` has been marked as obsolete. This was previously unused.
 - `ScriptException.JSStackTrace` has been marked as obsolete, use `ScriptException.ScriptStackTrace` instead.
+- `ScriptException.SourceLine` has been marked as obsolete, and consistently returns null now. The latter was always the case except for when using V8 before. The same information can be deduced from the project files and FileName + LineNumber fields.
 
 
 # 1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 - The `ScriptMethodInline` constructor that takes an `ExecutionThread` as an argument is now obsolete. Use the one without instead. JavaScript needs to run on the JavaScript thread anyway.
 - The `ScriptMethod<T>` contstructor that takes `Func` and `ExecutionThread` as arguments is now obsolete. Use the one without instead.
 - Calling script-methods that doesn't take any arguments should now consistently give an error. This was already the case for many functions. This is intended to ensure user-code is forward-compatible.
+- `ScriptException.ErrorMessage` has been marked as obsolete, use `ScriptException.Message` instead.
+- `ScriptException.Message` no longer includes all details about the script-exception, only the message itself. If you want the extra information, use `ScriptException.ToString()`, or check the specific fields.
 
 
 # 1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - `ScriptException.ErrorMessage` has been marked as obsolete, use `ScriptException.Message` instead.
 - `ScriptException.Message` no longer includes all details about the script-exception, only the message itself. If you want the extra information, use `ScriptException.ToString()`, or check the specific fields.
 - `Fuse.IScriptException` has been marked as obsolete. This was previously unused.
+- `ScriptException.JSStackTrace` has been marked as obsolete, use `ScriptException.ScriptStackTrace` instead.
 
 
 # 1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Calling script-methods that doesn't take any arguments should now consistently give an error. This was already the case for many functions. This is intended to ensure user-code is forward-compatible.
 - `ScriptException.ErrorMessage` has been marked as obsolete, use `ScriptException.Message` instead.
 - `ScriptException.Message` no longer includes all details about the script-exception, only the message itself. If you want the extra information, use `ScriptException.ToString()`, or check the specific fields.
+- `Fuse.IScriptException` has been marked as obsolete. This was previously unused.
 
 
 # 1.4

--- a/Source/Fuse.Common/Diagnostics.uno
+++ b/Source/Fuse.Common/Diagnostics.uno
@@ -97,6 +97,7 @@ namespace Fuse
 		}
 	}
 
+	[Obsolete]
 	public interface IScriptException
 	{
 		string FileName { get; }

--- a/Source/Fuse.Scripting.JavaScript/Duktape/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/Duktape/Context.uno
@@ -282,7 +282,7 @@ namespace Fuse.Scripting.Duktape
 			{
 				message = DukContext.safe_to_string(index);
 			}
-			return new ScriptException(name, message, fileName, lineNumber, null, stack);
+			return new ScriptException(name, message, fileName, lineNumber, stack);
 		}
 
 		internal void CheckError(int errorCode)

--- a/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScriptCore/Context.uno
@@ -177,7 +177,7 @@ namespace Fuse.Scripting.JavaScriptCore
 			{
 				message = wrapped != null ? wrapped.ToString() : message;
 			}
-			throw new ScriptException(name, message, file, lineNumber, null, stack);
+			throw new ScriptException(name, message, file, lineNumber, stack);
 		}
 
 		internal object Wrap(JSValueRef value)

--- a/Source/Fuse.Scripting.JavaScript/Tests/JsErrorTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/JsErrorTest.uno
@@ -46,7 +46,7 @@ namespace Fuse.Reactive.Test
 					Assert.AreEqual(3, s.LineNumber);
 				if (s.FileName != null)
 					Assert.Contains("Error.RequireInvalid.ux", s.FileName);
-				Assert.Contains("module not found: FuseJS/Pinecone", s.ErrorMessage);
+				Assert.Contains("module not found: FuseJS/Pinecone", s.Message);
 			}
 		}
 		
@@ -94,7 +94,7 @@ namespace Fuse.Reactive.Test
 				Assert.AreEqual(12, s.LineNumber);
 				Assert.Contains("Error.OnValueChanged.ux", s.FileName);
 				//it's uncertain how stable these error messages are
-				Assert.Contains("Cannot read property '0' of undefined", s.ErrorMessage);
+				Assert.Contains("Cannot read property '0' of undefined", s.Message);
 			}
 		}
 	}

--- a/Source/Fuse.Scripting.JavaScript/Tests/JsErrorTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/JsErrorTest.uno
@@ -20,8 +20,6 @@ namespace Fuse.Reactive.Test
 				var diagnostics = dg.DequeueAll();
 				Assert.AreEqual(1, diagnostics.Count);
 				var s = (ScriptException)diagnostics[0].Exception;
-				if (s.SourceLine != null)
-					Assert.Contains("none()", s.SourceLine);
 				Assert.AreEqual(3, s.LineNumber);
 				Assert.Contains("Error.UnknownSymbol.ux", s.FileName);
 			}
@@ -40,8 +38,6 @@ namespace Fuse.Reactive.Test
 				var diagnostics = dg.DequeueAll();
 				Assert.AreEqual(1, diagnostics.Count);
 				var s = (ScriptException)diagnostics[0].Exception;
-				if (s.SourceLine != null)
-					Assert.Contains("require(\"FuseJS/Pinecone\")", s.SourceLine);
 				if (s.LineNumber >= 0)
 					Assert.AreEqual(3, s.LineNumber);
 				if (s.FileName != null)
@@ -67,8 +63,6 @@ namespace Fuse.Reactive.Test
 					var diagnostics = dg.DequeueAll();
 					Assert.AreEqual(1, diagnostics.Count);
 					var s = (ScriptException)diagnostics[0].Exception;
-					if (s.SourceLine != null)
-						Assert.Contains("q.value.x", s.SourceLine);
 					Assert.AreEqual(6, s.LineNumber);
 					Assert.Contains("Error.ReadUndefined.ux", s.FileName);
 				}
@@ -89,8 +83,6 @@ namespace Fuse.Reactive.Test
 				var diagnostics = dg.DequeueAll();
 				Assert.AreEqual(1, diagnostics.Count);
 				var s = (ScriptException)diagnostics[0].Exception;
-				if (s.SourceLine != null)
-					Assert.Contains("newValue.value[0]", s.SourceLine);
 				Assert.AreEqual(12, s.LineNumber);
 				Assert.Contains("Error.OnValueChanged.ux", s.FileName);
 				//it's uncertain how stable these error messages are

--- a/Source/Fuse.Scripting.JavaScript/V8/Context.uno
+++ b/Source/Fuse.Scripting.JavaScript/V8/Context.uno
@@ -100,7 +100,6 @@ namespace Fuse.Scripting.V8
 				e.GetMessage(_context),
 				e.GetFileName(_context),
 				e.GetLineNumber(),
-				e.GetSourceLine(_context),
 				e.GetStackTrace(_context));
 			if (_vmDepth == 0)
 				throw se;

--- a/Source/Fuse.Scripting/ScriptException.uno
+++ b/Source/Fuse.Scripting/ScriptException.uno
@@ -1,79 +1,73 @@
+using Uno;
 
 namespace Fuse.Scripting
 {
 	public class ScriptException: Uno.Exception
 	{
 		public string Name { get; private set;}
-		public string ErrorMessage { get; private set;}
 		public string FileName { get; private set;}
 		public int LineNumber { get; private set;}
 		public string SourceLine { get; private set;}
 		public string JSStackTrace { get; private set;}
+
+		[Obsolete("Use ScriptException.Message instead")]
+		public string ErrorMessage { get { return Message; } }
 
 		const int MaxSourceLineLength = 300;
 		const string SourceLineTooLongMessage = " ... source line truncated for readability ...";
 
 		public ScriptException(
 			string name,
-			string errorMessage,
+			string message,
 			string fileName,
 			int lineNumber,
 			string sourceLine,
-			string stackTrace)
+			string stackTrace) : base(message)
 		{
 			Name = name;
-			ErrorMessage = errorMessage;
 			FileName = fileName;
 			LineNumber = lineNumber;
 			SourceLine = sourceLine;
 			JSStackTrace = stackTrace;
 		}
 
-		public override string Message
+		public override string ToString()
 		{
-			get
+			var stringBuilder = new Uno.Text.StringBuilder();
+			if (!string.IsNullOrEmpty(Name))
 			{
-				var stringBuilder = new Uno.Text.StringBuilder();
-				if (!string.IsNullOrEmpty(Name))
-				{
-					stringBuilder.Append("Name: ");
-					stringBuilder.AppendLine(Name);
-				}
-				if (!string.IsNullOrEmpty(ErrorMessage))
-				{
-					stringBuilder.Append("Error message: ");
-					stringBuilder.AppendLine(ErrorMessage);
-				}
-				if (!string.IsNullOrEmpty(FileName))
-				{
-					stringBuilder.Append("File name: ");
-					stringBuilder.AppendLine(FileName);
-				}
-				if (LineNumber >= 0)
-				{
-					stringBuilder.Append("Line number: ");
-					stringBuilder.AppendLine(LineNumber.ToString());
-				}
-				if (!string.IsNullOrEmpty(SourceLine))
-				{
-					stringBuilder.Append("Source line: ");
-					if (SourceLine.Length > MaxSourceLineLength)
-					{
-						stringBuilder.Append(SourceLine.Substring(0, MaxSourceLineLength));
-						stringBuilder.AppendLine(SourceLineTooLongMessage);
-					}
-					else
-					{
-						stringBuilder.AppendLine(SourceLine);
-					}
-				}
-				if (!string.IsNullOrEmpty(JSStackTrace))
-				{
-					stringBuilder.Append("JS stack trace: ");
-					stringBuilder.AppendLine(JSStackTrace);
-				}
-				return stringBuilder.ToString();
+				stringBuilder.Append("Name: ");
+				stringBuilder.AppendLine(Name);
 			}
+			if (!string.IsNullOrEmpty(FileName))
+			{
+				stringBuilder.Append("File name: ");
+				stringBuilder.AppendLine(FileName);
+			}
+			if (LineNumber >= 0)
+			{
+				stringBuilder.Append("Line number: ");
+				stringBuilder.AppendLine(LineNumber.ToString());
+			}
+			if (!string.IsNullOrEmpty(SourceLine))
+			{
+				stringBuilder.Append("Source line: ");
+				if (SourceLine.Length > MaxSourceLineLength)
+				{
+					stringBuilder.Append(SourceLine.Substring(0, MaxSourceLineLength));
+					stringBuilder.AppendLine(SourceLineTooLongMessage);
+				}
+				else
+				{
+					stringBuilder.AppendLine(SourceLine);
+				}
+			}
+			if (!string.IsNullOrEmpty(JSStackTrace))
+			{
+				stringBuilder.Append("JS stack trace: ");
+				stringBuilder.AppendLine(JSStackTrace);
+			}
+			return base.ToString() + "\n" + stringBuilder.ToString();
 		}
 	}
 }

--- a/Source/Fuse.Scripting/ScriptException.uno
+++ b/Source/Fuse.Scripting/ScriptException.uno
@@ -7,7 +7,6 @@ namespace Fuse.Scripting
 		public string Name { get; private set;}
 		public string FileName { get; private set;}
 		public int LineNumber { get; private set;}
-		public string SourceLine { get; private set;}
 		public string ScriptStackTrace { get; private set; }
 
 		[Obsolete("Use ScriptException.Message instead")]
@@ -16,21 +15,19 @@ namespace Fuse.Scripting
 		[Obsolete("Use ScriptException.ScriptStackTrace instead")]
 		public string JSStackTrace { get { return ScriptStackTrace; } }
 
-		const int MaxSourceLineLength = 300;
-		const string SourceLineTooLongMessage = " ... source line truncated for readability ...";
+		[Obsolete]
+		public string SourceLine { get { return null; } }
 
 		public ScriptException(
 			string name,
 			string message,
 			string fileName,
 			int lineNumber,
-			string sourceLine,
 			string stackTrace) : base(message)
 		{
 			Name = name;
 			FileName = fileName;
 			LineNumber = lineNumber;
-			SourceLine = sourceLine;
 			ScriptStackTrace = stackTrace;
 		}
 
@@ -51,19 +48,6 @@ namespace Fuse.Scripting
 			{
 				stringBuilder.Append("Line number: ");
 				stringBuilder.AppendLine(LineNumber.ToString());
-			}
-			if (!string.IsNullOrEmpty(SourceLine))
-			{
-				stringBuilder.Append("Source line: ");
-				if (SourceLine.Length > MaxSourceLineLength)
-				{
-					stringBuilder.Append(SourceLine.Substring(0, MaxSourceLineLength));
-					stringBuilder.AppendLine(SourceLineTooLongMessage);
-				}
-				else
-				{
-					stringBuilder.AppendLine(SourceLine);
-				}
 			}
 			if (!string.IsNullOrEmpty(ScriptStackTrace))
 			{

--- a/Source/Fuse.Scripting/ScriptException.uno
+++ b/Source/Fuse.Scripting/ScriptException.uno
@@ -8,10 +8,13 @@ namespace Fuse.Scripting
 		public string FileName { get; private set;}
 		public int LineNumber { get; private set;}
 		public string SourceLine { get; private set;}
-		public string JSStackTrace { get; private set;}
+		public string ScriptStackTrace { get; private set; }
 
 		[Obsolete("Use ScriptException.Message instead")]
 		public string ErrorMessage { get { return Message; } }
+
+		[Obsolete("Use ScriptException.ScriptStackTrace instead")]
+		public string JSStackTrace { get { return ScriptStackTrace; } }
 
 		const int MaxSourceLineLength = 300;
 		const string SourceLineTooLongMessage = " ... source line truncated for readability ...";
@@ -28,7 +31,7 @@ namespace Fuse.Scripting
 			FileName = fileName;
 			LineNumber = lineNumber;
 			SourceLine = sourceLine;
-			JSStackTrace = stackTrace;
+			ScriptStackTrace = stackTrace;
 		}
 
 		public override string ToString()
@@ -62,10 +65,10 @@ namespace Fuse.Scripting
 					stringBuilder.AppendLine(SourceLine);
 				}
 			}
-			if (!string.IsNullOrEmpty(JSStackTrace))
+			if (!string.IsNullOrEmpty(ScriptStackTrace))
 			{
-				stringBuilder.Append("JS stack trace: ");
-				stringBuilder.AppendLine(JSStackTrace);
+				stringBuilder.Append("Script stack trace: ");
+				stringBuilder.AppendLine(ScriptStackTrace);
 			}
 			return base.ToString() + "\n" + stringBuilder.ToString();
 		}

--- a/Source/Fuse.Scripting/ScriptModule.Require.uno
+++ b/Source/Fuse.Scripting/ScriptModule.Require.uno
@@ -80,7 +80,7 @@ namespace Fuse.Scripting
 
 						if (!e.Message.Contains(ModuleContainsAnErrorMessage))
 						{
-							Diagnostics.UserError("JavaScript error in " + path + " line " + e.LineNumber + ". " + e.ErrorMessage, this);
+							Diagnostics.UserError("JavaScript error in " + path + " line " + e.LineNumber + ". " + e.Message, this);
 							_lastErrorPath = path;
 						}
 						throw new Error(ModuleContainsAnErrorMessage + id);


### PR DESCRIPTION
This PR tries to restore some sanity to ScriptException:
- It tries to play ball with how normal `Uno.Exception`s work, in particular wrt Message vs ToString().
- `JSStackTrace` has been renamed to `ScriptStackTrace`, as this type is intended to be language agnostic
- The ill-advised SourceLine property that only worked on V8 has been dropped

There's more that can be done, but this should be sufficient to avoid breakages in feature-Models...

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [ ] ~Tests~
