### PR TITLE
Add warnings on invalid values to operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Expression Functions
 - Added `nonNull` for special evaluation handling for temporary null values. This may be useful in migrating code that is now producing many incompatbile argument warnings.
 - Changed operators / functions to report warnings if they are provided with invalid arguments. This should help locate errors in code that were previously silent and just didn't evaluate, or evaluated wrong.  Consider using the `??` operator, and the `isNull`, `isDefined` and `nonNull` functions to deal with non-data scenarios.
+- Removed `protected` from `BinaryOperator.OnNewOperands`. This was intended to be `internal` as there is no correct way to overload it. If you happened to use it we can provide a different base-class to use for you.
 
 ## Conversions
 - Added `float()` expression to force conversion to float values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Expression Functions
+- Added `nonNull` for special evaluation handling for temporary null values. This may be useful in migrating code that is now producing many incompatbile argument warnings.
+- Changed operators / functions to report warnings if they are provided with invalid arguments. This should help locate errors in code that were previously silent and just didn't evaluate, or evaluated wrong.  Consider using the `??` operator, and the `isNull`, `isDefined` and `nonNull` functions to deal with non-data scenarios.
+
 ## Conversions
 - Added `float()` expression to force conversion to float values
 - Added `string()` expression to force conversion to string values

--- a/Source/Fuse.Common/Tests/FuseTest/TestBase.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/TestBase.uno
@@ -62,7 +62,7 @@ namespace FuseTest
 			Diagnostics.DiagnosticReported -= OnDiagnostic;
 
 			if (_diagnosticsQueue.Count > 0)
-				throw new Exception("Unchecked, queued Diagnostics!");
+				throw new Exception("Unchecked, queued Diagnostics! Count="  + _diagnosticsQueue.Count);
 		}
 	}
 

--- a/Source/Fuse.Motion/DelayFunction.uno
+++ b/Source/Fuse.Motion/DelayFunction.uno
@@ -5,14 +5,17 @@ using Fuse.Reactive;
 namespace Fuse.Motion
 {
 	[UXFunction("delay")]
+	// TODO: Should not derive from BinaryOperator
+	// https://github.com/fusetools/fuselibs-public/issues/829
 	public class DelayFunction: BinaryOperator
 	{
 		[UXConstructor]
 		public DelayFunction([UXParameter("Value")] Expression value, [UXParameter("Delay")] Expression delay): base(value, delay) {}
 
-		protected override void OnNewOperands(IListener listener, object value, object delay)
+		internal override bool OnNewOperands(IListener listener, object value, object delay)
 		{
 			Timer.Wait(Marshal.ToDouble(delay), new SetClosure(this, listener, value).Run);
+			return true;
 		}
 
 		class SetClosure

--- a/Source/Fuse.Reactive.Expressions/QuaternaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/QuaternaryOperator.uno
@@ -4,6 +4,9 @@ using Uno.Collections;
 
 namespace Fuse.Reactive
 {
+	/* This class is part of a set of classes: UnaryOperator, BinaryOperator, TernaryOperator, QuaternaryOperator.
+		If you modify one you'll likely need to modify all four. */
+		
 	/** Optimized base class for reactive functions/operators that take a four arguments/operands. */
 	public abstract class QuaternaryOperator: Expression
 	{
@@ -96,6 +99,15 @@ namespace Fuse.Reactive
 				UpdateOperands();
 			}
 
+			void ClearData()
+			{
+				if (_hasData)
+				{
+					_hasData = false;
+					_listener.OnLostData(_qo);
+				}
+			}
+			
 			void UpdateOperands()
 			{
 				ClearDiagnostic();
@@ -110,16 +122,17 @@ namespace Fuse.Reactive
 							_hasData = true;
 							_listener.OnNewData(_qo, result);
 						}
-						else if (_hasData)
+						else
 						{
+							Fuse.Diagnostics.UserWarning( "Failed to compute value for (" +
+								_first + ", " + _second + ", " + _third + ", " + _fourth, _qo );
 							_hasData = false;
-							_listener.OnLostData(_qo);
+							ClearData();
 						}
 					}
-					else if (_hasData)
+					else
 					{
-						_hasData = false;
-						_listener.OnLostData(_qo);
+						ClearData();
 					}
 				}
 				catch (MarshalException me)

--- a/Source/Fuse.Reactive.Expressions/TernaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/TernaryOperator.uno
@@ -89,6 +89,15 @@ namespace Fuse.Reactive
 				UpdateOperands();
 			}
 			
