### PR TITLE
Add missing jsc header files to unoproj file

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/Fuse.Scripting.JavaScript.unoproj
+++ b/Source/Fuse.Scripting.JavaScript/Fuse.Scripting.JavaScript.unoproj
@@ -57,6 +57,22 @@
     "Duktape/duk_config.h:File",
     "Duktape/duktape.c:File",
     "Duktape/duktape.h:File",
-    "Duktape/duktape_helpers.h:File"
+    "Duktape/duktape_helpers.h:File",
+
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSBase.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSContext.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSContextRef.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSExport.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSManagedValue.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSObjectRef.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSStringRef.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSStringRefCF.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSTypedArray.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSValue.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSValueRef.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JSVirtualMachine.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JavaScript.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/JavaScriptCore.h:File",
+    "JavaScriptCore/3rdparty/JavaScriptCore/WebKitAvailability.h:File"
   ]
 }


### PR DESCRIPTION
I had not included the jsc header files in the fuse.scripting.javascript unoproj, so when we merged manualtestapp failed to build

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
