### PR TITLE
Pre-models cleanups

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/FuseJS/Builtins.uno
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/Builtins.uno
@@ -75,10 +75,10 @@ namespace Fuse.Reactive.FuseJS
 
 		internal bool UpdateModules(Fuse.Scripting.Context context)
 		{
-			var activity = false;
 			if(_timer != null)
-				activity = _timer.UpdateModule(context) || activity;
-			return activity;
+				return _timer.UpdateModule(context);
+
+			return false;
 		}
 	}
 }

--- a/Source/Fuse.Scripting.JavaScript/ObservableProperty.uno
+++ b/Source/Fuse.Scripting.JavaScript/ObservableProperty.uno
@@ -144,6 +144,8 @@ namespace Fuse.Scripting.JavaScript
 
 		void PushValue(Scripting.Context context, object val)
 		{
+			if (_subscription == null) return;
+
 			if (val != null)
 			{
 				_subscription.SetExclusive(context, val);


### PR DESCRIPTION
Here's a couple of small cleanups from the models-branch that are independently a good idea.

This PR contains:
- [ ] Changelog - *Not sure; the `_subscription == null`-case is the only one that might be worth logging, but I'm not sure it really can trigger*
- [ ] Tests - *Same thing as above, unsure if the functional change can actually trigger, or how to do so*
