### PR TITLE
Fuse.Nodes: introduce IRootVisualProvider

### DIFF
--- a/Source/Fuse.Nodes/AppBase.uno
+++ b/Source/Fuse.Nodes/AppBase.uno
@@ -11,6 +11,11 @@ using Fuse.Resources;
 
 namespace Fuse
 {
+	public interface IRootVisualProvider
+	{
+		Visual Root { get; }
+	}
+
 	/** Holds information about an unhandled exception */
 	public class UnhandledExceptionArgs: EventArgs
 	{
@@ -33,8 +38,11 @@ namespace Fuse
 		only need to derive from this class when adding support for a new platform.
 		Fuse already provides derived classes for each supported platform, all of them named @App, that you
 		should use as base class when creating an app for an already supported platform. */
-	public abstract class AppBase: Uno.Application, IProperties
+	public abstract class AppBase: Uno.Application, IProperties, IRootVisualProvider
 	{
+
+		Visual IRootVisualProvider.Root { get { return RootViewport; } }
+
 		/** The top-level root viewport of this @App. This object has `null` as parent. */
 		public RootViewport RootViewport { get; protected set; }
 


### PR DESCRIPTION
This will be used by the tool as well as feature-Models. It's being
added early to make it easier for the tool to support both master and
the upcoming feature.