### PR TITLE
Fix/range control.relative value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## RangeControl
+- `RangeControl.Value` and `RangeControl2D.Value` are not longer clamped to the `Range` of the control. This fixes issues where the `Value` was incorrectly modified when the range and value were both data bound. The user behaviors `LinearRangeBehavior` and `CircularRangeBehavior` will both however clamp to the range -- the user cannot select outside the range.
+
 ## Observables and bindings
 - Fixed an issue where missing data was propagated as null. This will affect Observable's that contain zero data, and may have resulted in some bindings showing old/incorrect data.
 

--- a/Source/Fuse.Animations/Attract.uno
+++ b/Source/Fuse.Animations/Attract.uno
@@ -96,12 +96,19 @@ namespace Fuse.Animations
 			void OnValueUpdate3(float3 value) { OnValueUpdate(value); }
 			void OnValueUpdate2(float2 value) { OnValueUpdate(value); }
 			void OnValueUpdate1(float value) { OnValueUpdate(value); }
+
+			//these must be filtered out since they'll permanently break the simulation
+			bool BadValue( float4 value ) 
+			{
+				var q = value.X + value.Y + value.Z + value.W;
+				return float.IsInfinity(q) || float.IsNaN(q);
+			}
 			
 			protected override void OnNewData( IExpression source, object oValue )
 			{
 				var value = float4(0);
 				int size = 0;
-				if (!Marshal.TryToZeroFloat4(oValue, out value, out size))
+				if (!Marshal.TryToZeroFloat4(oValue, out value, out size) || BadValue(value))
 				{
 					//invalid values can simply discard the simulation (forcing a new one to be created when
 					//a good value arrives)

--- a/Source/Fuse.Controls.Primitives/RangeControls/CircularRangeBehavior.uno
+++ b/Source/Fuse.Controls.Primitives/RangeControls/CircularRangeBehavior.uno
@@ -291,7 +291,10 @@ namespace Fuse.Gestures
 			if (step.Y > _zeroTolerance)
 				xRad = Math.Round(xRad/step.Y) * step.Y;
 			
-			ControlRelativeValue = new double2(rel,xRad);
+			//clamp as user can't select outside acceptable range
+			ControlRelativeValue = new double2(
+				Math.Clamp(rel,0,1),
+				Math.Clamp(xRad,0,1));
 		}
 		
 		double CurrentRadius

--- a/Source/Fuse.Controls.Primitives/RangeControls/LinearRangeBehavior.uno
+++ b/Source/Fuse.Controls.Primitives/RangeControls/LinearRangeBehavior.uno
@@ -149,7 +149,7 @@ namespace Fuse.Gestures
 			var step = Control.RelativeUserStep;
 			var r = PositionToValue(pos);
 			var q = step > 0 ? Math.Round(r/step) * step : r;
-			Control.RelativeValue = q;
+			Control.RelativeValue = Math.Clamp(q,0,1);
 		}
 
 		double PositionToValue(float2 pos)

