### PR TITLE
Fuse.Reactive.Expressions: do not crash on null input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 # 1.4
 
+## 1.4.1
+
+### Expressions
+- Fixed an issue where toUpper and toLower would crash on null intput. Now they propagate null instead.
+
+
 ## 1.4.0
 
 ### Notifications

--- a/Source/Fuse.Common/Tests/FuseTest/Value.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/Value.uno
@@ -59,5 +59,11 @@ namespace FuseTest
 			get { return Marshal.ToType<bool>(Object); }
 			set { Object = value; }
 		}
+
+		public string String
+		{
+			get { return Marshal.ToType<string>(Object); }
+			set { Object = value; }
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/StringFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/StringFunctions.uno
@@ -9,7 +9,10 @@ namespace Fuse.Reactive
 		public ToUpper([UXParameter("Value")] Expression value): base(value) {}
 		protected override object Compute(object s)
 		{
-			return s.ToString().ToUpper();
+			if (s != null)
+				return s.ToString().ToUpper();
+
+			return null;
 		}
 
 		public override string ToString()
@@ -25,7 +28,10 @@ namespace Fuse.Reactive
 		public ToLower([UXParameter("Value")] Expression value): base(value) {}
 		protected override object Compute(object s)
 		{
-			return s.ToString().ToLower();
+			if (s != null)
+				return s.ToString().ToLower();
+
+			return null;
 		}
 
 		public override string ToString()

--- a/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
@@ -1,0 +1,33 @@
+using Uno;
+using Uno.UX;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Reactive.Expressions.Test
+{
+	public class StringFunctionsTest : TestBase
+	{
+		[Test]
+		public void ToUpper()
+		{
+			var p = new UX.StringFunctions.ToUpper();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(null, p.NullInput.String);
+				Assert.AreEqual(null, p.NullResult.String);
+			}
+		}
+
+		[Test]
+		public void ToLower()
+		{
+			var p = new UX.StringFunctions.ToLower();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(null, p.NullInput.String);
+				Assert.AreEqual(null, p.NullResult.String);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.ToLower.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.ToLower.ux
@@ -1,0 +1,4 @@
+<Panel ux:Class="UX.StringFunctions.ToLower">
+	<FuseTest.Value ux:Name="NullInput" />
+	<FuseTest.Value String="{= toLower({Property NullInput.String}) }" ux:Name="NullResult"/>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.ToUpper.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.ToUpper.ux
@@ -1,0 +1,4 @@
+<Panel ux:Class="UX.StringFunctions.ToUpper">
+	<FuseTest.Value ux:Name="NullInput" />
+	<FuseTest.Value String="{= toUpper({Property NullInput.String}) }" ux:Name="NullResult"/>
+</Panel>


### PR DESCRIPTION
Fixes fusetools/uno#1454

This PR contains:
- [x] Changelog
- [ ] ~Documentation~ Does not contain new features
- [x] Tests
