### PR TITLE
Fix TimePicker properties

### DIFF
--- a/Source/Fuse.Controls.TimePicker/Android/TimePicker.uno
+++ b/Source/Fuse.Controls.TimePicker/Android/TimePicker.uno
@@ -11,17 +11,20 @@ namespace Fuse.Controls.Native.Android
 	extern(!Android) class TimePickerView
 	{
 		[UXConstructor]
-		public TimePickerView([UXParameter("Host")]ITimePickerHost host) { }
+		public TimePickerView([UXParameter("Host")]TimePicker host) { }
 	}
 
 	extern(Android) class TimePickerView : LeafView, ITimePickerView
 	{
-		ITimePickerHost _host;
+		TimePicker _host;
 
 		[UXConstructor]
-		public TimePickerView([UXParameter("Host")]ITimePickerHost host) : base(Create())
+		public TimePickerView([UXParameter("Host")]TimePicker host) : base(Create())
 		{
 			_host = host;
+
+			Value = _host.Value;
+			Is24HourView = _host.Is24HourView;
 
 			// onTimeChanged is extremely inconsistent, esp. when using the now-default clock mode, so
 			//  let's just skip trying to use it altogether and go for a polling-based approach instead.
@@ -59,7 +62,7 @@ namespace Fuse.Controls.Native.Android
 		{
 			if (Value != _pollValueCache)
 			{
-				OnValueChanged();
+				OnValueChanged(Value);
 				UpdatePollValueCache();
 			}
 		}
@@ -74,15 +77,14 @@ namespace Fuse.Controls.Native.Android
 			UpdateManager.RemoveAction(PollViewValue);
 		}
 
-		public bool Is24HourView
+		void OnValueChanged(DateTime value)
 		{
-			get { return GetIs24HourView(Handle); }
-			set { SetIs24HourView(Handle, value); }
+			_host.OnNativeViewValueChanged(value);
 		}
 
-		void OnValueChanged()
+		public bool Is24HourView
 		{
-			_host.OnValueChanged();
+			set { SetIs24HourView(Handle, value); }
 		}
 
 		[Foreign(Language.Java)]
@@ -150,14 +152,6 @@ namespace Fuse.Controls.Native.Android
 			android.widget.TimePicker timePicker = (android.widget.TimePicker)timePickerHandle;
 
 			timePicker.setIs24HourView(value);
-		@}
-
-		[Foreign(Language.Java)]
-		bool GetIs24HourView(Java.Object timePickerHandle)
-		@{
-			android.widget.TimePicker timePicker = (android.widget.TimePicker)timePickerHandle;
-
-			return timePicker.is24HourView();
 		@}
 	}
 }

--- a/Source/Fuse.Controls.TimePicker/iOS/TimePicker.uno
+++ b/Source/Fuse.Controls.TimePicker/iOS/TimePicker.uno
@@ -12,19 +12,22 @@ namespace Fuse.Controls.Native.iOS
 	extern(!iOS) class TimePickerView
 	{
 		[UXConstructor]
-		public TimePickerView([UXParameter("Host")]ITimePickerHost host) { }
+		public TimePickerView([UXParameter("Host")]TimePicker host) { }
 	}
 
 	[Require("Source.Include", "UIKit/UIKit.h")]
 	extern(iOS) class TimePickerView : LeafView, ITimePickerView
 	{
-		ITimePickerHost _host;
+		TimePicker _host;
 		IDisposable _valueChangedEvent;
 
 		[UXConstructor]
-		public TimePickerView([UXParameter("Host")]ITimePickerHost host) : base(Create())
+		public TimePickerView([UXParameter("Host")]TimePicker host) : base(Create())
 		{
 			_host = host;
+
+			Value = _host.Value;
+
 			_valueChangedEvent = UIControlEvent.AddValueChangedCallback(Handle, OnValueChanged);
 		}
 
@@ -38,7 +41,7 @@ namespace Fuse.Controls.Native.iOS
 
 		void OnValueChanged(ObjC.Object sender, ObjC.Object args)
 		{
-			_host.OnValueChanged();
+			_host.OnNativeViewValueChanged(Value);
 		}
 
 		public DateTime Value
@@ -50,7 +53,6 @@ namespace Fuse.Controls.Native.iOS
 		// Dummy prop, as the iOS API doesn't provide an explicit API for this.
 		public bool Is24HourView
 		{
-			get { return false; }
 			set {
 				// Do nothing
 			}


### PR DESCRIPTION
Originally, they were erroneously stored on the view, which led to some invalid conditions where a property would be set before the view was ready and the value lost. Now, following other native controls like Slider, values are stored on the semantic control, and propagated to the view.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
