### PR TITLE
More scripting cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - `Fuse.IScriptException` has been marked as obsolete. This was previously unused.
 - `ScriptException.JSStackTrace` has been marked as obsolete, use `ScriptException.ScriptStackTrace` instead.
 - `ScriptException.SourceLine` has been marked as obsolete, and consistently returns null now. The latter was always the case except for when using V8 before. The same information can be deduced from the project files and FileName + LineNumber fields.
+- `ModuleResult.Object` has been marked as obsolete. Use `ModuleResult.GetObject(Context)` instead.
 
 
 # 1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - `ScriptException.JSStackTrace` has been marked as obsolete, use `ScriptException.ScriptStackTrace` instead.
 - `ScriptException.SourceLine` has been marked as obsolete, and consistently returns null now. The latter was always the case except for when using V8 before. The same information can be deduced from the project files and FileName + LineNumber fields.
 - `ModuleResult.Object` has been marked as obsolete. Use `ModuleResult.GetObject(Context)` instead.
+- `ModuleResult.Exports` has been marked as obsolete. Use `ModuleResult.GetExports(Context)` instead.
 
 
 # 1.4

--- a/Source/Fuse.Scripting.JavaScript/FuseJS/Http.uno
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/Http.uno
@@ -20,7 +20,7 @@ namespace Fuse.Reactive.FuseJS
 
 		public override void Evaluate(Context c, ModuleResult result)
 		{
-			result.Object["exports"] = (Callback)CreateClient;
+			result.GetObject(c)["exports"] = (Callback)CreateClient;
 		}
 
 		object CreateClient(Context context, object[] args)

--- a/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
+++ b/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
@@ -103,6 +103,8 @@ namespace Fuse.Scripting.JavaScript
 					// Don't report chain-errors of already reported errors
 					if (!se.Message.Contains(ScriptModule.ModuleContainsAnErrorMessage))
 						_diagnostic.SetDiagnostic(se);
+
+					newModuleResult.Dispose();
 				}
 			}
 		}

--- a/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
+++ b/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
@@ -72,7 +72,7 @@ namespace Fuse.Scripting.JavaScript
 			EvaluateModule(context);
 
 			if (_moduleResult != null)
-				return _moduleResult.Object["exports"];
+				return _moduleResult.GetObject(context)["exports"];
 
 			return null;
 		}

--- a/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
+++ b/Source/Fuse.Scripting.JavaScript/ModuleInstance.uno
@@ -72,7 +72,7 @@ namespace Fuse.Scripting.JavaScript
 			EvaluateModule(context);
 
 			if (_moduleResult != null)
-				return _moduleResult.GetObject(context)["exports"];
+				return _moduleResult.GetExports(context);
 
 			return null;
 		}

