### PR TITLE
use nameof to keep strings consistent

### DIFF
--- a/Source/Fuse.Animations/Attractor.uno
+++ b/Source/Fuse.Animations/Attractor.uno
@@ -35,7 +35,9 @@ namespace Fuse.Animations
 		[UXConstructor]
 		public Attractor([UXParameter("Target")] Property<T> target)
 		{
-			if (target == null) throw new ArgumentNullException("target");
+			if (target == null)
+				throw new ArgumentNullException(nameof(target));
+
 			Target = target;
 		}
 

--- a/Source/Fuse.Animations/Change.uno
+++ b/Source/Fuse.Animations/Change.uno
@@ -62,8 +62,9 @@ namespace Fuse.Animations
 		[UXConstructor]
 		public Change([UXParameter("Target")] Property<T> target)
 		{
-			if (target == null) 
-				throw new ArgumentNullException("target");
+			if (target == null)
+				throw new ArgumentNullException(nameof(target));
+
 			Target = target;
 
 			if (IsContinuous)

--- a/Source/Fuse.Common/Internal/RootableList.uno
+++ b/Source/Fuse.Common/Internal/RootableList.uno
@@ -21,9 +21,9 @@ namespace Uno.Collections
 				throw new Exception( "Supports only one subscription" );
 				
 			if (added == null)
-				throw new ArgumentNullException("added");
+				throw new ArgumentNullException(nameof(added));
 			if (removed == null)
-				throw new ArgumentNullException("removed");
+				throw new ArgumentNullException(nameof(removed));
 
 			_added = added;
 			_removed = removed;

--- a/Source/Fuse.Elements/Resources/FileImageSource.uno
+++ b/Source/Fuse.Elements/Resources/FileImageSource.uno
@@ -151,8 +151,8 @@ namespace Fuse.Resources
 
 		public FileImageSourceImpl(FileSource file)
 		{
-			if(file == null)
-				throw new ArgumentNullException("bundleFile");
+			if (file == null)
+				throw new ArgumentNullException(nameof(file));
 
 			_file = file;
 			_file.DataChanged += OnDataChanged;

--- a/Source/Fuse.FileSystem/FileSystemModule.uno
+++ b/Source/Fuse.FileSystem/FileSystemModule.uno
@@ -903,7 +903,7 @@ namespace Fuse.FileSystem
 			where T : class
 		{
 			if (args == null)
-				throw new ArgumentNullException("args");
+				throw new ArgumentNullException(nameof(args));
 
 			var val = args.Length > index ? args[index] as T : null;
 			if (val == null)
@@ -917,7 +917,7 @@ namespace Fuse.FileSystem
 		private static string GetPathFromArgs(object[] args)
 		{
 			if (args == null)
-				throw new ArgumentNullException("args");
+				throw new ArgumentNullException(nameof(args));
 
 			var filename = args.Length > 0 ? args[0] as string : null;
 			if (filename == null)

--- a/Source/Fuse.Navigation/PageBinding.uno
+++ b/Source/Fuse.Navigation/PageBinding.uno
@@ -192,7 +192,10 @@ namespace Fuse.Navigation
 		public PageResourceBinding([UXParameter("Target")] Property<T> target, [UXParameter("Key")] string key)
 		{
 			Fuse.Diagnostics.Deprecated("PageResourceBinding has been deprecated. Use DataBinding instead", this);
-			if (target == null) throw new ArgumentNullException("target");
+
+			if (target == null)
+				throw new ArgumentNullException(nameof(target));
+
 			Target = target;
 			Key = key;
 		}

--- a/Source/Fuse.Nodes/Event.uno
+++ b/Source/Fuse.Nodes/Event.uno
@@ -167,7 +167,7 @@ namespace Fuse
 		public VisualEventArgs(Visual visual)
 		{
 			if (visual == null)
-				throw new ArgumentNullException("visual");
+				throw new ArgumentNullException(nameof(visual));
 
 			Visual = visual;
 		}

--- a/Source/Fuse.Scripting.JavaScript/FuseJS/Timer.uno
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/Timer.uno
@@ -153,8 +153,11 @@ namespace Fuse.Reactive.FuseJS
 
 			public CallbackClosure(Context context, Scripting.Function func, object[] args)
 			{
-				if(func == null) throw new Uno.ArgumentNullException("func");
-				if(args == null) throw new Uno.ArgumentNullException("args");
+				if (func == null)
+					throw new Uno.ArgumentNullException(nameof(func));
+
+				if (args == null)
+					throw new Uno.ArgumentNullException(nameof(args));
 
 				_context = context;
 				_func = func;

--- a/Source/Fuse.Storage/ApplicationDir.uno
+++ b/Source/Fuse.Storage/ApplicationDir.uno
@@ -8,11 +8,11 @@ namespace Fuse.Storage
 	{
 		public static bool Write(string filename, string value)
 		{
-			if(filename == null)
-				throw new ArgumentNullException("filename");
+			if (filename == null)
+				throw new ArgumentNullException(nameof(filename));
 
-			if(value == null)
-				throw new ArgumentNullException("value");
+			if (value == null)
+				throw new ArgumentNullException(nameof(value));
 
 			var filepath = Path.Combine(Directory.GetUserDirectory(UserDirectory.Data), filename);
 			CreateFile(filepath);
@@ -29,8 +29,8 @@ namespace Fuse.Storage
 
 		public static bool TryRead(string filename, out string content)
 		{
-			if(filename == null)
-				throw new ArgumentNullException("filename");
+			if (filename == null)
+				throw new ArgumentNullException(nameof(filename));
 
 			var filepath = Path.Combine(Directory.GetUserDirectory(UserDirectory.Data), filename);
 			if (!File.Exists(filepath))
@@ -54,8 +54,8 @@ namespace Fuse.Storage
 
 		public static bool Delete(string filename)
 		{
-			if(filename == null)
-				throw new ArgumentNullException("filename");
+			if (filename == null)
+				throw new ArgumentNullException(nameof(filename));
 			
 			var filepath = Path.Combine(Directory.GetUserDirectory(UserDirectory.Data), filename);
 			if(!File.Exists(filepath)) return false;

--- a/Source/Fuse.Triggers/Actions/Set.uno
+++ b/Source/Fuse.Triggers/Actions/Set.uno
@@ -60,7 +60,8 @@ namespace Fuse.Triggers.Actions
 		public Set([UXParameter("Target")] Property<T> target)
 		{
 			if (target == null)
-				throw new ArgumentNullException("target");
+				throw new ArgumentNullException(nameof(target));
+
 			Target = target;
 		}
 		


### PR DESCRIPTION
Using nameof(foo) instead of "foo" will give us compilation-errors if we rename the variable but forget to update the exception. So let's use it to make sure things are consistent. At least one place was out of date already.

I just noticed that this was pretty inconsistent while reading some code.