### PR TITLE
Seal some expressions

### DIFF
--- a/Source/Fuse.Reactive.Expressions/MathFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/MathFunctions.uno
@@ -161,7 +161,7 @@ namespace Fuse.Reactive
 			_name = name;
 			_op = op;
 		}
-		protected override bool Compute(object operand, out object result)
+		protected sealed override bool Compute(object operand, out object result)
 		{
 			result = null;
 			float4 v;
@@ -207,7 +207,7 @@ namespace Fuse.Reactive
 			_name = name;
 			_op = op;
 		}
-		protected override bool Compute(object left, object right, out object result)
+		protected sealed override bool Compute(object left, object right, out object result)
 		{
 			result = null;
 			

--- a/Source/Fuse.Reactive.Expressions/NameValuePair.uno
+++ b/Source/Fuse.Reactive.Expressions/NameValuePair.uno
@@ -3,7 +3,7 @@ using Uno.UX;
 namespace Fuse.Reactive
 {
 	/** Creates a `Fuse.NameValuePair` from a name and a value. */
-	public class NameValuePair: BinaryOperator
+	public sealed class NameValuePair: BinaryOperator
 	{
 		[UXConstructor]
 		public NameValuePair([UXParameter("Name")] Expression name, [UXParameter("Value")] Expression value) : base(name, value)


### PR DESCRIPTION
We don't want to allow users to override these, so let's mark them as sealed.