### PR TITLE
Drop Context methods from ISubscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - `Fuse.Scripting`'s `Object` type has a `CallMethod` method, this now takes a `Scripting.Context`. This guarentees that it can only occur on the VM thread.
 - IMirror is no longer implemented by ThreadWorker. This functionality has been moved to the context
 - Moved `ArrayMirror`, `ClassInstance`, `ModuleInstance`, `ObjectMirror`, `Observable`, `ObservableProperty`, `RootableScriptModule` & `ThreadWorker` to the `Fuse.Scripting.JavaScript` namespace
-- Removed the `CanEvaluate` method and instead rely on the passing of the `Scripting.Context` to know if we are on the VM thread or not. This required adding some methods to the `ISubscription` which take the `Scripting.Context`
+- Removed the `CanEvaluate` method and instead rely on the passing of the `Scripting.Context` to know if we are on the VM thread or not.
 - The 'wrapping' functionality has been moved from the `ThreadWorker` to a standalone static class called `TypeWrapper`. The `IThreadWorker` no longer provides `Wrap` & `UnWrap`
 - `ThreadWorker.ScriptClass` functionality moved to context. We will likely want to factor this out to a helper class however for now the major benefit is that `ThreadWorker` no longer owns these features.
 - Remove the public `Context` property from the `ThreadWorker`. Sadly the context is still available via the internal field so that the tests can work. This will need to be fixed.