--- a/Source/Fuse.Scripting/Module.uno
+++ b/Source/Fuse.Scripting/Module.uno
@@ -8,8 +8,7 @@ namespace Fuse.Scripting
 	{
 		public object EvaluateExports(Context c, string id)
 		{
-			var r = Evaluate(c, id).GetObject(c)["exports"];
-			return r;
+			return Evaluate(c, id).GetExports(c);
 		}
 
 		public ModuleResult Evaluate(Context c, string id)

--- a/Source/Fuse.Scripting/Module.uno
+++ b/Source/Fuse.Scripting/Module.uno
@@ -8,7 +8,7 @@ namespace Fuse.Scripting
 	{
 		public object EvaluateExports(Context c, string id)
 		{
-			var r = Evaluate(c, id).Object["exports"];
+			var r = Evaluate(c, id).GetObject(c)["exports"];
 			return r;
 		}
 

--- a/Source/Fuse.Scripting/ModuleResult.uno
+++ b/Source/Fuse.Scripting/ModuleResult.uno
@@ -14,6 +14,7 @@ namespace Fuse.Scripting
 		public readonly Module Module;
 
 		readonly Scripting.Object _object;
+		[Obsolete("Use GetObject(Context) instead")]
 		public Scripting.Object Object { get { return _object; } }
 
 		public Scripting.Object GetObject(Context c)

--- a/Source/Fuse.Scripting/ModuleResult.uno
+++ b/Source/Fuse.Scripting/ModuleResult.uno
@@ -22,7 +22,10 @@ namespace Fuse.Scripting
 			return _object;
 		}
 
+		[Obsolete("Use GetExports(Context)")]
 		public object Exports { get { return _object["exports"]; } }
+
+		public object GetExports(Context c) { return _object["exports"]; }
 
 		public ScriptException Error { get; internal set; }
 

--- a/Source/Fuse.Scripting/ModuleResult.uno
+++ b/Source/Fuse.Scripting/ModuleResult.uno
@@ -12,8 +12,16 @@ namespace Fuse.Scripting
 		public readonly Context Context;
 		public readonly string Id;
 		public readonly Module Module;
-		public readonly Scripting.Object Object;
-		public object Exports { get { return Object["exports"]; } }
+
+		readonly Scripting.Object _object;
+		public Scripting.Object Object { get { return _object; } }
+
+		public Scripting.Object GetObject(Context c)
+		{
+			return _object;
+		}
+
+		public object Exports { get { return _object["exports"]; } }
 
 		public ScriptException Error { get; internal set; }
 
@@ -24,7 +32,7 @@ namespace Fuse.Scripting
 		{
 			Context = context;
 			Module = mod;
-			Object = obj;
+			_object = obj;
 			Id = id;
 
 			// Watch global key for changes
@@ -106,9 +114,9 @@ namespace Fuse.Scripting
 
 		void OnDisposed(Scripting.Context context)
 		{
-			if (Object.ContainsKey("disposed"))
+			if (_object.ContainsKey("disposed"))
 			{
-				var disposed = Object["disposed"] as Scripting.Array;
+				var disposed = _object["disposed"] as Scripting.Array;
 				if (disposed != null)
 				{
 					for (int i = 0; i < disposed.Length; i++)

--- a/Source/Fuse.Scripting/NativeModule.uno
+++ b/Source/Fuse.Scripting/NativeModule.uno
@@ -29,7 +29,7 @@ namespace Fuse.Scripting
 
 		public override void Evaluate(Context c, ModuleResult result)
 		{
-			var module = result.Object;
+			var module = result.GetObject(c);
 			if (module != null)
 			{
 				var obj = module["exports"] as Scripting.Object;

--- a/Source/Fuse.Scripting/ScriptModule.Evaluate.uno
+++ b/Source/Fuse.Scripting/ScriptModule.Evaluate.uno
@@ -64,7 +64,7 @@ namespace Fuse.Scripting
 
 		protected virtual string GenerateArgs(Context c, ModuleResult result, List<object> args)
 		{
-			var module = result.Object;
+			var module = result.GetObject(c);
 
 			var rt = GenerateRequireTable(c);
 

--- a/Source/Fuse.Scripting/ScriptModule.Require.uno
+++ b/Source/Fuse.Scripting/ScriptModule.Require.uno
@@ -91,7 +91,7 @@ namespace Fuse.Scripting
 					module.AddDependency(_dependant.Invalidate);
 				}
 
-				return module.GetObject(context)["exports"];
+				return module.GetExports(context);
 			}
 		}
 

--- a/Source/Fuse.Scripting/ScriptModule.Require.uno
+++ b/Source/Fuse.Scripting/ScriptModule.Require.uno
@@ -33,12 +33,12 @@ namespace Fuse.Scripting
 				var id = args[0] as string;
 				if (id == null) throw new Error("require(): argument must be a string");
 
-				return Require(id);
+				return Require(context, id);
 			}
 
 			static string _lastErrorPath;
 
-			public object Require(string id)
+			public object Require(Context context, string id)
 			{
 				bool isFile;
 				var path = _m.ComputePath(id, out isFile);
@@ -91,9 +91,7 @@ namespace Fuse.Scripting
 					module.AddDependency(_dependant.Invalidate);
 				}
 
-				
-
-				return module.Object["exports"];
+				return module.GetObject(context)["exports"];
 			}
 		}
 

--- a/Source/Fuse.Scripting/ScriptModule.Require.uno
+++ b/Source/Fuse.Scripting/ScriptModule.Require.uno
@@ -38,7 +38,7 @@ namespace Fuse.Scripting
 
 			static string _lastErrorPath;
 
-			public object Require(Context context, string id)
+			object Require(Context context, string id)
 			{
 				bool isFile;
 				var path = _m.ComputePath(id, out isFile);

--- a/Source/Fuse.WebSockets/WebSocketModule.uno
+++ b/Source/Fuse.WebSockets/WebSocketModule.uno
@@ -22,7 +22,7 @@ namespace Fuse.WebSocket
 
 		public override void Evaluate(Context c, ModuleResult result)
 		{
-			result.Object["exports"] = new FunctionClosure(c, Create).Callback;
+			result.GetObject(c)["exports"] = new FunctionClosure(c, Create).Callback;
 		}
 
 		protected abstract object Create(Context context, object[] args);


### PR DESCRIPTION
Here's some more thread-safety and general API cleanups in Fuse.Scripting and Fuse.Scripting.JavaScript.

The only functional change would be disposing the ModuleResult in an error-case, which usually shouldn't be triggered.