### PR TITLE
Reevaluate builtins

### DIFF
--- a/Source/Fuse.Common/Tests/FuseTest/TestRootNode.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestRootNode.uno
@@ -450,6 +450,11 @@ namespace FuseTest
 			_modules.Add( new T() );
 		}
 		static List<object> _modules;
+
+		public IDisposable RetainJavaScript()
+		{
+			return Fuse.Reactive.JavaScript.RetainJavaScript();
+		}
 	}
 
 	/**	

--- a/Source/Fuse.Reactive.Bindings/Tests/Each.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/Each.Test.uno
@@ -273,11 +273,15 @@ namespace Fuse.Reactive.Test
 				Assert.AreEqual( "r2,r3", GetText(e.C) );
 
 				//try rerooting to ensure sanity
-				root.Children.Remove(e);
-				Assert.AreEqual( 1, e.C.Children.Count ); //Each only
-				root.StepFrameJS();
-				root.Children.Add(e);
-				root.StepFrameJS();
+				using (var js = root.RetainJavaScript())
+				{
+					root.Children.Remove(e);
+					Assert.AreEqual( 1, e.C.Children.Count ); //Each only
+					root.StepFrameJS();
+					root.Children.Add(e);
+					root.StepFrameJS();
+				}
+
 				Assert.AreEqual( "1,2", GetText(e.C) );
 			}
 		}

--- a/Source/Fuse.Scripting.JavaScript/JavaScript.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScript.uno
@@ -1,4 +1,4 @@
-//using Uno;
+using Uno;
 using Uno.UX;
 using Uno.Collections;
 using Uno.Compiler;
@@ -66,13 +66,13 @@ namespace Fuse.Reactive
 
 		Module IModuleProvider.GetModule()
 		{
-			if (IsRootingCompleted) throw new Uno.Exception("Cannot require() a rooted module");
+			if (IsRootingCompleted) throw new Exception("Cannot require() a rooted module");
 			return _scriptModule;
 		}
 
 		object _currentDc;
-		Uno.IDisposable _sub;
-		
+		IDisposable _sub;
+
 		internal void SetDataContext(object newDc)
 		{
 			DisposeSubscription();

--- a/Source/Fuse.Scripting.JavaScript/JavaScript.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScript.uno
@@ -22,7 +22,7 @@ namespace Fuse.Reactive
 	public partial class JavaScript: Behavior, IModuleProvider, ValueForwarder.IValueListener, Node.ISiblingDataProvider, IContext
 	{
 		static int _javaScriptCounter;
-		static internal readonly Fuse.Scripting.JavaScript.ThreadWorker Worker;
+		static internal Fuse.Scripting.JavaScript.ThreadWorker Worker { get; private set; }
 
 		internal readonly NameTable _nameTable;
 		Fuse.Scripting.JavaScript.RootableScriptModule _scriptModule;
@@ -69,6 +69,9 @@ namespace Fuse.Reactive
 				{
 					nm.InternalReset();
 				}
+
+				Worker.Dispose();
+				Worker = null;
 			}
 
 		}

--- a/Source/Fuse.Scripting.JavaScript/Tests/Various.Test.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/Various.Test.uno
@@ -103,8 +103,11 @@ namespace Fuse.Reactive.Test
 			{
 				//just not throwing is good enough
 				root.StepFrameJS();
-				e.Parent.Remove(e);
-				root.StepFrameJS();
+				using (var js = root.RetainJavaScript())
+				{
+					e.Parent.Remove(e);
+					root.StepFrameJS();
+				}
 			}
 		}
 
@@ -257,19 +260,22 @@ namespace Fuse.Reactive.Test
 				root.StepFrameJS();
 				Assert.AreEqual(3, getSubscriberCount.Count);
 
-				// Unroot everything
-				root.Children.Remove(e);
-				root.StepFrameJS();
+				using (var js = root.RetainJavaScript())
+				{
+					// Unroot everything
+					root.Children.Remove(e);
+					root.StepFrameJS();
 
-				// Should now have zero subscribers - none from JS, none 
-				// from the implicit property backing
-				JavaScript.Worker.Invoke(getSubscriberCount.Run);
-				root.StepFrameJS();
-				Assert.AreEqual(0, getSubscriberCount.Count);
+					// Should now have zero subscribers - none from JS, none 
+					// from the implicit property backing
+					JavaScript.Worker.Invoke(getSubscriberCount.Run);
+					root.StepFrameJS();
+					Assert.AreEqual(0, getSubscriberCount.Count);
 
-				// Add it back
-				root.Children.Add(e);
-				root.StepFrameJS();
+					// Add it back
+					root.Children.Add(e);
+					root.StepFrameJS();
+				}
 
 				Assert.IsTrue(e.IsRootingCompleted);
 


### PR DESCRIPTION
This will force builtins to be reevaluated, which fixes some problems
with Polyfills/Window not being available when an app that uses
the JavaScript-tag but *not* FuseJS gets rooted before one that uses
both.

This fixes problems with tests using AllTests.unoproj on feature-Models,
but the problem should also be possible to trigger from preview or other
carefully crafted apps.

