### PR TITLE
Fix null sender in RangeControl

### DIFF
--- a/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
+++ b/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
@@ -243,7 +243,7 @@ namespace Fuse.Controls
 
 		void IRangeViewHost.OnProgressChanged(double newProgress)
 		{
-			SetValue(ValueFromRelative(newProgress), null);	
+			SetValue(ValueFromRelative(newProgress), RangeView);
 		}
 		
 		double IRangeViewHost.RelativeUserStep


### PR DESCRIPTION
I don't know of any bugs this actually caused, but the logic is clearly a bit strange. This should use the NativeView as the sender when calling SetValue to avoid value propagation loops.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