+			void ClearData()
+			{
+				if (_hasData)
+				{
+					_hasData = false;
+					_listener.OnLostData(_to);
+				}
+			}
+			
 			void UpdateOperands()
 			{
 				ClearDiagnostic();
@@ -104,16 +113,16 @@ namespace Fuse.Reactive
 							_hasData = true;
 							_listener.OnNewData(_to, result);
 						} 
-						else if (_hasData)
+						else
 						{
-							_hasData = false;
-							_listener.OnLostData(_to);
+							Fuse.Diagnostics.UserWarning( "Failed to compute value for (" +
+								_first +", " + _second + ", " + _third, _to );
+							ClearData();
 						}
 					}
 					else if (_hasData)
 					{
-						_hasData = false;
-						_listener.OnLostData(_to);
+						ClearData();
 					}
 				}
 				catch (MarshalException me)

--- a/Source/Fuse.Reactive.Expressions/TernaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/TernaryOperator.uno
@@ -4,6 +4,9 @@ using Uno.Collections;
 
 namespace Fuse.Reactive
 {
+	/* This class is part of a set of classes: UnaryOperator, BinaryOperator, TernaryOperator, QuaternaryOperator.
+		If you modify one you'll likely need to modify all four. */
+		
 	/** Optimized base class for reactive functions/operators that take a three arguments/operands. */
 	public abstract class TernaryOperator: Expression
 	{
@@ -120,7 +123,7 @@ namespace Fuse.Reactive
 							ClearData();
 						}
 					}
-					else if (_hasData)
+					else
 					{
 						ClearData();
 					}

--- a/Source/Fuse.Reactive.Expressions/Tests/MathFunctions.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/MathFunctions.Test.uno
@@ -207,21 +207,21 @@ namespace Fuse.Reactive.Test
 			var p = new UX.MathFunctions.Clamp();
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
-				p.a.Float = 0.5f;
-				p.mn.Float = 10;
-				p.mx.Float = 20;
+				p.a.Value = 0.5f;
+				p.mn.Value = 10;
+				p.mx.Value = 20;
 				root.PumpDeferred();
 				Assert.AreEqual(10, p.clamp.Float);
 				
-				p.a.Float2 = float2(0,15);
+				p.a.Value = float2(0,15);
 				root.PumpDeferred();
 				Assert.AreEqual(float2(10,15), p.clamp.Float2);
 				
-				p.a.Float3 = float3(21,0,8);
+				p.a.Value = float3(21,0,8);
 				root.PumpDeferred();
 				Assert.AreEqual(float3(20,10,10), p.clamp.Float3);
 				
-				p.a.Float4 = float4(1,0,50,15);
+				p.a.Value = float4(1,0,50,15);
 				root.PumpDeferred();
 				Assert.AreEqual(float4(10,10,20,15), p.clamp.Float4);
 			}

--- a/Source/Fuse.Reactive.Expressions/Tests/TernaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/TernaryOperator.Test.uno
@@ -51,6 +51,31 @@ namespace Fuse.Reactive.Test
 				Assert.AreEqual( "xyz", p.d.ObjectValue );
 			}
 		}
