### PR TITLE
Model: Attach to parent on property update

### DIFF
--- a/Source/Fuse.Models/FuseJS/Internal/Model.js
+++ b/Source/Fuse.Models/FuseJS/Internal/Model.js
@@ -300,6 +300,9 @@ function Model(initialState, stateInitializer)
 			var oldMeta = idToMeta.get(node.__fuse_id);
 			if (oldMeta instanceof Object) {
 				var thisIndex = oldMeta.parents.findIndex(function(x) { return x.meta == meta });
+				if (thisIndex == -1) {
+					throw new Error("Internal error: Attempted to detach child that is not attached to us");
+				}
 				oldMeta.parents.splice(thisIndex, 1);
 				oldMeta.invalidatePath();
 

--- a/Source/Fuse.Models/FuseJS/Internal/Model.js
+++ b/Source/Fuse.Models/FuseJS/Internal/Model.js
@@ -33,7 +33,9 @@ function Model(initialState, stateInitializer)
 		var meta = stateToMeta.get(state);
 
 		if (meta instanceof Object) {
-			if (parentMeta !== null) { meta.parents.push(parentMeta); }
+			if (parentMeta != null) {
+				attachChild(parentMeta, meta);
+			}
 			return meta.node;
 		}
 
@@ -293,6 +295,19 @@ function Model(initialState, stateInitializer)
 			else {
 				return node[key] === newValue;
 			}
+		}
+
+		function attachChild(parentMeta, childMeta) {
+			if (childMeta.parents.some(function(parent) {
+				return parent
+					&& parent.key === parentMeta.key
+					&& parent.meta === parentMeta.meta
+			})) {
+				// Already a parent
+				return;
+			}
+
+			childMeta.parents.push(parentMeta);
 		}
 
 		function removeAsParentFrom(node) {

--- a/Source/Fuse.Models/FuseJS/Internal/Model.js
+++ b/Source/Fuse.Models/FuseJS/Internal/Model.js
@@ -354,8 +354,8 @@ function Model(initialState, stateInitializer)
 
 				var newValue;
 				if (keyMeta instanceof Object) {
-					// Value is already instrumented
-					newValue = keyMeta.node;
+					// Value is already instrumented, but re-instrument to add as parent
+					newValue = instrument({meta: meta, key: key}, keyMeta, value);
 				}
 				else if (value instanceof Object) {
 					newValue = instrument({meta: meta, key: key}, (value instanceof Array) ? [] : {}, value);

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -570,6 +570,35 @@ namespace Fuse.Models.Test
 			}
 		}
 
+		[Test]
+		public void MultiParent()
+		{
+			var e = new UX.Model.MultiParent();
+			using(var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+
+				Assert.AreEqual("1337", GetRecursiveText(e.listParent));
+
+				e.step1.Perform();
+				root.StepFrameJS();
+
+				Assert.AreEqual("1337", GetRecursiveText(e.listParent));
+				Assert.AreEqual(1337, e.field.Value);
+
+				e.step2.Perform();
+				root.StepFrameJS();
+
+				Assert.AreEqual("1337", GetRecursiveText(e.listParent));
+				Assert.AreEqual(0, e.field.Value);
+
+				e.step3.Perform();
+				root.StepFrameJS();
+
+				Assert.AreEqual("1337,123", GetRecursiveText(e.listParent));
+			}
+		}
+
 		static List<T> ChildrenOfType<T>(Visual n) where T : Node
 		{
 			var l = new List<T>();

--- a/Source/Fuse.Models/Tests/UX/MultiParent.js
+++ b/Source/Fuse.Models/Tests/UX/MultiParent.js
@@ -1,0 +1,24 @@
+class Foo {
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+export default class {
+	constructor() {
+		this.list = [ new Foo(1337) ];
+		this.field = null;
+	}
+
+	step1() {
+		this.field = this.list[0];
+	}
+
+	step2() {
+		this.field = new Foo(0);
+	}
+
+	step3() {
+		this.list.push(new Foo(123));
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/MultiParent.ux
+++ b/Source/Fuse.Models/Tests/UX/MultiParent.ux
@@ -1,0 +1,12 @@
+<Panel ux:Class="UX.Model.MultiParent" Model="UX/MultiParent">
+	<Panel ux:Name="listParent">
+		<Each Items="{list}">
+			<Text Value="{value}" />
+		</Each>
+	</Panel>
+	<FuseTest.DudElement ux:Name="field" Value="{field.value}" />
+
+	<FuseTest.Invoke ux:Name="step1" Handler="{step1}" />
+	<FuseTest.Invoke ux:Name="step2" Handler="{step2}" />
+	<FuseTest.Invoke ux:Name="step3" Handler="{step3}" />
+</Panel>


### PR DESCRIPTION
Fixes #844, as well as a number of other bugs relating to how Model.js manages parent-child relationships.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [x] Tests