--- a/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
@@ -64,10 +64,6 @@ namespace FuseTest
 			void ISubscription.ClearExclusive() { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
 			void ISubscription.SetExclusive(object newValue) { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
 			void ISubscription.ReplaceAllExclusive(IArray values) { Source.ReplaceAllExclusive(values); }
-
-			void ISubscription.ClearExclusive(Fuse.Scripting.Context context) { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
-			void ISubscription.SetExclusive(Fuse.Scripting.Context context, object newValue) { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
-			void ISubscription.ReplaceAllExclusive(Fuse.Scripting.Context context, IArray values) { Source.ReplaceAllExclusive(values); }
 		}
 		
 		class ReadOnlySubscription : Subscription

--- a/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
@@ -61,20 +61,20 @@ namespace FuseTest
 				Source.Unsubscribe(Observer);
 			}
 			
-			public void ClearExclusive() { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
-			public void SetExclusive(object newValue) { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
-			public void ReplaceAllExclusive(IArray values) { Source.ReplaceAllExclusive(values); }
+			void ISubscription.ClearExclusive() { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
+			void ISubscription.SetExclusive(object newValue) { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
+			void ISubscription.ReplaceAllExclusive(IArray values) { Source.ReplaceAllExclusive(values); }
 
-			public void ClearExclusive(Fuse.Scripting.Context context) { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
-			public void SetExclusive(Fuse.Scripting.Context context, object newValue) { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
-			public void ReplaceAllExclusive(Fuse.Scripting.Context context, IArray values) { Source.ReplaceAllExclusive(values); }
+			void ISubscription.ClearExclusive(Fuse.Scripting.Context context) { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
+			void ISubscription.SetExclusive(Fuse.Scripting.Context context, object newValue) { Fuse.Diagnostics.InternalError( "Unsupported", this ); }
+			void ISubscription.ReplaceAllExclusive(Fuse.Scripting.Context context, IArray values) { Source.ReplaceAllExclusive(values); }
 		}
 		
 		class ReadOnlySubscription : Subscription
 		{
-			public void ClearExclusive() { Fuse.Diagnostics.InternalError( "ReadOnly array", this ); }
-			public void SetExclusive(object newValue) { Fuse.Diagnostics.InternalError( "ReadOnly array", this ); }
-			public void ReplaceAllExclusive(IArray values) { Fuse.Diagnostics.InternalError( "ReadOnly array", this ); }
+			void ISubscription.ClearExclusive() { Fuse.Diagnostics.InternalError( "ReadOnly array", this ); }
+			void ISubscription.SetExclusive(object newValue) { Fuse.Diagnostics.InternalError( "ReadOnly array", this ); }
+			void ISubscription.ReplaceAllExclusive(IArray values) { Fuse.Diagnostics.InternalError( "ReadOnly array", this ); }
 		}
 		
 		virtual protected void OnSubscription() { }

--- a/Source/Fuse.Reactive/IObservable.uno
+++ b/Source/Fuse.Reactive/IObservable.uno
@@ -136,13 +136,6 @@ namespace Fuse.Reactive
 		void SetExclusive(object newValue);
 		/** Replaces the `IObservableArray` with the given values, without notifying this subscription of the change. */
 		void ReplaceAllExclusive(IArray values);
-
-		/** Clears the contents of the `IObservableArray` without notifying this subscription of the change. Guareentees this was called from language thread */
-		void ClearExclusive(Scripting.Context context);
-		/** Replaces the `IObservableArray` with a list of length 1, containting the given object, without notifying this subscription of the change. Guareentees this was called from language thread  */
-		void SetExclusive(Scripting.Context context, object newValue);
-		/** Replaces the `IObservableArray` with the given values, without notifying this subscription of the change. Guareentees this was called from language thread  */
-		void ReplaceAllExclusive(Scripting.Context context, IArray values);
 	}
 
 	/** Represents an object that can receive change notifications for an `IObservableArray`. */

--- a/Source/Fuse.Scripting.JavaScript/Observable.uno
+++ b/Source/Fuse.Scripting.JavaScript/Observable.uno
@@ -232,6 +232,11 @@ namespace Fuse.Scripting.JavaScript
 		*/
 		public ISubscription Subscribe(IObserver observer)
 		{
+			return SubscribeInternal(observer);
+		}
+
+		internal Subscription SubscribeInternal(IObserver observer)
+		{
 			return new Subscription(this, observer);
 		}
 

--- a/Source/Fuse.Scripting.JavaScript/Observable.uno
+++ b/Source/Fuse.Scripting.JavaScript/Observable.uno
@@ -109,7 +109,7 @@ namespace Fuse.Scripting.JavaScript
 				}
 			}
 
-			public void SetExclusive(Scripting.Context context, object newValue)
+			void ISubscription.SetExclusive(Scripting.Context context, object newValue)
 			{
 				ClearDiagnostic();
 
@@ -123,7 +123,7 @@ namespace Fuse.Scripting.JavaScript
 				op.Perform(context);
 			}
 
-			public void SetExclusive(object newValue)
+			void ISubscription.SetExclusive(object newValue)
 			{
 				ClearDiagnostic();
 
@@ -162,7 +162,7 @@ namespace Fuse.Scripting.JavaScript
 				}
 			}
 
-			public void ReplaceAllExclusive(IArray newValues)
+			void ISubscription.ReplaceAllExclusive(IArray newValues)
 			{
 				var arr = new object[newValues.Length];
 				for (int i = 0; i < arr.Length; i++)
@@ -172,7 +172,7 @@ namespace Fuse.Scripting.JavaScript
 				_om._worker.Invoke(op.Perform);
 			}
 
-			public void ReplaceAllExclusive(Scripting.Context context, IArray newValues)
+			void ISubscription.ReplaceAllExclusive(Scripting.Context context, IArray newValues)
 			{
 				var arr = new object[newValues.Length];
 				for (int i = 0; i < arr.Length; i++)
@@ -200,13 +200,13 @@ namespace Fuse.Scripting.JavaScript
 				}
 			}
 
-			public void ClearExclusive(Scripting.Context context)
+			void ISubscription.ClearExclusive(Scripting.Context context)
 			{
 				var op = new ClearExclusiveOperation(_om.Object, _origin);
 				op.Perform(context);
 			}
 
-			public void ClearExclusive()
+			void ISubscription.ClearExclusive()
 			{
 				var op = new ClearExclusiveOperation(_om.Object, _origin);
 				_om._worker.Invoke(op.Perform);

--- a/Source/Fuse.Scripting.JavaScript/Observable.uno
+++ b/Source/Fuse.Scripting.JavaScript/Observable.uno
@@ -109,7 +109,7 @@ namespace Fuse.Scripting.JavaScript
 				}
 			}
 
-			void ISubscription.SetExclusive(Scripting.Context context, object newValue)
+			public void SetExclusive(Scripting.Context context, object newValue)
 			{
 				ClearDiagnostic();
 
@@ -172,7 +172,7 @@ namespace Fuse.Scripting.JavaScript
 				_om._worker.Invoke(op.Perform);
 			}
 
-			void ISubscription.ReplaceAllExclusive(Scripting.Context context, IArray newValues)
+			public void ReplaceAllExclusive(Scripting.Context context, IArray newValues)
 			{
 				var arr = new object[newValues.Length];
 				for (int i = 0; i < arr.Length; i++)
@@ -200,7 +200,7 @@ namespace Fuse.Scripting.JavaScript
 				}
 			}
 
-			void ISubscription.ClearExclusive(Scripting.Context context)
+			public void ClearExclusive(Scripting.Context context)
 			{
 				var op = new ClearExclusiveOperation(_om.Object, _origin);
 				op.Perform(context);

--- a/Source/Fuse.Scripting.JavaScript/ObservableProperty.uno
+++ b/Source/Fuse.Scripting.JavaScript/ObservableProperty.uno
@@ -50,10 +50,10 @@ namespace Fuse.Scripting.JavaScript
 			return _observable;
 		}
 
-		ISubscription _subscription;
+		Observable.Subscription _subscription;
 		void Subscribe(Scripting.Context context)
 		{
-			_subscription = _observable.Subscribe(this);
+			_subscription = (Observable.Subscription)_observable.Subscribe(this);
 			PushValue(context, _property.GetAsObject());
 			_property.AddListener(this);
 		}

--- a/Source/Fuse.Scripting.JavaScript/ObservableProperty.uno
+++ b/Source/Fuse.Scripting.JavaScript/ObservableProperty.uno
@@ -53,7 +53,7 @@ namespace Fuse.Scripting.JavaScript
 		Observable.Subscription _subscription;
 		void Subscribe(Scripting.Context context)
 		{
-			_subscription = (Observable.Subscription)_observable.Subscribe(this);
+			_subscription = _observable.SubscribeInternal(this);
 			PushValue(context, _property.GetAsObject());
 			_property.AddListener(this);
 		}

--- a/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeArray.uno
+++ b/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeArray.uno
@@ -93,7 +93,7 @@ namespace Fuse.Scripting.JavaScript
 			}
 
 
