### PR TITLE
Fuse.Common: move GLHelper include

### DIFF
--- a/Source/Fuse.Common/FramebufferPool.uno
+++ b/Source/Fuse.Common/FramebufferPool.uno
@@ -6,7 +6,6 @@ using Fuse.Resources;
 
 namespace Fuse
 {
-	[extern(ANDROID) Require("Source.Include", "Uno/Graphics/GLHelper.h")]
 	public static class FramebufferPool
 	{
 		static FramebufferPoolImpl framebufferPool;
@@ -57,7 +56,7 @@ namespace Fuse
 		}
 	}
 
-
+	[extern(ANDROID) Require("Source.Include", "Uno/Graphics/GLHelper.h")]
 	internal class FramebufferPoolImpl : ISoftDisposable
 	{
 		public FramebufferPoolImpl()


### PR DESCRIPTION
I have no idea how this worked. We're including this in the wrong
generated source-file.

But let's fix it, as this has been reported by a user.