### PR TITLE
Fixed some cases where we exposed internal members through protected …

### DIFF
--- a/Source/Fuse.Controls.Navigation/NavigationControl.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.uno
@@ -113,7 +113,8 @@ namespace Fuse.Controls
 		
 		//the outlet page on which this control resides.
 		protected Visual AncestorPage { private set; get; }
-		internal protected RouterPage AncestorRouterPage { private set; get; }
+
+		internal RouterPage AncestorRouterPage { private set; get; }
 
 		/* 
 			This affects the structure of navigation, in particular by associating PageData.RouterPage's
@@ -307,7 +308,7 @@ namespace Fuse.Controls
 			to get the derived classes compiling and overriding parts of the interface. So the derived
 			classes simply implement the entire interaace and call this function.
 		*/
-		protected OutletType RouterOutletType
+		internal OutletType RouterOutletType
 		{
 			get
 			{
@@ -317,7 +318,7 @@ namespace Fuse.Controls
 			}
 		}
 		
-		internal class ControlPageData
+		public class ControlPageData
 		{
 			public Trigger Enter, Exit, Inactive, Removing;
 			

--- a/Source/Fuse.Navigation/ModifyRouteCommand.uno
+++ b/Source/Fuse.Navigation/ModifyRouteCommand.uno
@@ -115,7 +115,7 @@ namespace Fuse.Navigation
 			}
 		}
 		
-		protected abstract bool ProcessArguments(RouterRequest request, Argument[] args);
+		internal abstract bool ProcessArguments(RouterRequest request, Argument[] args);
 		
 		protected class ArgumentArrayAdapter : IArray
 		{
@@ -148,7 +148,7 @@ namespace Fuse.Navigation
 	[UXFunction("modifyRoute")]
 	public sealed class ModifyRouteCommand : RouteModificationCommand
 	{
-		protected override bool ProcessArguments(RouterRequest request, Argument[] args)
+		internal override bool ProcessArguments(RouterRequest request, Argument[] args)
 		{
 			for (int i=0; i < args.Length; ++i)
 			{
@@ -177,7 +177,7 @@ namespace Fuse.Navigation
 	[UXFunction("gotoRoute")]
 	public sealed class GotoRouteCommand : RouteModificationCommand
 	{
-		protected override bool ProcessArguments(RouterRequest request, Argument[] args)
+		internal override bool ProcessArguments(RouterRequest request, Argument[] args)
 		{
 			return request.AddHow( ModifyRouteHow.Goto ) &&
 				request.AddPath( new ArgumentArrayAdapter(args) );
@@ -192,7 +192,7 @@ namespace Fuse.Navigation
 	[UXFunction("pushRoute")]
 	public sealed class PushRouteCommand : RouteModificationCommand
 	{
-		protected override bool ProcessArguments(RouterRequest request, Argument[] args)
+		internal override bool ProcessArguments(RouterRequest request, Argument[] args)
 		{
 			return request.AddHow( ModifyRouteHow.Push ) &&
 				request.AddPath( new ArgumentArrayAdapter(args) );

--- a/Source/Fuse.Navigation/VisualNavigation.uno
+++ b/Source/Fuse.Navigation/VisualNavigation.uno
@@ -131,7 +131,7 @@ namespace Fuse.Navigation
 		
 		internal protected IList<PageData> Pages { get { return _pages; } }
 		
-		protected PageData GetPageData( Visual page ) 
+		internal PageData GetPageData( Visual page ) 
 		{
 			if (page == null)
 				return null;


### PR DESCRIPTION
…methods/properties

This has come up before, and this is a problem when generating docs because the docs backend has a check for this which apparently the uno frontend does not :S.

I thought i had made a ticket for this on Uno a long time ago, but apparently i never did that.

Not sure if this is the best or most correct way of correcting these errors, but they fixed my problem with us exposing internal types / members through protected methods.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
