### PR TITLE
UxGeneratorTest: avoid triggering warning

### DIFF
--- a/Tests/UxGeneratorTests/UxGeneratorTests/UxTests.uno
+++ b/Tests/UxGeneratorTests/UxGeneratorTests/UxTests.uno
@@ -40,7 +40,7 @@ public class UxTests
     public void AppearanceAndFills()
     {
         var panel = new AppearanceAndFills();
-        var rectangle = panel.FirstVisualChild as Fuse.Controls.Rectangle;
+        var rectangle = panel.FirstChild<Visual>() as Fuse.Controls.Rectangle;
 
         Assert.IsTrue(rectangle != null);
         Assert.AreEqual(1, rectangle.Fills.Count);


### PR DESCRIPTION
This avoids this warning:
```
Tests\UxGeneratorTests\UxGeneratorTests\UxTests.uno(43.31): W4139: 'Fuse.Visual.get_FirstVisualChild()' is obsolete: 'Use FirstChild<Visual>() instead'
```