-			public void ReplaceAllExclusive(Scripting.Context context, IArray values)
+			void ReplaceAllExclusive(Scripting.Context context, IArray values)
 			{
 				var ta = SubscriptionSubject as TreeArray;
 
@@ -103,7 +103,7 @@ namespace Fuse.Scripting.JavaScript
 				UpdateManager.PostAction(new ReplaceAllOnUIThreadClosure(ta, values, this).Perform);
 			}
 
-			public void ReplaceAllExclusive(IArray values)
+			void ReplaceAllExclusive(IArray values)
 			{
 				var ta = SubscriptionSubject as TreeArray;
 
@@ -114,24 +114,34 @@ namespace Fuse.Scripting.JavaScript
 				ta.ReplaceAll(values, this);
 			}
 
-			public void ClearExclusive()
+			void ISubscription.ClearExclusive()
 			{
 				ReplaceAllExclusive(new SimpleArray());
 			}
 
-			public void ClearExclusive(Scripting.Context context)
+			void ISubscription.ClearExclusive(Scripting.Context context)
 			{
 				ReplaceAllExclusive(context, new SimpleArray());
 			}
 
-			public void SetExclusive(object newValue)
+			void ISubscription.SetExclusive(object newValue)
 			{
 				ReplaceAllExclusive(new SimpleArray(newValue));
 			}
 
-			public void SetExclusive(Scripting.Context context, object newValue)
+			void ISubscription.SetExclusive(Scripting.Context context, object newValue)
 			{
 				ReplaceAllExclusive(context, new SimpleArray(newValue));
+			}
+
+			void ISubscription.ReplaceAllExclusive(Scripting.Context context, IArray values)
+			{
+				ReplaceAllExclusive(context, values);
+			}
+
+			void ISubscription.ReplaceAllExclusive(IArray values)
+			{
+				ReplaceAllExclusive(values);
 			}
 
 			class SimpleArray : IArray

--- a/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeArray.uno
+++ b/Source/Fuse.Scripting.JavaScript/TreeObservable/TreeArray.uno
@@ -93,7 +93,7 @@ namespace Fuse.Scripting.JavaScript
 			}
 
 
-			void ReplaceAllExclusive(Scripting.Context context, IArray values)
+			public void ReplaceAllExclusive(Scripting.Context context, IArray values)
 			{
 				var ta = SubscriptionSubject as TreeArray;
 
@@ -119,7 +119,7 @@ namespace Fuse.Scripting.JavaScript
 				ReplaceAllExclusive(new SimpleArray());
 			}
 
-			void ISubscription.ClearExclusive(Scripting.Context context)
+			public void ClearExclusive(Scripting.Context context)
 			{
 				ReplaceAllExclusive(context, new SimpleArray());
 			}
@@ -129,14 +129,9 @@ namespace Fuse.Scripting.JavaScript
 				ReplaceAllExclusive(new SimpleArray(newValue));
 			}
 
-			void ISubscription.SetExclusive(Scripting.Context context, object newValue)
+			public void SetExclusive(Scripting.Context context, object newValue)
 			{
 				ReplaceAllExclusive(context, new SimpleArray(newValue));
-			}
-
-			void ISubscription.ReplaceAllExclusive(Scripting.Context context, IArray values)
-			{
-				ReplaceAllExclusive(context, values);
 			}
 
 			void ISubscription.ReplaceAllExclusive(IArray values)


### PR DESCRIPTION
All call-sites can do better directly, due to internal knowledge
about the objects.

For instance, Fuse.Scripting.JavaScript.ObservableProperty knows
exactly the type of Subscription-object it gets, and can call
specific script-shortcut versions of the methods.

And Fuse.Scripting.JavaScript.TreeArray is going to dispatch to the
UI-thread anyway, so it can just do this a bit earlier.

This should fix some problems in premium packages that use this type.

This PR contains:
- [x] Changelog
- [ ] ~Documentation~ Only internal API
- [ ] ~Tests~ Functionality already covered