+		
+		[Test]
+		public void Error()
+		{
+			var p = new UX.TernaryOperator.Error();
+			using (var dg = new RecordDiagnosticGuard())
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.IsFalse( p.iq.BoolValue );
+				
+				p.c.Value = 'a';
+				root.PumpDeferred();
+				
+				var d = dg.DequeueAll();
+				Assert.IsTrue( d.Count == 1 || d.Count == 2 ); //TODO: there is a double OnNewData somewhere, not relevant to this feature though!
+				Assert.Contains( "Failed to compute", d[0].Message );
+
+				Assert.IsFalse( p.iq.BoolValue );
+				
+				p.c.Value = 0.5;
+				root.PumpDeferred();
+				Assert.IsTrue( p.iq.BoolValue );
+				Assert.AreEqual( 1.5f, p.q.Value );
+			}
+		}
 	}
 	
 	[UXFunction("_terJoin")]

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/BinaryOperator.Error.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/BinaryOperator.Error.ux
@@ -1,0 +1,7 @@
+<Panel ux:Class="UX.BinaryOperator.Error">
+	<Let ux:Name="a" Value="{= 1 }"/>
+	<Let ux:Name="b"/>
+	
+	<FuseTest.DudElement StringValue="{= _binJoin({a},{b}) }" ux:Name="q"/>
+	<FuseTest.DudElement BoolValue="isDefined(_binJoin({a},{b}))" ux:Name="iq"/>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/MathFunctions.Clamp.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/MathFunctions.Clamp.ux
@@ -1,6 +1,6 @@
 <Panel ux:Class="UX.MathFunctions.Clamp">
-	<FuseTest.Value ux:Name="a"/>
-	<FuseTest.Value ux:Name="mn"/>
-	<FuseTest.Value ux:Name="mx"/>
-	<FuseTest.Value Float4="clamp({Property a.Object},{Property mn.Object},{Property mx.Object})" ux:Name="clamp"/>
+	<Let ux:Name="a"/>
+	<Let ux:Name="mn"/>
+	<Let ux:Name="mx"/>
+	<FuseTest.Value Float4="clamp({a},{mn},{mx})" ux:Name="clamp"/>
 </Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/MathFunctions.Lerp.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/MathFunctions.Lerp.ux
@@ -2,5 +2,5 @@
 	<FuseTest.Value ux:Name="a"/>
 	<FuseTest.Value ux:Name="b"/>
 	<FuseTest.Value ux:Name="t"/>
-	<FuseTest.Value Float4="lerp({Property a.Object},{Property b.Object},{Property t.Object})" ux:Name="lerp"/>
+	<FuseTest.Value Float4="lerp(nonNull({Property a.Object}),nonNull({Property b.Object}),nonNull({Property t.Object}))" ux:Name="lerp"/>
 </Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/QuaternaryOperator.Error.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/QuaternaryOperator.Error.ux
@@ -1,0 +1,9 @@
+<Panel ux:Class="UX.QuaternaryOperator.Error">
+	<Let ux:Name="a" Value="{= 1 }"/>
+	<Let ux:Name="b" Value="{= 2 }"/>
+	<Let ux:Name="c" Value="{= 3 }"/>
+	<Let ux:Name="d"/>
+	
+	<FuseTest.DudElement StringValue="{= _quaJoin({a},{b},{c},{d}) }" ux:Name="q"/>
+	<FuseTest.DudElement BoolValue="isDefined(_quaJoin({a},{b},{c},{d}))" ux:Name="iq"/>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/TernaryOperator.Error.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/TernaryOperator.Error.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.TernaryOperator.Error">
+	<Let ux:Name="a" Value="{= 1 }"/>
+	<Let ux:Name="b" Value="{= 2 }"/>
+	<Let ux:Name="c"/>
+	
+	<FuseTest.DudElement Value="lerp({a},{b},{c})" ux:Name="q"/>
+	<FuseTest.DudElement BoolValue="isDefined(lerp({a},{b},{c}))" ux:Name="iq"/>
+</Panel>


### PR DESCRIPTION
This adds more warning messages to operators.

I'm getting unhappy with a lot of the redundant code and will likely refactor it soon.

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [x] Tests
