### PR TITLE
Fix typo in TimePicker doc

### DIFF
--- a/Source/Fuse.Controls.TimePicker/TimePicker.Docs.uno
+++ b/Source/Fuse.Controls.TimePicker/TimePicker.Docs.uno
@@ -47,7 +47,7 @@ namespace Fuse.Controls
 				</JavaScript>
 
 				<NativeViewHost>
-					<TimePicker Value="{someTime}" Is24HourTimeView="true" />
+					<TimePicker Value="{someTime}" Is24HourView="true" />
 				</NativeViewHost>
 
 				<Button Text="Time to get cracking!" Clicked="{timeToGetCracking}" Margin="5" />


### PR DESCRIPTION
I believe the name of this property was changed prior to release, and I probably forgot to update the docs.

Fixes #767.

This PR contains:
- [ ] Changelog
- [x] Documentation
- [ ] Tests
