### PR TITLE
Logical fix to batching cleanup

### DIFF
--- a/Source/Fuse.Elements/Element.Batching.uno
+++ b/Source/Fuse.Elements/Element.Batching.uno
@@ -63,7 +63,10 @@ namespace Fuse.Elements
 			{
 				// get rid of old element batcher
 				if (_elementBatcher != null)
+				{
+					_elementBatcher.Dispose();
 					_elementBatcher = null;
+				}
 
 				for (var i = 0; i < zOrder.Length; i++) 
 				{


### PR DESCRIPTION
fixes https://github.com/fusetools/support-101ventures/issues/41

I was unable to come up with an isolated reproduction, thus could not create a unit test. It does fix the reported project. I've gone through several scenarios that exercise the code change, but I just couldn't get the original crash to happen except in the original code. :/

This PR contains:
- [ ] ~Changelog~
- [ ] ~Documentation~
- [ ] ~Tests~
