### PR TITLE
Travis: install pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - XCODE_XCCONFIG_FILE=$TRAVIS_BUILD_DIR/.travis.xcconfig
 
 install:
+  - sudo easy_install pip
   - pip install six
   - wget https://az664292.vo.msecnd.net/files/9Wz3GRnbPRghC2nt-Mono.zip -O mono.zip &&
     unzip -d mono mono.zip &&


### PR DESCRIPTION
Looks like pip is not part of xcode command line tools anymore, could not find any details in apples changelogs. But on my fresh high sierra install I was also missing pip

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