--- a/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
+++ b/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
@@ -45,6 +45,8 @@ namespace Fuse.Controls
 		/** Minimum value of the RangeControl. Defaults to 0
 
 			This is the left/top value of the RangeControl and may be a value larger than Maximum.
+			
+			@see Range
 		*/
 		public double Minimum
 		{
@@ -64,6 +66,8 @@ namespace Fuse.Controls
 			Maximum value of the RangeControl. Defaults to 100 
 		
 			This is the bottom/right value of the RangeControl and may be a value smaller than Minimum.
+			
+			@see Range
 		*/
 		public double Maximum
 		{
@@ -82,6 +86,10 @@ namespace Fuse.Controls
 			The range of values covered by the control.
 			
 			This maps to `Minimum, Maximum`.
+			
+			This range is not enforced by the `RangeControl`, the actual `Value` may be programmatically set outside the desired range. This is required to support bound values correctly where the order of  setting `Range` and `Value` is undefined. 
+			
+			The standard range behaviours @LinearRangeBehavior and @CircularRangeBehavior will clamp the user's selection to the range.
 		*/
 		public float2 Range
 		{
@@ -93,15 +101,6 @@ namespace Fuse.Controls
 			}
 		}
 
-		double EffectiveMinimum
-		{
-			get { return Minimum < Maximum ? Minimum : Maximum; }
-		}
-		double EffectiveMaximum
-		{
-			get { return Minimum < Maximum ? Maximum : Minimum; }
-		}
-		
 		double _value = 0.0;
 		[UXOriginSetter("SetValue")]
 		/**
@@ -131,12 +130,10 @@ namespace Fuse.Controls
 
 		public void SetValue(double value, IPropertyListener origin)
 		{
-			var v = ClampToRange(value);
-
-			if (v != _value)
+			if (value != _value)
 			{
-				_value = v;
-				OnValueChanged(v, origin);
+				_value = value;
+				OnValueChanged(value, origin);
 			}
 
 			var rv = RangeView;
@@ -175,11 +172,6 @@ namespace Fuse.Controls
 			set { UserStep = StepValueFromRelative(value); }
 		}
 
-		double ClampToRange(double v)
-		{
-			return Math.Min(Math.Max(EffectiveMinimum, v), EffectiveMaximum);
-		}
-
 		public event ValueChangedHandler<double> ValueChanged;
 		
 		public event ValueChangedHandler<double> ProgressChanged
@@ -190,9 +182,6 @@ namespace Fuse.Controls
 
 		void OnRangeChanged()
 		{
-			// Makes sure value is still clamped to range, and raises ValueChanged if this
-			// leads to a change
-			SetValue(Value, null);
 			OnProgressChanged();
 		}
 

--- a/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
+++ b/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
@@ -231,8 +231,9 @@ namespace Fuse.Controls
 		{
 			var range = Maximum - Minimum;
 			var q = (value - Minimum) / (Maximum - Minimum);
-			//if (range == 0 || double.IsInfinity(q))
-			//	return 0;
+			//this would most likely happen if the range and values are data bound, thus likely a temporary condition
+			if (range == 0 || double.IsInfinity(q))
+				return 0;
 			return q;
 		}
 		

--- a/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
+++ b/Source/Fuse.Controls.Primitives/RangeControls/RangeControl.uno
@@ -229,7 +229,11 @@ namespace Fuse.Controls
 		
 		internal double ValueToRelative(double value)
 		{
-			return (value - Minimum) / (Maximum - Minimum);
+			var range = Maximum - Minimum;
+			var q = (value - Minimum) / (Maximum - Minimum);
+			//if (range == 0 || double.IsInfinity(q))
+			//	return 0;
+			return q;
 		}
 		
 		internal double StepValueToRelative( double value )

--- a/Source/Fuse.Controls.Primitives/RangeControls/RangeControl2D.uno
+++ b/Source/Fuse.Controls.Primitives/RangeControls/RangeControl2D.uno
@@ -52,12 +52,10 @@ namespace Fuse.Controls
 
 		public void SetValue(float2 value, IPropertyListener origin)
 		{
-			var v = ClampToRange(value);
-
-			if (v != _value)
+			if (value != _value)
 			{
-				_value = v;
-				OnValueChanged(v, origin);
+				_value = value;
+				OnValueChanged(value, origin);
 			}
 		}
 
@@ -84,20 +82,12 @@ namespace Fuse.Controls
 			set { UserStep = ValueFromRelative(value); }
 		}
 
-		float2 ClampToRange(float2 v)
-		{
-			return Math.Min(Math.Max(Minimum, v), Maximum);
-		}
-
 		public event ValueChangedHandler<float2> ValueChanged;
 		public event ValueChangedHandler<float> ValueXChanged;
 		public event ValueChangedHandler<float> ValueYChanged;
 		
 		void OnRangeChanged()
 		{
-			// Makes sure value is still clamped to range, and raises ValueChanged if this
-			// leads to a change
-			SetValue(Value, null);
 		}
 
 		void OnValueChanged(float2 value, IPropertyListener origin)

--- a/Source/Fuse.Controls.Primitives/Tests/RangeControl.Test.uno
+++ b/Source/Fuse.Controls.Primitives/Tests/RangeControl.Test.uno
@@ -99,5 +99,23 @@ namespace Fuse.Gestures.Test
 			}
 		}
 		
+		[Test]
+		//values can be outside range, but user can't select them
+		public void RangeValue()
+		{
+			var p = new UX.RangeControl.RangeValue();
+			using (var root = TestRootPanel.CreateWithChild(p,int2(300)))
+			{
+				Assert.AreEqual(150, p.rc.Value);
+				
+				root.PointerSwipe( float2(150,150), float2(250,150) );
+				Assert.AreEqual(100, p.rc.Value);
+				
+				p.rc.Value = -50;
+				root.PumpDeferred();
+				Assert.AreEqual(-50, p.rc.Value);
+			}
+		}
+		
 	}
 }

--- a/Source/Fuse.Controls.Primitives/Tests/RangeControl2D.Test.uno
+++ b/Source/Fuse.Controls.Primitives/Tests/RangeControl2D.Test.uno
@@ -1,0 +1,38 @@
+using Uno;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Gestures.Test
+{
+	public class RangeControl2DTest : TestBase
+	{
+		[Test]
+		//a left half-circle control, basic check that all properties work together
+		public void CircularBasic()
+		{	
+			var p = new UX.RangeControl2D.CircularBasic();
+			using (var root = TestRootPanel.CreateWithChild(p, int2(100,100)))
+			{
+				Assert.AreEqual(225, p.crb.DegreesValue);
+				
+				var a = Math.DegreesToRadians(135.0f);
+				var r = 40;
+				root.PointerPress( float2(Math.Cos(a),Math.Sin(a))*r + float2(50,50) );
+				root.PointerRelease();
+				Assert.AreEqual(float2(30,160), p.Value);
+				
+				//a value outside the range to test clamping.
+				a = Math.DegreesToRadians(45.0f);
+				r = 15;
+				root.PointerPress( float2(Math.Cos(a),Math.Sin(a))*r + float2(50,50) );
+				root.PointerRelease();
+				Assert.AreEqual(100, p.Value.Y);
+				//there's no guarantee at the moment of clamping direction (could be max or min)
+				//TODO: https://github.com/fusetools/fuselibs-public/issues/798
+				Assert.IsTrue( Math.Abs(p.Value.X-0) < 1e-4 ||
+					Math.Abs(p.Value.X-120) < 1e-4);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Controls.Primitives/Tests/UX/RangeControl.RangeValue.ux
+++ b/Source/Fuse.Controls.Primitives/Tests/UX/RangeControl.RangeValue.ux
@@ -1,0 +1,5 @@
+<Panel ux:Class="UX.RangeControl.RangeValue" Padding="100">
+	<RangeControl Minimum="0" Maximum="100" Value="150" ux:Name="rc" HitTestMode="LocalBounds">
+		<LinearRangeBehavior ux:Name="LRB"/>
+	</RangeControl>
+</Panel>

--- a/Source/Fuse.Controls.Primitives/Tests/UX/RangeControl2D.CircularBasic.ux
+++ b/Source/Fuse.Controls.Primitives/Tests/UX/RangeControl2D.CircularBasic.ux
@@ -1,0 +1,5 @@
+<RangeControl2D ux:Class="UX.RangeControl2D.CircularBasic" Minimum="0,100" Maximum="120,200" Value="90,150" ux:Name="rc" HitTestMode="LocalBounds">
+	<CircularRangeBehavior ux:Name="crb" 
+		StartAngleDegrees="90" EndAngleDegrees="270"
+		MinimumRadius="0.5" MaximumRadius="1"/>
+</RangeControl2D>


### PR DESCRIPTION
Corrects some behavior with using RangeControl and bound values. Fixes a related numeric stability issue in `attract`.

RangeControl no longer clamps the Value, only the behaviours do.

Fixes https://github.com/fusetools/fuselibs-public/issues/673

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
