### PR TITLE
Fixes a NodeGroup ordering issue, affects Each/With ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+## With/NodeGroup/Each
+- Fixed a defect in `NodeGroup` that would cause some nodes to be inserted in the wrong order, in particular if using combinations of `Each`, `With`, triggers, and `Defer`.
 
 # 1.4
 

--- a/Source/Fuse.Nodes/Node.uno
+++ b/Source/Fuse.Nodes/Node.uno
@@ -127,6 +127,10 @@ namespace Fuse
 		/** 
 			Allows a way for things that insert nodes (like `Each`) to determine the end of the
 			group of nodes further inserted by that node (such as a combination with `Match` or `Deferred`)
+			
+			If this node forms a group it should perform a recursive call to `GetLastNodeInGroup` on the final Node in its local group.  Higher level calls are expected to get the final node in the full chain, not just the local node.
+			
+			Node's that don't form a group, or where the group terminates, should return `this`.
 		*/
 		internal virtual Node GetLastNodeInGroup()
 		{

--- a/Source/Fuse.Nodes/NodeGroup.uno
+++ b/Source/Fuse.Nodes/NodeGroup.uno
@@ -232,6 +232,13 @@ namespace Fuse
 			}
 			_addedNodes = null;
 		}
+		
+		internal override Node GetLastNodeInGroup()
+		{
+			if (_addedNodes == null || _addedNodes.Length == 0)
+				return this;
+			return _addedNodes[_addedNodes.Length-1].GetLastNodeInGroup();
+		}
 	}
 
 	/**

--- a/Source/Fuse.Nodes/Tests/NodeGroup.Test.uno
+++ b/Source/Fuse.Nodes/Tests/NodeGroup.Test.uno
@@ -75,5 +75,16 @@ namespace Fuse.Controls.Test
 				Assert.AreEqual( "😀", p.T.Value );
 			}
 		}
+		
+		[Test]
+		public void EachOrder()
+		{
+			var p = new UX.NodeGroup.EachOrder();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("1a,1b,1c,2a,2b,2c,3a,3b,3c", GetText(p));
+			}
+		}
 	}
 }

--- a/Source/Fuse.Nodes/Tests/UX/NodeGroup.EachOrder.ux
+++ b/Source/Fuse.Nodes/Tests/UX/NodeGroup.EachOrder.ux
@@ -1,0 +1,12 @@
+<Panel ux:Class="UX.NodeGroup.EachOrder">
+	<JavaScript>
+		exports.items = [1,2,3]
+	</JavaScript>
+	<Each Items="{items}">
+		<NodeGroup IsActive="true">
+			<Text Value="{}a"/>
+			<Text Value="{}b"/>
+			<Text Value="{}c"/>
+		</NodeGroup>
+	</Each>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/With.Basic.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/With.Basic.ux
@@ -1,0 +1,12 @@
+<Panel ux:Class="UX.With.Basic">
+	<JavaScript>
+		exports.data = {
+			one: "Un",
+			two: "Deux",
+		}
+	</JavaScript>
+	<With Data="{data}">
+		<Text Value="{one}"/>
+		<Text Value="{two}"/>
+	</With>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/With.EachOrder.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/With.EachOrder.ux
@@ -1,0 +1,26 @@
+<Panel ux:Class="UX.With.EachOrder">
+    <JavaScript>
+		exports.items = [1,2,3,4]
+    </JavaScript>
+	<Each Items="{items}">
+		<With Data="{}">
+			<Text Value="{}" />
+		</With>
+	</Each>
+	
+	<!-- invovles a few other items that were involved in the original bug -->
+	<Panel ux:Name="s">
+		<Each Items="{items}">
+			<With Data="{}">
+				<WhileFalse>
+					<Text Value="{}" />
+				</WhileFalse>
+			</With>
+			<With Data="{}">
+				<Instance>
+					<Text Value="-{}" />
+				</Instance>
+			</With>
+		</Each>
+	</Panel>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/With.Observable.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/With.Observable.ux
@@ -1,0 +1,22 @@
+<Panel ux:Class="UX.With.Observable">
+	<JavaScript>
+		var Observable = require("FuseJS/Observable")
+		
+		exports.data = Observable({
+			one: "Un",
+			two: "Deux",
+		})
+		
+		exports.next = function() {
+			exports.data.value = {
+				one: "i",
+				two: "ii",
+			}
+		}
+	</JavaScript>
+	<With Data="{data}">
+		<Text Value="{one}"/>
+		<Text Value="{two}"/>
+	</With>
+	<FuseTest.Invoke Handler="{next}" ux:Name="callNext"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/With.Order.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/With.Order.ux
@@ -1,0 +1,12 @@
+<Panel ux:Class="UX.With.Order">
+	<JavaScript>
+		exports.one = "A"
+		exports.two = "B"
+	</JavaScript>
+	<With Data="{one}">
+		<Text Value="{}"/>
+	</With>
+	<With Data="{two}">
+		<Text Value="{}"/>
+	</With>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/With.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/With.Test.uno
@@ -1,0 +1,49 @@
+using Uno;
+using Uno.Testing;
+
+using Fuse;
+
+using FuseTest;
+
+namespace Fuse.Test
+{
+	public class WithTest : TestBase
+	{
+		[Test]
+		public void Basic()
+		{
+			var p = new UX.With.Basic();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual( "Un,Deux", GetText(p));
+			}
+		}
+		
+		[Test]
+		public void Observable()
+		{
+			var p = new UX.With.Observable();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("Un,Deux", GetText(p));
+				
+				p.callNext.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual("i,ii", GetText(p));
+			}
+		}
+		
+		[Test]
+		public void Order()
+		{
+			var p = new UX.With.Order();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("A,B", GetText(p));
+			}
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Bindings/Tests/With.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/With.Test.uno
@@ -45,5 +45,18 @@ namespace Fuse.Test
 				Assert.AreEqual("A,B", GetText(p));
 			}
 		}
+		
+		[Test]
+		//https://github.com/fusetools/fuselibs-public/issues/803
+		public void EachOrder()
+		{
+			var p = new UX.With.EachOrder();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("1,2,3,4", GetText(p));
+				Assert.AreEqual("1,-1,2,-2,3,-3,4,-4", GetText(p.s));
+			}
+		}
 	}
 }

--- a/Source/Fuse.Triggers/Deferred.uno
+++ b/Source/Fuse.Triggers/Deferred.uno
@@ -200,7 +200,7 @@ namespace Fuse
 		{
 			if (_added == null || _added.Count == 0)
 				return this;
-			return _added[_added.Count-1];
+			return _added[_added.Count-1].GetLastNodeInGroup();
 		}
 	}
 }


### PR DESCRIPTION
It's only accidental that the ordering worked previously -- the code just didn't account for ordering, thus it was undefined previously.
fixes https://github.com/fusetools/fuselibs-public/issues/803

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [x] Tests
