### PR TITLE
Fuse.Reactive.Expressions: fixup ToUpper / ToLower tests

### DIFF
--- a/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
@@ -12,10 +12,16 @@ namespace Fuse.Reactive.Expressions.Test
 		public void ToUpper()
 		{
 			var p = new UX.StringFunctions.ToUpper();
+			using (var dg = new RecordDiagnosticGuard())
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
 				Assert.AreEqual(null, p.NullInput.String);
 				Assert.AreEqual(null, p.NullResult.String);
+
+				var diagnostics = dg.DequeueAll();
+				Assert.AreEqual(2, diagnostics.Count);
+				Assert.Contains("Failed to compute value", diagnostics[0].Message);
+				Assert.Contains("Failed to compute value", diagnostics[1].Message);
 			}
 		}
 
@@ -23,10 +29,16 @@ namespace Fuse.Reactive.Expressions.Test
 		public void ToLower()
 		{
 			var p = new UX.StringFunctions.ToLower();
+			using (var dg = new RecordDiagnosticGuard())
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
 				Assert.AreEqual(null, p.NullInput.String);
 				Assert.AreEqual(null, p.NullResult.String);
+
+				var diagnostics = dg.DequeueAll();
+				Assert.AreEqual(2, diagnostics.Count);
+				Assert.Contains("Failed to compute value", diagnostics[0].Message);
+				Assert.Contains("Failed to compute value", diagnostics[1].Message);
 			}
 		}
 	}


### PR DESCRIPTION
This broke when merging release-1.4 into master, due to divergent changes