### PR TITLE
merge redundant code in expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Unreleased
 
-## Navigation
-- Fixed an issue with `Navigator.Pages` not registering pages correctly in certain initialization orders
-- Added `$navigationRequest` to `Navigation.Pages` objects. This can be used to fine-tune the navigation.
 ## Expressions
 - Deprecated `UnaryOperator.OnNewOperand` and `OnLostOperand`.  These are part of a broken pattern of using unary expressions (and were not present on Binary/Ternary/QuaternaryOperator). You generally shouldn't need this, and should implement `Compute` instead. In the rare cases you need the vrituals you'll need to extend Expression and implement `Subscribe`, using `ExpressionListener` as a way to capture the correct functionality.
 - Moved `VarArgFunction.Argument` to `Expression.Argument`. It's in a base class so still has visibility in `VarArgFunction`.
 - `VarArgFunction.Subscription.OnNewData` and `OnLostData` have been sealed. They should not have been open for overriding before as it conflicts with the inner workings on the class. Only the `OnNewPartialArguments` and `OnNewArguments` should be overridden.
+
+## Navigation
+- Fixed an issue with `Navigator.Pages` not registering pages correctly in certain initialization orders
+- Added `$navigationRequest` to `Navigation.Pages` objects. This can be used to fine-tune the navigation.
 
 ## Instance
 - Added `Instance.Item` to work similar to an `Each` with a single data item

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fixed an issue with `Navigator.Pages` not registering pages correctly in certain initialization orders
 - Added `$navigationRequest` to `Navigation.Pages` objects. This can be used to fine-tune the navigation.
 ## Expressions
-- Removed `UnaryOperator.OnNewOperand` and `OnLostOperand`.  This were part of a broken pattern of using unary expressions (and were not present on Binary/Ternary/QuaternaryOperator). You will need to extend Expression and implement `Subscribe`, using `ExpressionListener` as a way to capture the correct functionality. It was already broken before, this forces a fix to be made.
+- Deprecated `UnaryOperator.OnNewOperand` and `OnLostOperand`.  These are part of a broken pattern of using unary expressions (and were not present on Binary/Ternary/QuaternaryOperator). You generally shouldn't need this, and should implement `Compute` instead. In the rare cases you need the vrituals you'll need to extend Expression and implement `Subscribe`, using `ExpressionListener` as a way to capture the correct functionality.
 - Moved `VarArgFunction.Argument` to `Expression.Argument`. It's in a base class so still has visibility in `VarArgFunction`.
 - `VarArgFunction.Subscription.OnNewData` and `OnLostData` have been sealed. They should not have been open for overriding before as it conflicts with the inner workings on the class. Only the `OnNewPartialArguments` and `OnNewArguments` should be overridden.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Navigation
 - Fixed an issue with `Navigator.Pages` not registering pages correctly in certain initialization orders
 - Added `$navigationRequest` to `Navigation.Pages` objects. This can be used to fine-tune the navigation.
+## Expressions
+- Removed `UnaryOperator.OnNewOperand` and `OnLostOperand`.  This were part of a broken pattern of using unary expressions (and were not present on Binary/Ternary/QuaternaryOperator). You will need to extend Expression and implement `Subscribe`, using `ExpressionListener` as a way to capture the correct functionality. It was already broken before, this forces a fix to be made.
+- Moved `VarArgFunction.Argument` to `Expression.Argument`. It's in a base class so still has visibility in `VarArgFunction`.
+- `VarArgFunction.Subscription.OnNewData` and `OnLostData` have been sealed. They should not have been open for overriding before as it conflicts with the inner workings on the class. Only the `OnNewPartialArguments` and `OnNewArguments` should be overridden.
 
 ## Instance
 - Added `Instance.Item` to work similar to an `Each` with a single data item

--- a/Source/Fuse.Motion/DelayFunction.uno
+++ b/Source/Fuse.Motion/DelayFunction.uno
@@ -1,37 +1,60 @@
 using Uno;
 using Uno.UX;
+
 using Fuse.Reactive;
 
 namespace Fuse.Motion
 {
 	[UXFunction("delay")]
-	// TODO: Should not derive from BinaryOperator
-	// https://github.com/fusetools/fuselibs-public/issues/829
-	public class DelayFunction: BinaryOperator
+	public class DelayFunction: Expression
 	{
+		Expression _value, _delay;
+		
 		[UXConstructor]
-		public DelayFunction([UXParameter("Value")] Expression value, [UXParameter("Delay")] Expression delay): base(value, delay) {}
-
-		internal override bool OnNewOperands(IListener listener, object value, object delay)
+		public DelayFunction([UXParameter("Value")] Expression value, [UXParameter("Delay")] Expression delay)
 		{
-			Timer.Wait(Marshal.ToDouble(delay), new SetClosure(this, listener, value).Run);
-			return true;
+			_value = value;
+			_delay = delay;
 		}
 
+		public sealed override IDisposable Subscribe(IContext context, IListener listener)
+		{
+			var sub = new Subscription(this,  listener);
+			sub.Init(context);
+			return sub;
+		}
+		
+		class Subscription : ExpressionListener
+		{
+			public Subscription( DelayFunction source, IListener listener ) :
+				base( source, listener, new Expression[]{ source._value, source._delay }, Flags.None )
+			{ }
+			
+			protected override void OnArguments(Argument[] args)
+			{
+				//TODO: https://github.com/fusetools/fuselibs-public/issues/872  This doesn't deal with lost data correctly
+				//TODO: https://github.com/fusetools/fuselibs-public/issues/873 doesn't handle invalid Delay
+				Timer.Wait(Marshal.ToDouble(args[1].Value), new SetClosure(this, args[0].Value).Run);
+			}
+			
+			public new void SetData(object value)
+			{
+				base.SetData(value);
+			}
+		}
+		
 		class SetClosure
 		{
-			readonly DelayFunction _func;
-			readonly IListener _target;
+			readonly Subscription _sub;
 			readonly object _v;
-			public SetClosure(DelayFunction func, IListener target, object v)
+			public SetClosure(Subscription sub, object v)
 			{
-				_func = func;
-				_target = target;
+				_sub = sub;
 				_v = v;
 			}
 			public void Run()
 			{
-				_target.OnNewData(_func, _v);
+				_sub.SetData(_v);
 			}
 		}
 	}

--- a/Source/Fuse.Navigation/ModifyRouteCommand.uno
+++ b/Source/Fuse.Navigation/ModifyRouteCommand.uno
@@ -57,6 +57,7 @@ namespace Fuse.Navigation
 					return;
 					
 				_innerSub = new InnerSubscription(this);
+				_innerSub.Init(_context);
 			}
 
 			//TODO: Remove these, perhaps this class doesn't need to be an InnerListener?
@@ -70,10 +71,9 @@ namespace Fuse.Navigation
 			bool _triggered;
 			
 			public InnerSubscription(OuterSubscription outSub)
-				: base(outSub._expr, outSub._context) 
+				: base(outSub._expr)
 			{
 				_outSub = outSub;
-				Init();
 			}
 			
 			protected override void OnNewArguments(Argument[] args)

--- a/Source/Fuse.Reactive.Bindings/InstantiatorFunction.uno
+++ b/Source/Fuse.Reactive.Bindings/InstantiatorFunction.uno
@@ -36,7 +36,9 @@ namespace Fuse.Reactive
 			}
 			
 			var node = Arguments.Count > 0 ? Arguments[0] : null;
-			return new InstantiatorSubscription(this, _item, listener, context, node );
+			var ins = new InstantiatorSubscription(this, _item, listener, context, node );
+			ins.Init(context);
+			return ins;
 		}
 		
 		class InstantiatorSubscription : InnerListener
@@ -63,8 +65,10 @@ namespace Fuse.Reactive
 				_item = item;
 				_listener = listener;
 				_context = context;
-				
-				
+			}
+			
+			public void Init(IContext context)
+			{
 				if (_node == null)	
 					OnNewNode(null);
 				else

--- a/Source/Fuse.Reactive.Expressions/BinaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/BinaryOperator.uno
@@ -4,29 +4,29 @@ using Uno.Collections;
 
 namespace Fuse.Reactive
 {
-	/* This class is part of a set of classes: UnaryOperator, BinaryOperator, TernaryOperator, QuaternaryOperator.
-		If you modify one you'll likely need to modify all four. */
-		
-	/** Optimized base class for reactive functions/operators that take a two arguments/operands. 
-
-		Subclasses must override etiher `Compute` for pure/synchronous functions, or `OnNewOperands` to 
-		allow more advanced control over when the listener is notified.
-	*/
-	public abstract class BinaryOperator: Expression
+	/** Base class for reactive functions/operators that take two arguments/operands. */
+	public abstract class BinaryOperator: ComputeExpression
 	{
-		public Expression Left { get; private set; }
-		public Expression Right { get; private set; }
-		protected BinaryOperator(Expression left, Expression right)
-		{
-			Left = left;
-			Right = right;
-		}
+		public Expression Left { get { return GetArgument(0); } }
+		public Expression Right { get { return GetArgument(1); } }
+		
+		protected BinaryOperator(Expression left, Expression right, 
+			Flags flags = Flags.DeprecatedVirtualFlags)
+			: base( new Expression[]{ left, right}, flags )
+		{ }
 
-		public override IDisposable Subscribe(IContext context, IListener listener)
+		protected BinaryOperator(Expression left, Expression right, 
+			string name, Flags flags = Flags.None)
+			: base( new Expression[]{ left, right}, flags, name )
+		{ }
+		
+		internal override Flags GetFlags()
 		{
-			return Subscription.Create(this, context, listener);
+			return Flags.None |
+				(IsLeftOptional ? Flags.Optional0 : Flags.None) |
+				(IsRightOptional ? Flags.Optional1 : Flags.None);
 		}
-
+		
 		protected virtual bool IsLeftOptional { get { return false; } }
 		protected virtual bool IsRightOptional { get { return false; } }
 
@@ -40,131 +40,9 @@ namespace Fuse.Reactive
 		/** @deprecated Override the other `Compute` function. 2017-11-29 */
 		protected virtual object Compute(object left, object right) { return null; }
 
-		/* TODO: This shouldn't exist, it should follow the same pattern as Ternary/QuaternaryOperator. It's still internal now due to `DelayFunction` incorrectly deriving from a `BinaryOperator` 
-		https://github.com/fusetools/fuselibs-public/issues/829 */
-		internal virtual bool OnNewOperands(IListener listener, object left, object right)
+		protected override sealed bool Compute(Argument[] args, out object result)
 		{
-			object result;
-			if (Compute(left, right, out result))
-			{
-				listener.OnNewData(this, result);
-				return true;
-			}
-			else
-				return false;
-		}
-		
-		protected virtual void OnLostOperands(IListener listener)
-		{
-			listener.OnLostData(this);
-		}
-
-		class Subscription: InnerListener
-		{
-			readonly BinaryOperator _bo;
-			object _left, _right;
-
-			IDisposable _leftSub;
-			IDisposable _rightSub;
-
-			IListener _listener;
-			bool _hasLeft;
-			bool _hasRight;
-			bool _hasData;
-
-			protected Subscription(BinaryOperator bo, IListener listener)
-			{
-				_bo = bo;
-				_listener = listener;
-			}
-
-			public static Subscription Create(BinaryOperator bo, IContext context, IListener listener)
-			{
-				var res = new Subscription(bo, listener);
-				res.Init(context);
-				return res;
-			}
-			
-			/** Must be called by subclasses at the end of constructor, or when fully initialized.
-				This avoids race condition if subscriptions call back synchronously. */
-			protected void Init(IContext context)
-			{
-				_leftSub = _bo.Left.Subscribe(context, this);
-				_rightSub = _bo.Right.Subscribe(context, this);
-				UpdateOperands();
-			}
-
-			protected override void OnNewData(IExpression source, object value)
-			{
-				if (source == _bo.Left) { _hasLeft = true; _left = value; }
-				if (source == _bo.Right) { _hasRight = true; _right = value; }
-				UpdateOperands();
-			}
-			
-			protected override void OnLostData(IExpression source)
-			{
-				if (source == _bo.Left) { _hasLeft = false; _left = null; }
-				if (source == _bo.Right) { _hasRight = false; _right = null; }
-				UpdateOperands();
-			}
-			
-			void ClearData()
-			{
-				if (_hasData)
-				{
-					_hasData = false;
-					_listener.OnLostData(_bo);
-				}
-			}
-			
-			void UpdateOperands()
-			{
-				ClearDiagnostic();
-				
-				try
-				{
-					if ((_hasLeft || _bo.IsLeftOptional) && (_hasRight || _bo.IsRightOptional))
-					{
-						//see OnNewOperands for why this structure is weird compared to Ternary/QuaternaryOperator
-						if (_bo.OnNewOperands(_listener, _left, _right))
-						{
-							_hasData = true;
-						}
-						else
-						{
-							Fuse.Diagnostics.UserWarning( "Failed to compute value for (" +
-								_left + ", " + _right, _bo );
-							ClearData();
-						}
-					}
-					else if (_hasData)
-					{
-						ClearData();
-					}
-				}
-				catch (MarshalException me)
-				{
-					SetDiagnostic(me.Message, _bo);
-				}
-			}
-
-			public override void Dispose()
-			{
-				base.Dispose();
-
-				if (_leftSub != null)
-				{
-					_leftSub.Dispose();
-					_leftSub = null;
-				}
-				if (_rightSub != null)
-				{
-					_rightSub.Dispose();
-					_rightSub = null;
-				}
-				_listener = null;
-			}
+			return Compute(args[0].Value, args[1].Value, out result);
 		}
 	}
 }
-

--- a/Source/Fuse.Reactive.Expressions/BinaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/BinaryOperator.uno
@@ -30,19 +30,19 @@ namespace Fuse.Reactive
 		protected virtual bool IsLeftOptional { get { return false; } }
 		protected virtual bool IsRightOptional { get { return false; } }
 
-		protected virtual bool Compute(object left, object right, out object result)
+		protected virtual bool TryCompute(object left, object right, out object result)
 		{
-			Fuse.Diagnostics.Deprecated( " No `Compute`, or a deprecated form, overriden. Migrate your code to override the one with `bool` return. ", this );
+			Fuse.Diagnostics.Deprecated( " No `TryCompute`, or a deprecated form, overriden. Migrate your code to override the one with `bool` return. ", this );
 			result = Compute(left, right);
 			return true;
 		}
 		
-		/** @deprecated Override the other `Compute` function. 2017-11-29 */
+		/** @deprecated Override the `TryCompute` function. 2017-11-29 */
 		protected virtual object Compute(object left, object right) { return null; }
 
-		protected override sealed bool Compute(Argument[] args, out object result)
+		protected override sealed bool TryCompute(Argument[] args, out object result)
 		{
-			return Compute(args[0].Value, args[1].Value, out result);
+			return TryCompute(args[0].Value, args[1].Value, out result);
 		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/ConversionFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/ConversionFunctions.uno
@@ -25,7 +25,7 @@ namespace Fuse.Reactive
 		public ToString([UXParameter("Operand")] Expression operand)
 			: base(operand, "string") { }
 			
-		protected override bool Compute(object operand, out object result)
+		protected override bool TryCompute(object operand, out object result)
 		{
 			result = null;
 			if (operand == null)

--- a/Source/Fuse.Reactive.Expressions/ConversionFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/ConversionFunctions.uno
@@ -23,7 +23,7 @@ namespace Fuse.Reactive
 	{
 		[UXConstructor]
 		public ToString([UXParameter("Operand")] Expression operand)
-			: base(operand) { }
+			: base(operand, "string") { }
 			
 		protected override bool Compute(object operand, out object result)
 		{

--- a/Source/Fuse.Reactive.Expressions/Expression.uno
+++ b/Source/Fuse.Reactive.Expressions/Expression.uno
@@ -8,6 +8,35 @@ namespace Fuse.Reactive
 	{
 		/** See `IExpression.Subscribe` for docs.	*/
 		public abstract IDisposable Subscribe(IContext context, IListener listener);
+		
+		/** Holds information about an argument to an Expression 
+			@advanced */
+		public class Argument 
+		{
+			internal IExpression Source;
+			internal IDisposable Subscription;
+
+			/** The current value of the argument. If `HasValue` is `false`, `null` is returned. */
+			public object Value { get; internal set; }
+
+			/** Whether or not this argument has yielded a value yet. 
+				This can only return false if `OnNewPartialArguments` was overridden.
+			*/
+			public bool HasValue { get; internal set; }
+			
+			internal void Dispose()
+			{
+				if (Subscription != null)
+				{
+					Subscription.Dispose();
+					Subscription = null;
+				}
+
+				Value = null;
+				HasValue = false;
+			}
+		}
+		
 	}
 
 	public abstract class ConstantExpression: Expression

--- a/Source/Fuse.Reactive.Expressions/ExpressionListener.uno
+++ b/Source/Fuse.Reactive.Expressions/ExpressionListener.uno
@@ -313,7 +313,7 @@ namespace Fuse.Reactive
 			
 			The length of `args` is guaranteed to be same length as the constructor `args` argument.
 		*/
-		protected abstract bool Compute(Expression.Argument[] args, out object result);
+		protected abstract bool TryCompute(Expression.Argument[] args, out object result);
 		
 		public sealed override IDisposable Subscribe(IContext context, IListener listener)
 		{
@@ -341,7 +341,7 @@ namespace Fuse.Reactive
 				}
 				
 				object result;
-				if (_expr.Compute(args, out result))
+				if (_expr.TryCompute(args, out result))
 				{
 					SetData( result );
 				}

--- a/Source/Fuse.Reactive.Expressions/ExpressionListener.uno
+++ b/Source/Fuse.Reactive.Expressions/ExpressionListener.uno
@@ -1,0 +1,350 @@
+using Uno;
+
+namespace Fuse.Reactive
+{
+	/**
+		Subscribes to many argument expressions used in higher level functions. This collects common
+		behaviour and means to simplify higher-level code.
+		
+		NOTE: The use of InnerListener is questionable but unavoidable at this time.
+		https://github.com/fusetools/fuselibs-public/issues/785
+		
+		@hide
+	*/
+	public abstract class ExpressionSubscriber : InnerListener
+	{
+		[Flags]
+		public enum Flags
+		{
+			None = 0,
+			Optional0 = 1 << 0,
+			Optional1 = 1 << 1,
+			Optional2 = 1 << 2,
+			Optional3 = 1 << 3,
+			
+			AllOptional = 1 << 10,
+		}
+		
+		object _source;
+		Flags _flags;
+		Expression.Argument[] _args;
+
+		internal ExpressionSubscriber( Expression[] args, Flags flags, object source = null )
+		{
+			_flags = flags;
+			_source = source ?? this;
+			
+			_args = new Expression.Argument[args.Length];
+			for (int i=0; i < args.Length; ++i)
+			{
+				if (args[i] == null)
+					throw new Exception( "May not contain null: " + nameof(args) );
+				_args[i] = new Expression.Argument{ Source = args[i] };
+			}
+		}
+		
+		/** Must be called by instantiators of subscription after construction.
+			This avoids race condition if subscriptions call back synchronously. */
+		public void Init(IContext context)
+		{
+			for (int i=0; i < _args.Length; ++i)
+				_args[i].Subscription = _args[i].Source.Subscribe(context, this);
+			UpdateOperands(); //in case all optional
+		}
+		
+		protected sealed override void OnNewData(IExpression source, object value)
+		{
+			for (int i=0; i < _args.Length; ++i)
+			{
+				if (_args[i].Source == source)
+				{
+					_args[i].Value = value;
+					_args[i].HasValue = true;
+				}
+			}
+			UpdateOperands();
+		}
+	
+		protected sealed override void OnLostData(IExpression source)
+		{
+			for (int i=0; i < _args.Length; ++i)
+			{
+				if (_args[i].Source == source)
+				{
+					_args[i].Value = null;
+					_args[i].HasValue = false;
+				}
+			}
+			
+			UpdateOperands();
+		}
+		
+		bool IsOptional(int index)
+		{
+			if (_flags.HasFlag( Flags.AllOptional ) )
+				return true;
+			if (index == 0)
+				return _flags.HasFlag( Flags.Optional0 );
+			if (index == 1)
+				return _flags.HasFlag( Flags.Optional1 );
+			if (index == 2)
+				return _flags.HasFlag( Flags.Optional2 );
+			if (index == 3)
+				return _flags.HasFlag( Flags.Optional3 );
+			return false;
+		}
+		
+		void UpdateOperands()
+		{
+			ClearDiagnostic();
+			
+			try
+			{
+				bool okay = true;
+				for (int i=0; i < _args.Length; ++i)
+				{
+					if (!_args[i].HasValue && !IsOptional(i))
+					{
+						okay = false;
+						break;
+					}
+				}
+				
+				if (okay)
+					OnArguments(_args);
+				else
+					OnClearData();
+			}
+			catch (MarshalException me)
+			{
+				OnClearData();
+				SetDiagnostic(me.Message, _source);
+			}
+		}
+		
+		public override void Dispose()
+		{
+			for (int i=0; i < _args.Length; ++i)
+				_args[i].Dispose();
+			_source = null;
+			base.Dispose();
+		}
+		
+		/**
+			Will only be called if all non-optional arguments have been provided.
+			
+			It is the implementers responsibility to call `SetData` or `ClearData` as appropriate.  Note that this class will however call `ClearData` on its own if not all optional arguments are provided, or there is an error.
+		*/
+		protected abstract void OnArguments(Expression.Argument[] args);
+		
+		internal abstract void OnClearData();
+	}
+
+	/**
+		A base class for common expression subscriptions. This handles the basic bookkeeping. Derived classes should implement `OnArguments` (coming from the base class). The members `ClearData` and `SetData` should be called to set the output state.
+		
+		Using this directly is unsual, consider `ComputeExpression` instead.
+		
+		Derived classes should implement `OnArguments`
+		
+		@advanced
+	*/
+	public abstract class ExpressionListener : ExpressionSubscriber
+	{
+		IListener _listener;
+		bool _hasData;
+		object _curData;
+		Expression _source;
+
+		protected ExpressionListener( Expression source, IListener listener, Expression[] args, Flags flags = Flags.None) :
+			base( args, flags, source )
+		{
+			if (listener == null)
+				throw new Exception( "May not be null: "+  nameof(listener) );
+			if (source == null)
+				throw new Exception( "May not be null: " + nameof(source) );
+				
+			_listener = listener;
+			_source = source;
+		}
+		
+		public override void Dispose()
+		{
+			_listener = null;
+			_hasData = false;
+			_curData = null;
+			base.Dispose();
+		}
+		
+		/** The output will be cleared, set to a lost data state */
+		internal override sealed void OnClearData()
+		{
+			ClearData();
+		}
+		
+		protected void ClearData()
+		{
+			if (_hasData && _listener != null)
+			{
+				_hasData = false;
+				_curData = null;
+				_listener.OnLostData(_source);
+			}
+		}
+		
+		/** The output is set to the given value. */
+		protected void SetData(object value)
+		{
+			if (!_hasData || value != _curData)
+			{
+				_hasData = true;
+				_curData = value;
+				_listener.OnNewData(_source, value);
+			}
+		}
+	}
+	
+	/**
+		Base class for UX expression functions that take arguments and compute a value from them.
+		
+		This is the preferred base for most functions unless they have special needs to track whether/when arguments are set and/or lost.
+		
+		Only a conctructor and the `Compute` method need to be defined.
+	*/
+	public abstract class ComputeExpression : Expression
+	{
+		[Flags]
+		public enum Flags
+		{
+			None = 0,
+			Optional0 = 1 << 0,
+			Optional1 = 1 << 1,
+			Optional2 = 1 << 2,
+			Optional3 = 1 << 3,
+		
+			/** All arguments to the expression are optional. `Compute` will be called when HasValue is false for individual, or all, values */
+			AllOptional = 1 << 4,
+			
+			/** A warning should not be emitted when `Compute` returns false, indicating this is an expected condition, or the derived class will emit its own diagnostics */
+			OmitComputeWarning = 1 << 5,
+			
+			/** @deprecated 2017-12-14 This is strictly for compatibility with deprecated constructors */
+			DeprecatedVirtualFlags = 1 << 10,
+		}
+		
+		Expression[] _args;
+		protected Expression GetArgument(int i)
+		{
+			return _args[i];
+		}
+		
+		Flags _flags;
+		String _name;
+		protected ComputeExpression( Expression[] args, Flags flags = Flags.None, string name = null )
+		{
+			_flags = flags;
+			_args = args;
+			_name = name;
+			
+			if (_flags.HasFlag( Flags.DeprecatedVirtualFlags) )
+			{
+				//DEPRECATED: 2017-12-14
+				Fuse.Diagnostics.Deprecated( "This constructor and use of the Is*Optional virtuals is deprecated. Pass the optionals as flags to the constructor, or specifiy Flags.None to avoid the message", this );
+			}
+		}
+
+		//may be null if undefined
+		protected string Name 
+		{
+			get { return _name; }
+		}
+		string EffectiveName
+		{
+			get { return _name ?? this.GetType().FullName; } // `.Name` would be better, but it doesn't appear to be defined
+		}
+		
+		public override string ToString()
+		{
+			string r = Name + "(";
+			for (int i=0; i < _args.Length; ++i)
+			{
+				if (i > 0)
+					r += ", ";
+				r += _args[i];
+			}
+			r += ")";
+			return r;
+		}
+		
+		ExpressionSubscriber.Flags EffectiveFlags
+		{
+			get 
+			{
+				var flags =_flags.HasFlag(Flags.DeprecatedVirtualFlags) ? GetFlags() : _flags;
+
+				return ExpressionListener.Flags.None |	
+					(flags.HasFlag(Flags.Optional0) ? ExpressionListener.Flags.Optional0 : ExpressionListener.Flags.None) |
+					(flags.HasFlag(Flags.Optional1) ? ExpressionListener.Flags.Optional1 : ExpressionListener.Flags.None) |
+					(flags.HasFlag(Flags.Optional2) ? ExpressionListener.Flags.Optional2 : ExpressionListener.Flags.None) |
+					(flags.HasFlag(Flags.Optional3) ? ExpressionListener.Flags.Optional3 : ExpressionListener.Flags.None) |
+					(flags.HasFlag(Flags.AllOptional) ? ExpressionListener.Flags.AllOptional :
+					ExpressionListener.Flags.None);
+			}
+		}
+		
+		internal virtual Flags GetFlags() { return _flags; }
+		
+		/**
+			Should calculate the resulting value from the provided arguments.
+			
+			The length of `args` is guaranteed to be same length as the constructor `args` argument.
+		*/
+		protected abstract bool Compute(Expression.Argument[] args, out object result);
+		
+		public sealed override IDisposable Subscribe(IContext context, IListener listener)
+		{
+			var sub = new Subscription(this,  listener);
+			sub.Init(context);
+			return sub;
+		}
+
+		class Subscription : ExpressionListener
+		{
+			ComputeExpression _expr;
+			
+			public Subscription( ComputeExpression expr, IListener listener )
+				: base( expr, listener, expr._args, expr.EffectiveFlags )
+			{
+				_expr = expr;
+			}
+
+			protected override void OnArguments(Expression.Argument[] args)
+			{
+				object result;
+				if (_expr.Compute(args, out result))
+				{
+					SetData( result );
+				}
+				else
+				{
+					if (!_expr._flags.HasFlag( ComputeExpression.Flags.OmitComputeWarning ) )
+					{
+						string msg = "Failed to compute value for (";
+						for (int i=0; i < args.Length; ++i)
+						{
+							if (i > 0)
+								msg += ",";
+							if (args[i].HasValue)
+								msg += args[i].Value;
+							else
+								msg += "undefined";
+						}
+						Fuse.Diagnostics.UserWarning( msg, _expr );
+					}
+					ClearData();
+				}
+			}
+		}
+	}
+	
+}

--- a/Source/Fuse.Reactive.Expressions/Fuse.Reactive.Expressions.unoproj
+++ b/Source/Fuse.Reactive.Expressions/Fuse.Reactive.Expressions.unoproj
@@ -24,6 +24,7 @@
     "Fuse.Scripting.Test",
     "Fuse.Common.Test.Helpers",
     "Fuse.Expressions.Test",
+    "Fuse.Motion",
     "Fuse.Scripting.JavaScript.Test"
   ],
   "Includes": [

--- a/Source/Fuse.Reactive.Expressions/IsDefined.uno
+++ b/Source/Fuse.Reactive.Expressions/IsDefined.uno
@@ -23,7 +23,7 @@ namespace Fuse.Reactive
 			: base( new Expression[]{ operand }, Flags.OmitComputeWarning | Flags.AllOptional )
 		{ }
 
-		protected sealed override bool Compute(Expression.Argument[] args, out object result)
+		protected sealed override bool TryCompute(Expression.Argument[] args, out object result)
 		{
 			result = args[0].HasValue;
 			return true;
@@ -46,7 +46,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public IsNull([UXParameter("Operand")] Expression operand)
 			: base(operand, "isNull", Flags.Optional0) {}
-		protected override bool Compute(object operand, out object result)
+		protected override bool TryCompute(object operand, out object result)
 		{
 			result = operand == null;
 			return true;
@@ -69,7 +69,7 @@ namespace Fuse.Reactive
 			: base( new Expression[]{ operand }, Flags.OmitComputeWarning )
 		{ }
 		
-		protected override bool Compute(Expression.Argument[] args, out object result)
+		protected override bool TryCompute(Expression.Argument[] args, out object result)
 		{
 			result = args[0].Value;
 			return args[0].Value != null;

--- a/Source/Fuse.Reactive.Expressions/MathFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/MathFunctions.uno
@@ -10,7 +10,7 @@ namespace Fuse.Reactive
 		public Min([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
 			base(left, right, "min") {}
 			
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Marshal.Min(left, right);
 			return true;
@@ -24,7 +24,7 @@ namespace Fuse.Reactive
 		public Max([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right) : 
 			base(left, right, "max") {}
 			
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Marshal.Max(left, right);
 			return true;
@@ -38,7 +38,7 @@ namespace Fuse.Reactive
 		public Mod([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right) : 
 			base(left, right, "mod") {}
 			
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Math.Mod( Marshal.ToFloat(left), Marshal.ToFloat(right) );
 			return true;
@@ -51,7 +51,7 @@ namespace Fuse.Reactive
 	{
 		[UXConstructor]
 		public Even([UXParameter("Operand")] Expression operand): base(operand, "even") {}
-		protected override bool Compute(object operand, out object result)
+		protected override bool TryCompute(object operand, out object result)
 		{
 			result = null;
 			float v = 0;
@@ -70,7 +70,7 @@ namespace Fuse.Reactive
 	{
 		[UXConstructor]
 		public Odd([UXParameter("Operand")] Expression operand): base(operand, "odd") {}
-		protected override bool Compute(object operand, out object result)
+		protected override bool TryCompute(object operand, out object result)
 		{
 			result = null;
 			float v = 0;
@@ -103,7 +103,7 @@ namespace Fuse.Reactive
 		public Alternate([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right) : 
 			base(left, right, "alternate") {}
 			
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = null;
 			float fvalue = 0;
@@ -137,7 +137,7 @@ namespace Fuse.Reactive
 		{
 			_op = op;
 		}
-		protected sealed override bool Compute(object operand, out object result)
+		protected sealed override bool TryCompute(object operand, out object result)
 		{
 			result = null;
 			float4 v;
@@ -178,7 +178,7 @@ namespace Fuse.Reactive
 			_op = op;
 		}
 		
-		protected sealed override bool Compute(object left, object right, out object result)
+		protected sealed override bool TryCompute(object left, object right, out object result)
 		{
 			result = null;
 			
@@ -404,7 +404,7 @@ namespace Fuse.Reactive
 			[UXParameter("Third")] Expression third) : 
 			base(first, second, third, Flags.None)
 		{ }
-		protected override bool Compute(object a, object b, object t, out object result)
+		protected override bool TryCompute(object a, object b, object t, out object result)
 		{
 			result = null;
 			float4 av = float4(0), bv = float4(0);
@@ -461,7 +461,7 @@ namespace Fuse.Reactive
 			[UXParameter("Third")] Expression third) : 
 			base(first, second, third, Flags.None) 
 		{ }
-		protected override bool Compute(object a, object mn, object mx, out object result)
+		protected override bool TryCompute(object a, object mn, object mx, out object result)
 		{
 			result = null;
 			float4 av = float4(0);

--- a/Source/Fuse.Reactive.Expressions/MathFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/MathFunctions.uno
@@ -7,16 +7,13 @@ namespace Fuse.Reactive
 	public sealed class Min: BinaryOperator
 	{
 		[UXConstructor]
-		public Min([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public Min([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
+			base(left, right, "min") {}
+			
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Marshal.Min(left, right);
 			return true;
-		}
-
-		public override string ToString()
-		{
-			return "min(" + Left + ", " + Right + ")";
 		}
 	}
 
@@ -24,16 +21,13 @@ namespace Fuse.Reactive
 	public sealed class Max: BinaryOperator
 	{
 		[UXConstructor]
-		public Max([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public Max([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right) : 
+			base(left, right, "max") {}
+			
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Marshal.Max(left, right);
 			return true;
-		}
-
-		public override string ToString()
-		{
-			return "max(" + Left + ", " + Right + ")";
 		}
 	}
 	
@@ -41,16 +35,13 @@ namespace Fuse.Reactive
 	public sealed class Mod : BinaryOperator
 	{
 		[UXConstructor]
-		public Mod([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public Mod([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right) : 
+			base(left, right, "mod") {}
+			
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Math.Mod( Marshal.ToFloat(left), Marshal.ToFloat(right) );
 			return true;
-		}
-
-		public override string ToString()
-		{
-			return "mod(" + Left + ", " + Right + ")";
 		}
 	}
 
@@ -59,7 +50,7 @@ namespace Fuse.Reactive
 	public sealed class Even : UnaryOperator
 	{
 		[UXConstructor]
-		public Even([UXParameter("Operand")] Expression operand): base(operand) {}
+		public Even([UXParameter("Operand")] Expression operand): base(operand, "even") {}
 		protected override bool Compute(object operand, out object result)
 		{
 			result = null;
@@ -71,11 +62,6 @@ namespace Fuse.Reactive
 			result = q % 2 == 0;
 			return true;
 		}
-
-		public override string ToString()
-		{
-			return "even(" + Operand +  ")";
-		}
 	}
 	
 	[UXFunction("odd")]
@@ -83,7 +69,7 @@ namespace Fuse.Reactive
 	public sealed class Odd : UnaryOperator
 	{
 		[UXConstructor]
-		public Odd([UXParameter("Operand")] Expression operand): base(operand) {}
+		public Odd([UXParameter("Operand")] Expression operand): base(operand, "odd") {}
 		protected override bool Compute(object operand, out object result)
 		{
 			result = null;
@@ -94,11 +80,6 @@ namespace Fuse.Reactive
 			var q = (int)Math.Round(v);
 			result = q % 2 != 0;
 			return true;
-		}
-
-		public override string ToString()
-		{
-			return "odd(" + Operand +  ")";
 		}
 	}
 
@@ -119,7 +100,9 @@ namespace Fuse.Reactive
 	public sealed class Alternate : BinaryOperator
 	{
 		[UXConstructor]
-		public Alternate([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public Alternate([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right) : 
+			base(left, right, "alternate") {}
+			
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = null;
@@ -136,11 +119,6 @@ namespace Fuse.Reactive
 			result = b;
 			return true;
 		}
-
-		public override string ToString()
-		{
-			return "alternate(" + Left + ", " + Right + ")";
-		}
 	}
 
 	/** 
@@ -153,12 +131,10 @@ namespace Fuse.Reactive
 	public abstract class UnaryFloatOperator : UnaryOperator
 	{
 		internal delegate double FloatOp(double value);
-		string _name;
 		FloatOp _op;
 		internal UnaryFloatOperator(Expression operand, string name, FloatOp op) : 
-			base(operand) 
+			base(operand, name)
 		{
-			_name = name;
 			_op = op;
 		}
 		protected sealed override bool Compute(object operand, out object result)
@@ -187,10 +163,6 @@ namespace Fuse.Reactive
 				
 			return false;
 		}
-		public override string ToString()
-		{
-			return _name + "(" + Operand +  ")";
-		}
 	}
 
 	/**
@@ -199,14 +171,13 @@ namespace Fuse.Reactive
 	public abstract class BinaryFloatOperator : BinaryOperator
 	{
 		internal delegate double FloatOp(double a, double b);
-		string _name;
 		FloatOp _op;
 		internal BinaryFloatOperator(Expression left, Expression right, string name, FloatOp op) : 
-			base(left, right) 
+			base(left, right, name) 
 		{
-			_name = name;
 			_op = op;
 		}
+		
 		protected sealed override bool Compute(object left, object right, out object result)
 		{
 			result = null;
@@ -218,10 +189,6 @@ namespace Fuse.Reactive
 				return false;
 			result = _op(lv, rv);
 			return true;
-		}
-		public override string ToString()
-		{
-			return _name + "(" + Left + "," + Right +  ")";
 		}
 	}
 	
@@ -435,7 +402,7 @@ namespace Fuse.Reactive
 		public Lerp([UXParameter("First")] Expression first, 
 			[UXParameter("Second")] Expression second, 
 			[UXParameter("Third")] Expression third) : 
-			base(first, second, third) 
+			base(first, second, third, Flags.None)
 		{ }
 		protected override bool Compute(object a, object b, object t, out object result)
 		{
@@ -492,7 +459,7 @@ namespace Fuse.Reactive
 		public Clamp([UXParameter("First")] Expression first, 
 			[UXParameter("Second")] Expression second, 
 			[UXParameter("Third")] Expression third) : 
-			base(first, second, third) 
+			base(first, second, third, Flags.None) 
 		{ }
 		protected override bool Compute(object a, object mn, object mx, out object result)
 		{

--- a/Source/Fuse.Reactive.Expressions/NameValuePair.uno
+++ b/Source/Fuse.Reactive.Expressions/NameValuePair.uno
@@ -6,7 +6,7 @@ namespace Fuse.Reactive
 	public sealed class NameValuePair: BinaryOperator
 	{
 		[UXConstructor]
-		public NameValuePair([UXParameter("Name")] Expression name, [UXParameter("Value")] Expression value) : base(name, value)
+		public NameValuePair([UXParameter("Name")] Expression name, [UXParameter("Value")] Expression value) : base(name, value, Flags.None)
 		{
 		}
 

--- a/Source/Fuse.Reactive.Expressions/NameValuePair.uno
+++ b/Source/Fuse.Reactive.Expressions/NameValuePair.uno
@@ -10,7 +10,7 @@ namespace Fuse.Reactive
 		{
 		}
 
-		protected override bool Compute(object name, object value, out object result)
+		protected override bool TryCompute(object name, object value, out object result)
 		{
 			result = new Fuse.NameValuePair(name.ToString(), value);
 			return true;

--- a/Source/Fuse.Reactive.Expressions/NullCoalesce.uno
+++ b/Source/Fuse.Reactive.Expressions/NullCoalesce.uno
@@ -1,98 +1,31 @@
 using Uno;
 using Uno.UX;
-using Uno.Collections;
 
 namespace Fuse.Reactive
 {
-	public sealed class NullCoalesce: Expression
+	public sealed class NullCoalesce: ComputeExpression
 	{
-		public Expression Left { get; private set; }
-		public Expression Right { get; private set; }
 		[UXConstructor]
 		public NullCoalesce([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right)
+			: base( new Expression[]{left, right}, Flags.OmitComputeWarning | Flags.AllOptional)
+		{}
+
+		protected override bool Compute(Expression.Argument[] args, out object result)
 		{
-			Left = left;
-			Right = right;
-		}
-
-		public override IDisposable Subscribe(IContext context, IListener listener)
-		{
-			return Subscription.Create(this, context, listener);
-		}
-
-		class Subscription: InnerListener
-		{
-			readonly NullCoalesce _bo;
-			object _left, _right;
-
-			IDisposable _leftSub;
-			IDisposable _rightSub;
-
-			IListener _listener;
-			bool _hasLeft;
-			bool _hasRight;
-
-			protected Subscription(NullCoalesce bo, IListener listener)
+			if (args[0].HasValue && args[0].Value != null)
 			{
-				_bo = bo;
-				_listener = listener;
-			}
-
-			public static Subscription Create(NullCoalesce bo, IContext context, IListener listener)
-			{
-				var res = new Subscription(bo, listener);
-				res.Init(context);
-				return res;
+				result = args[0].Value;
+				return true;
 			}
 			
-			/** Must be called by subclasses at the end of constructor, or when fully initialized.
-				This avoids race condition if subscriptions call back synchronously. */
-			protected void Init(IContext context)
+			if (args[1].HasValue)
 			{
-				_leftSub = _bo.Left.Subscribe(context, this);
-				_rightSub = _bo.Right.Subscribe(context, this);
-			}
-
-			protected override void OnNewData(IExpression source, object value)
-			{
-				if (source == _bo.Left) { _hasLeft = true; _left = value; }
-				if (source == _bo.Right) { _hasRight = true; _right = value; }
-				UpdateValue();
+				result = args[1].Value;
+				return true;
 			}
 			
-			void UpdateValue()
-			{
-				if (_hasLeft && _left != null)
-					_listener.OnNewData( _bo, _left );
-				else if (_hasRight)
-					_listener.OnNewData( _bo, _right );
-				else 
-					_listener.OnLostData( _bo );
-			}
-			
-			protected override void OnLostData(IExpression source)
-			{
-				if (source == _bo.Left) { _hasLeft = false; }
-				if (source == _bo.Right) { _hasRight = false; }
-				UpdateValue();
-			}
-
-			public override void Dispose()
-			{
-				base.Dispose();
-
-				if (_leftSub != null)
-				{
-					_leftSub.Dispose();
-					_leftSub = null;
-				}
-				if (_rightSub != null)
-				{
-					_rightSub.Dispose();
-					_rightSub = null;
-				}
-				_listener = null;
-			}
+			result = null;
+			return false;
 		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/NullCoalesce.uno
+++ b/Source/Fuse.Reactive.Expressions/NullCoalesce.uno
@@ -10,7 +10,7 @@ namespace Fuse.Reactive
 			: base( new Expression[]{left, right}, Flags.OmitComputeWarning | Flags.AllOptional)
 		{}
 
-		protected override bool Compute(Expression.Argument[] args, out object result)
+		protected override bool TryCompute(Expression.Argument[] args, out object result)
 		{
 			if (args[0].HasValue && args[0].Value != null)
 			{

--- a/Source/Fuse.Reactive.Expressions/Object.uno
+++ b/Source/Fuse.Reactive.Expressions/Object.uno
@@ -25,7 +25,7 @@ namespace Fuse.Reactive
 	{
 		readonly Dictionary<string, object> _dict = new Dictionary<string, object>();
 
-		public ArrayObject(VarArgFunction.Argument[] args): base(args)
+		public ArrayObject(Expression.Argument[] args): base(args)
 		{
 			for (var i = 0; i < args.Length; i++)
 			{

--- a/Source/Fuse.Reactive.Expressions/Operators.uno
+++ b/Source/Fuse.Reactive.Expressions/Operators.uno
@@ -28,7 +28,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public Add([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right) : 
 			base(left, right, "+") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Marshal.Add(left, right);
 			return true;
@@ -40,7 +40,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public Subtract([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
 			base(left, right, "-") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Marshal.Subtract(left, right);
 			return true;
@@ -52,7 +52,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public Multiply([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
 			base(left, right, "*") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Marshal.Multiply(left, right);
 			return true;
@@ -64,7 +64,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public Divide([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
 			base(left, right,"/") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Marshal.Divide(left, right);
 			return true;
@@ -77,7 +77,7 @@ namespace Fuse.Reactive
 		public Conditional([UXParameter("Condition")] Expression condition, [UXParameter("TrueValue")] Expression trueValue, [UXParameter("FalseValue")] Expression falseValue)
 			: base(condition, trueValue, falseValue, Flags.Optional2) {}
 
-		protected override bool Compute(object cond, object trueVal, object falseVal, out object result)
+		protected override bool TryCompute(object cond, object trueVal, object falseVal, out object result)
 		{
 			result = null;
 			if (cond == null) return false;
@@ -96,7 +96,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public LessThan([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
 			base(left, right,"<") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Marshal.LessThan(left, right);
 			return true;
@@ -108,7 +108,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public GreaterThan([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right):
 			base(left, right, ">") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Marshal.GreaterThan(left, right);
 			return true;
@@ -120,7 +120,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public GreaterOrEqual([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right)
 			: base(left, right,">=") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = null;
 			if (left == null || right == null) return false;
@@ -134,7 +134,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public LessOrEqual([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right):
 			base(left, right,"<=") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = null;
 			if (left == null || right == null) return false;
@@ -148,7 +148,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public Equal([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
 			base(left, right,"==") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = Marshal.EqualTo(left, right);
 			return true;
@@ -160,7 +160,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public NotEqual([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
 			base(left, right, "!=") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = null;
 			if (left == null || right == null) return false;
@@ -174,7 +174,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public LogicalAnd([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
 			base(left, right, "&&") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = null;
 			if (left == null || right == null) return false;
@@ -188,7 +188,7 @@ namespace Fuse.Reactive
 		[UXConstructor]
 		public LogicalOr([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
 			base(left, right, "||") {}
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = null;
 			if (left == null || right == null) return false;

--- a/Source/Fuse.Reactive.Expressions/Operators.uno
+++ b/Source/Fuse.Reactive.Expressions/Operators.uno
@@ -6,73 +6,76 @@ namespace Fuse.Reactive
 {
 	public abstract class InfixOperator: BinaryOperator
 	{
+		/** @deprecated Use the constructor that takes a name, as flags */
+		[Obsolete]
 		protected InfixOperator(Expression left, Expression right): base(left, right) {}
+		
+		protected InfixOperator(Expression left, Expression right, string symbol, Flags flags = Flags.None) :
+			base(left, right, symbol, flags) 
+		{ }
 
-		public abstract string Symbol { get; }
+		/** @deprecated Provide a name to the constructor instead. */
+		public virtual string Symbol { get { return ""; } }
 
 		public override string ToString()
 		{
-			return "(" + Left + " " + Symbol + " " + Right + ")";
+			return "(" + Left + " " + (Name ?? Symbol) + " " + Right + ")";
 		}
 	}
 
 	public sealed class Add: InfixOperator
 	{
 		[UXConstructor]
-		public Add([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public Add([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right) : 
+			base(left, right, "+") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Marshal.Add(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return "+"; } } 
 	}
 
 	public sealed class Subtract: InfixOperator
 	{
 		[UXConstructor]
-		public Subtract([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public Subtract([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
+			base(left, right, "-") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Marshal.Subtract(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return "-"; } } 
 	}
 
 	public sealed class Multiply: InfixOperator
 	{
 		[UXConstructor]
-		public Multiply([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public Multiply([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
+			base(left, right, "*") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Marshal.Multiply(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return "*"; } } 
 	}
 
 	public sealed class Divide: InfixOperator
 	{
 		[UXConstructor]
-		public Divide([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public Divide([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
+			base(left, right,"/") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Marshal.Divide(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return "/"; } } 
 	}
 
 	public sealed class Conditional: TernaryOperator
 	{
 		[UXConstructor]
 		public Conditional([UXParameter("Condition")] Expression condition, [UXParameter("TrueValue")] Expression trueValue, [UXParameter("FalseValue")] Expression falseValue)
-			: base(condition, trueValue, falseValue) {}
+			: base(condition, trueValue, falseValue, Flags.Optional2) {}
 
 		protected override bool Compute(object cond, object trueVal, object falseVal, out object result)
 		{
@@ -81,8 +84,6 @@ namespace Fuse.Reactive
 			result = ((bool)Marshal.ToBool(cond)) ? trueVal : falseVal;
 			return true;
 		}
-
-		protected override bool IsThirdOptional { get { return true; } }
 
 		public override string ToString() 
 		{
@@ -93,33 +94,32 @@ namespace Fuse.Reactive
 	public sealed class LessThan: InfixOperator
 	{
 		[UXConstructor]
-		public LessThan([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public LessThan([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
+			base(left, right,"<") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Marshal.LessThan(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return "<"; } } 
 	}
 
 	public sealed class GreaterThan: InfixOperator
 	{
 		[UXConstructor]
-		public GreaterThan([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public GreaterThan([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right):
+			base(left, right, ">") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Marshal.GreaterThan(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return ">"; } } 
 	}
 
 	public sealed class GreaterOrEqual: InfixOperator
 	{
 		[UXConstructor]
-		public GreaterOrEqual([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public GreaterOrEqual([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right)
+			: base(left, right,">=") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = null;
@@ -127,14 +127,13 @@ namespace Fuse.Reactive
 			result = (bool)Marshal.GreaterThan(left, right) || (bool)Marshal.EqualTo(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return ">="; } } 
 	}
 
 	public sealed class LessOrEqual: InfixOperator
 	{
 		[UXConstructor]
-		public LessOrEqual([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public LessOrEqual([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right):
+			base(left, right,"<=") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = null;
@@ -142,27 +141,25 @@ namespace Fuse.Reactive
 			result = (bool)Marshal.LessThan(left, right) || (bool)Marshal.EqualTo(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return "<="; } } 
 	}
 
 	public sealed class Equal: InfixOperator
 	{
 		[UXConstructor]
-		public Equal([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public Equal([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
+			base(left, right,"==") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = Marshal.EqualTo(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return "=="; } } 
 	}
 
 	public sealed class NotEqual: InfixOperator
 	{
 		[UXConstructor]
-		public NotEqual([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public NotEqual([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
+			base(left, right, "!=") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = null;
@@ -170,14 +167,13 @@ namespace Fuse.Reactive
 			result = !(bool)Marshal.EqualTo(left, right);
 			return true;
 		}
-
-		public override string Symbol { get { return "!="; } } 
 	}
 
 	public sealed class LogicalAnd: InfixOperator
 	{
 		[UXConstructor]
-		public LogicalAnd([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public LogicalAnd([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
+			base(left, right, "&&") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = null;
@@ -185,14 +181,13 @@ namespace Fuse.Reactive
 			result = (bool)Marshal.ToBool(left) && (bool)Marshal.ToBool(right);
 			return true;
 		}
-
-		public override string Symbol { get { return "&&"; } } 
 	}
 
 	public sealed class LogicalOr: InfixOperator
 	{
 		[UXConstructor]
-		public LogicalOr([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): base(left, right) {}
+		public LogicalOr([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right): 
+			base(left, right, "||") {}
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = null;
@@ -200,8 +195,6 @@ namespace Fuse.Reactive
 			result = (bool)Marshal.ToBool(left) || (bool)Marshal.ToBool(right);
 			return true;
 		}
-
-		public override string Symbol { get { return "||"; } } 
 	}
-
+	
 }

--- a/Source/Fuse.Reactive.Expressions/QuaternaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/QuaternaryOperator.uno
@@ -33,9 +33,9 @@ namespace Fuse.Reactive
 		protected virtual bool IsThirdOptional { get { return false; } }
 		protected virtual bool IsFourthOptional { get { return false; } }
 
-		protected virtual bool Compute(object first, object second, object third, object fourth, out object result)
+		protected virtual bool TryCompute(object first, object second, object third, object fourth, out object result)
 		{
-			Fuse.Diagnostics.Deprecated( " No `Compute`, or a deprecated form, overriden. Migrate your code to override the one with `bool` return. ", this );
+			Fuse.Diagnostics.Deprecated( " No `TryCompute`, or a deprecated form, overriden. Migrate your code to override the one with `bool` return. ", this );
 			result = Compute(first, second, third, fourth);
 			return true;
 		}
@@ -43,9 +43,9 @@ namespace Fuse.Reactive
 		/** @deprecated Override the other `Compute` function. 2017-11-29 */
 		protected virtual object Compute(object first, object second, object third, object fourth) { return null; }
 		
-		protected override sealed bool Compute(Argument[] args, out object result)
+		protected override sealed bool TryCompute(Argument[] args, out object result)
 		{
-			return Compute(args[0].Value, args[1].Value, args[2].Value, args[3].Value, out result);
+			return TryCompute(args[0].Value, args[1].Value, args[2].Value, args[3].Value, out result);
 		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/StringFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/StringFunctions.uno
@@ -6,7 +6,7 @@ namespace Fuse.Reactive
 	public sealed class ToUpper: UnaryOperator
 	{
 		[UXConstructor]
-		public ToUpper([UXParameter("Value")] Expression value): base(value) {}
+		public ToUpper([UXParameter("Value")] Expression value): base(value,"toUpper") {}
 		protected override bool Compute(object s, out object result)
 		{
 			result = null;
@@ -15,28 +15,19 @@ namespace Fuse.Reactive
 			return true;
 		}
 
-		public override string ToString()
-		{
-			return "toUpper(" + Operand + ")";
-		}
 	}
 
 	[UXFunction("toLower")]
 	public sealed class ToLower: UnaryOperator
 	{
 		[UXConstructor]
-		public ToLower([UXParameter("Value")] Expression value): base(value) {}
+		public ToLower([UXParameter("Value")] Expression value): base(value, "toLower") {}
 		protected override bool Compute(object s, out object result)
 		{
 			result = null;
 			if (s == null) return false;
 			result = s.ToString().ToLower();
 			return true;
-		}
-
-		public override string ToString()
-		{
-			return "toLower(" + Operand + ")";
 		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/StringFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/StringFunctions.uno
@@ -7,7 +7,7 @@ namespace Fuse.Reactive
 	{
 		[UXConstructor]
 		public ToUpper([UXParameter("Value")] Expression value): base(value,"toUpper") {}
-		protected override bool Compute(object s, out object result)
+		protected override bool TryCompute(object s, out object result)
 		{
 			result = null;
 			if (s == null) return false;
@@ -22,7 +22,7 @@ namespace Fuse.Reactive
 	{
 		[UXConstructor]
 		public ToLower([UXParameter("Value")] Expression value): base(value, "toLower") {}
-		protected override bool Compute(object s, out object result)
+		protected override bool TryCompute(object s, out object result)
 		{
 			result = null;
 			if (s == null) return false;

--- a/Source/Fuse.Reactive.Expressions/Subscription.uno
+++ b/Source/Fuse.Reactive.Expressions/Subscription.uno
@@ -3,13 +3,18 @@ using Uno.Collections;
 
 namespace Fuse.Reactive
 {
-	/** Appropriate base clase for expression operand subscriptions. 
+	/** Using this class directly is unusual. `ComputeExpression` is the preferred option for functions, and `ExpressionListener` for when that doesn't apply.
+	
+		Relying on this behaviour is bad. The Observable support was only intended for bindings. All other 
+		values should use IExpression's facilities. The unintended support may be removed in the future.
 
 		Implements `IListener`, and forward incoming values to the protected `OnNewData` method.
 		If the incoming value is an observable, a subscription is created and the value of that observable
 		is forwarded to the `OnNewData` method instead.
 
-		Extenders should override `OnNewData()` and `Dispose()`.
+		Extenders should override `OnNewData()`, `OnLostData` and `Dispose()`.
+		
+		@hide
 	*/
 	public abstract class InnerListener: IDisposable, IListener
 	{
@@ -18,7 +23,7 @@ namespace Fuse.Reactive
 
 		IDisposable _diag;
 
-		public void SetDiagnostic(string message, IExpression source)
+		public void SetDiagnostic(string message, object source)
 		{
 			ClearDiagnostic();
 			_diag = Diagnostics.ReportTemporalUserWarning(message, source);

--- a/Source/Fuse.Reactive.Expressions/TernaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/TernaryOperator.uno
@@ -31,19 +31,19 @@ namespace Fuse.Reactive
 		protected virtual bool IsSecondOptional { get { return false; } }
 		protected virtual bool IsThirdOptional { get { return false; } }
 
-		protected virtual bool Compute(object first, object second, object third, out object result)
+		protected virtual bool TryCompute(object first, object second, object third, out object result)
 		{
-			Fuse.Diagnostics.Deprecated( " No `Compute`, or a deprecated form, overriden. Migrate your code to override the one with `bool` return. ", this );
+			Fuse.Diagnostics.Deprecated( " No `TryCompute`, or a deprecated form, overriden. Migrate your code to override the one with `bool` return. ", this );
 			result = Compute(first, second, third);
 			return true;
 		}
 		
-		/** @deprecated Override the other `Compute` function. 2017-11-29 */
+		/** @deprecated Override the `TryCompute` function. 2017-11-29 */
 		protected virtual object Compute(object first, object second, object third) { return null; }
 
-		protected override sealed bool Compute(Argument[] args, out object result)
+		protected override sealed bool TryCompute(Argument[] args, out object result)
 		{
-			return Compute(args[0].Value, args[1].Value, args[2].Value, out result);
+			return TryCompute(args[0].Value, args[1].Value, args[2].Value, out result);
 		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/TernaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/TernaryOperator.uno
@@ -4,28 +4,29 @@ using Uno.Collections;
 
 namespace Fuse.Reactive
 {
-	/* This class is part of a set of classes: UnaryOperator, BinaryOperator, TernaryOperator, QuaternaryOperator.
-		If you modify one you'll likely need to modify all four. */
-		
-	/** Optimized base class for reactive functions/operators that take a three arguments/operands. */
-	public abstract class TernaryOperator: Expression
+	/** Base class for reactive functions/operators that take three arguments/operands. */
+	public abstract class TernaryOperator: ComputeExpression
 	{
-		public Expression First { get; private set; }
-		public Expression Second { get; private set; }
-		public Expression Third { get; private set; }
+		public Expression First { get { return GetArgument(0); } }
+		public Expression Second { get { return GetArgument(1); } }
+		public Expression Third { get { return GetArgument(2); } }
 
-		protected TernaryOperator(Expression first, Expression second, Expression third)
+		protected TernaryOperator(Expression first, Expression second, Expression third,
+				Flags flags = Flags.DeprecatedVirtualFlags )
+			: base( new Expression[]{ first, second, third }, flags )
 		{
-			First = first;
-			Second = second;
-			Third = third;
 		}
 
-		public override IDisposable Subscribe(IContext context, IListener listener)
+		internal override Flags GetFlags()
 		{
-			return Subscription.Create(this, context, listener);
+			return Flags.None |
+				(IsFirstOptional ? Flags.Optional0 : Flags.None) |
+				(IsSecondOptional ? Flags.Optional1 : Flags.None) |
+				(IsThirdOptional ? Flags.Optional2 : Flags.None);
 		}
+		
 
+		/**  DEPRECATED: 2017-12-14  Use flags in constructor instead. These virtuals are only used if DeprecatedVirtualFlags specified, and only at initialization of subscription. */
 		protected virtual bool IsFirstOptional { get { return false; } }
 		protected virtual bool IsSecondOptional { get { return false; } }
 		protected virtual bool IsThirdOptional { get { return false; } }
@@ -40,122 +41,9 @@ namespace Fuse.Reactive
 		/** @deprecated Override the other `Compute` function. 2017-11-29 */
 		protected virtual object Compute(object first, object second, object third) { return null; }
 
-		class Subscription: InnerListener
+		protected override sealed bool Compute(Argument[] args, out object result)
 		{
-			readonly TernaryOperator _to;
-			object _first, _second, _third;
-			bool _hasFirst, _hasSecond, _hasThird;
-			bool _hasData;
-
-			IDisposable _firstSub;
-			IDisposable _secondSub;
-			IDisposable _thirdSub;
-
-			IListener _listener;
-			
-			protected Subscription(TernaryOperator to, IListener listener)
-			{
-				_to = to;
-				_listener = listener;
-			}
-
-			public static Subscription Create(TernaryOperator to, IContext context, IListener listener)
-			{
-				var sub = new Subscription(to, listener);
-				sub.Init(context);
-				return sub;
-			}
-
-			/** Must be called by subclasses at the end of constructor, or when fully initialized.
-				This avoids race condition if subscriptions call back synchronously. */
-			protected void Init(IContext context)
-			{
-				_firstSub = _to.First.Subscribe(context, this);
-				_secondSub = _to.Second.Subscribe(context, this);
-				_thirdSub = _to.Third.Subscribe(context, this);
-				UpdateOperands(); //in case all optional
-			}
-
-			protected override void OnNewData(IExpression source, object value)
-			{
-				if (source == _to.First) { _hasFirst = true; _first = value; }
-				if (source == _to.Second) { _hasSecond = true; _second = value; }
-				if (source == _to.Third) { _hasThird = true; _third = value; }
-				UpdateOperands();
-			}
-			
-			protected override void OnLostData(IExpression source)
-			{
-				if (source == _to.First) { _hasFirst = false; _first = null; }
-				if (source == _to.Second) { _hasSecond = false; _second = null; }
-				if (source == _to.Third) { _hasThird = false; _third = null; }
-				UpdateOperands();
-			}
-			
-			void ClearData()
-			{
-				if (_hasData)
-				{
-					_hasData = false;
-					_listener.OnLostData(_to);
-				}
-			}
-			
-			void UpdateOperands()
-			{
-				ClearDiagnostic();
-				
-				try
-				{
-					if ((_hasFirst || _to.IsFirstOptional) && (_hasSecond || _to.IsSecondOptional) && 
-						(_hasThird || _to.IsThirdOptional))
-					{
-						object result;
-						if (_to.Compute(_first, _second, _third, out result))
-						{
-							_hasData = true;
-							_listener.OnNewData(_to, result);
-						} 
-						else
-						{
-							Fuse.Diagnostics.UserWarning( "Failed to compute value for (" +
-								_first +", " + _second + ", " + _third, _to );
-							ClearData();
-						}
-					}
-					else
-					{
-						ClearData();
-					}
-				}
-				catch (MarshalException me)
-				{
-					SetDiagnostic(me.Message, _to);
-				}
-			}
-
-			public override void Dispose()
-			{
-				base.Dispose();
-
-				if (_firstSub != null)
-				{
-					_firstSub.Dispose();
-					_firstSub = null;
-				}
-				if (_secondSub != null)
-				{
-					_secondSub.Dispose();
-					_secondSub = null;
-				}
-				if (_thirdSub != null)
-				{
-					_thirdSub.Dispose();
-					_thirdSub = null;
-				}
-				_listener = null;
-			}
+			return Compute(args[0].Value, args[1].Value, args[2].Value, out result);
 		}
 	}
 }
-

--- a/Source/Fuse.Reactive.Expressions/Tests/BinaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/BinaryOperator.Test.uno
@@ -82,7 +82,7 @@ namespace Fuse.Reactive.Test
 			: base(left, right, flags)
 		{}
 		
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{	
 			//for Error test
 			if (right == "triggerBad")
@@ -104,7 +104,7 @@ namespace Fuse.Reactive.Test
 			: base(left, right, Flags.Optional1)
 		{}
 			
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = left.ToString() + (right == null ? "+" : right.ToString());
 			return true;
@@ -119,7 +119,7 @@ namespace Fuse.Reactive.Test
 			: base(left, right, Flags.Optional0 | Flags.Optional1)
 		{}
 		
-		protected override bool Compute(object left, object right, out object result)
+		protected override bool TryCompute(object left, object right, out object result)
 		{
 			result = (left == null ? "+" : left.ToString()) + (right == null ? "+" : right.ToString());
 			return true;

--- a/Source/Fuse.Reactive.Expressions/Tests/BinaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/BinaryOperator.Test.uno
@@ -74,9 +74,14 @@ namespace Fuse.Reactive.Test
 	{
 		[UXConstructor]
 		public BinJoin([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right)
-			: base(left, right)
+			: base(left, right, Flags.None)
 		{}
 			
+		protected BinJoin([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right,
+			Flags flags)
+			: base(left, right, flags)
+		{}
+		
 		protected override bool Compute(object left, object right, out object result)
 		{	
 			//for Error test
@@ -96,11 +101,9 @@ namespace Fuse.Reactive.Test
 	{
 		[UXConstructor]
 		public BinJoinR([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right)
-			: base(left, right)
+			: base(left, right, Flags.Optional1)
 		{}
 			
-		protected override bool IsRightOptional { get { return true; } }
-		
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = left.ToString() + (right == null ? "+" : right.ToString());
@@ -113,21 +116,13 @@ namespace Fuse.Reactive.Test
 	{
 		[UXConstructor]
 		public BinJoinLR([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right)
-			: base(left, right)
+			: base(left, right, Flags.Optional0 | Flags.Optional1)
 		{}
-			
-		protected override bool IsLeftOptional { get { return true; } }
-		protected override bool IsRightOptional { get { return true; } }
 		
 		protected override bool Compute(object left, object right, out object result)
 		{
 			result = (left == null ? "+" : left.ToString()) + (right == null ? "+" : right.ToString());
 			return true;
-		}
-		
-		protected override void OnLostOperands(IListener listener)
-		{
-			Fuse.Diagnostics.InternalError( "shouldn't happen since both are optional" );
 		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/Tests/QuaternaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/QuaternaryOperator.Test.uno
@@ -96,9 +96,14 @@ namespace Fuse.Reactive.Test
 		[UXConstructor]
 		public QuaJoin([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
 			[UXParameter("Third")] Expression third, [UXParameter("Fourth")] Expression fourth)
-			: base(first, second, third, fourth)
+			: base(first, second, third, fourth, Flags.None)
 		{}
 			
+		protected QuaJoin([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
+			[UXParameter("Third")] Expression third, [UXParameter("Fourth")] Expression fourth, Flags flags)
+			: base(first, second, third, fourth, flags)
+		{}
+		
 		protected override bool Compute(object first, object second, object third, object fourth, out object result)
 		{
 			//special case for Error test (as we had no actual QuaternaryOperator's to test)
@@ -122,10 +127,8 @@ namespace Fuse.Reactive.Test
 		[UXConstructor]
 		public QuaJoin1([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
 			[UXParameter("Third")] Expression third, [UXParameter("Fourth")] Expression fourth)
-			: base(first, second, third, fourth)
+			: base(first, second, third, fourth, Flags.Optional0)
 		{}
-			
-		protected override bool IsFirstOptional { get { return true; } }
 	}
 	
 	[UXFunction("_quaJoin2")]
@@ -134,10 +137,8 @@ namespace Fuse.Reactive.Test
 		[UXConstructor]
 		public QuaJoin2([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
 			[UXParameter("Third")] Expression third, [UXParameter("Fourth")] Expression fourth)
-			: base(first, second, third, fourth)
+			: base(first, second, third, fourth, Flags.Optional1)
 		{}
-			
-		protected override bool IsSecondOptional { get { return true; } }
 	}
 
 	[UXFunction("_quaJoin3")]
@@ -146,10 +147,8 @@ namespace Fuse.Reactive.Test
 		[UXConstructor]
 		public QuaJoin3([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
 			[UXParameter("Third")] Expression third, [UXParameter("Fourth")] Expression fourth)
-			: base(first, second, third, fourth)
+			: base(first, second, third, fourth, Flags.Optional2)
 		{}
-			
-		protected override bool IsThirdOptional { get { return true; } }
 	}
 
 	[UXFunction("_quaJoin4")]
@@ -158,9 +157,7 @@ namespace Fuse.Reactive.Test
 		[UXConstructor]
 		public QuaJoin4([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
 			[UXParameter("Third")] Expression third, [UXParameter("Fourth")] Expression fourth)
-			: base(first, second, third, fourth)
+			: base(first, second, third, fourth, Flags.Optional3)
 		{}
-			
-		protected override bool IsFourthOptional { get { return true; } }
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/Tests/QuaternaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/QuaternaryOperator.Test.uno
@@ -104,7 +104,7 @@ namespace Fuse.Reactive.Test
 			: base(first, second, third, fourth, flags)
 		{}
 		
-		protected override bool Compute(object first, object second, object third, object fourth, out object result)
+		protected override bool TryCompute(object first, object second, object third, object fourth, out object result)
 		{
 			//special case for Error test (as we had no actual QuaternaryOperator's to test)
 			if (fourth == "triggerBad")

--- a/Source/Fuse.Reactive.Expressions/Tests/TernaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/TernaryOperator.Test.uno
@@ -84,9 +84,14 @@ namespace Fuse.Reactive.Test
 		[UXConstructor]
 		public TerJoin([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
 			[UXParameter("Third")] Expression third)
-			: base(first, second, third)
+			: base(first, second, third, Flags.None)
 		{}
 			
+		protected TerJoin([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
+			[UXParameter("Third")] Expression third, Flags flags)
+			: base(first, second, third, flags)
+		{}
+		
 		protected override bool Compute(object first, object second, object third, out object result)
 		{
 			result = (first == null ? "*" : first.ToString()) +
@@ -102,10 +107,8 @@ namespace Fuse.Reactive.Test
 		[UXConstructor]
 		public TerJoin1([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
 			[UXParameter("Third")] Expression third)
-			: base(first, second, third)
+			: base(first, second, third, Flags.Optional0)
 		{}
-			
-		protected override bool IsFirstOptional { get { return true; } }
 	}
 	
 	[UXFunction("_terJoin2")]
@@ -114,10 +117,8 @@ namespace Fuse.Reactive.Test
 		[UXConstructor]
 		public TerJoin2([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
 			[UXParameter("Third")] Expression third)
-			: base(first, second, third)
+			: base(first, second, third, Flags.Optional1)
 		{}
-			
-		protected override bool IsSecondOptional { get { return true; } }
 	}
 	
 	[UXFunction("_terJoin3")]
@@ -126,10 +127,8 @@ namespace Fuse.Reactive.Test
 		[UXConstructor]
 		public TerJoin3([UXParameter("First")] Expression first, [UXParameter("Second")] Expression second,
 			[UXParameter("Third")] Expression third)
-			: base(first, second, third)
+			: base(first, second, third, Flags.Optional2)
 		{}
-			
-		protected override bool IsThirdOptional { get { return true; } }
 	}
 	
 }

--- a/Source/Fuse.Reactive.Expressions/Tests/TernaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/TernaryOperator.Test.uno
@@ -92,7 +92,7 @@ namespace Fuse.Reactive.Test
 			: base(first, second, third, flags)
 		{}
 		
-		protected override bool Compute(object first, object second, object third, out object result)
+		protected override bool TryCompute(object first, object second, object third, out object result)
 		{
 			result = (first == null ? "*" : first.ToString()) +
 				(second == null ? "*" : second.ToString()) +

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/UnaryOperator.Basic.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/UnaryOperator.Basic.ux
@@ -1,0 +1,7 @@
+<Panel ux:Class="UX.UnaryOperator.Basic">
+	<FuseTest.Data Value=" 'hi' " ux:Name="v"/>
+	
+	<FuseTest.DudElement StringValue="{= _unJoin('ab') }" ux:Name="a"/>
+	<FuseTest.DudElement StringValue="{= _unJoin({none}) ?? 'x' }" ux:Name="b"/>
+	<FuseTest.DudElement StringValue="{= _unJoin({v}) }" ux:Name="c"/>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/UnaryOperator.Deprecated.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/UnaryOperator.Deprecated.ux
@@ -1,0 +1,5 @@
+<Panel ux:Class="UX.UnaryOperator.Deprecated">
+	<Let ux:Name="a" Value="( one: 'abc', two: 'def') "/>
+	<FuseTest.DudElement ObjectValue="_unDep({a}.one)" ux:Name="d1"/>
+	<FuseTest.DudElement ObjectValue="_unDep({a})" ux:Name="d2"/>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UnaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/UnaryOperator.Test.uno
@@ -1,0 +1,57 @@
+using Uno;
+using Uno.UX;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Reactive.Test
+{
+	public class UnaryOperatorTest : TestBase
+	{
+		[Test]
+		//tests the deprecated functionality, since it's weird, and not covered by normal unary tests
+		public void Deprecated()
+		{
+			using (var dg = new RecordDiagnosticGuard())
+			{
+				var p = new UX.UnaryOperator.Deprecated();
+				using (var root = TestRootPanel.CreateWithChild(p))
+				{
+					Assert.AreEqual( "abc", p.d1.ObjectValue);
+					
+					p.a.Value = null;
+					root.PumpDeferred();
+					Assert.AreEqual( "lost", p.d1.ObjectValue);
+					Assert.AreEqual( "null", p.d2.ObjectValue);
+				
+					var msgs = dg.DequeueAll();
+					Assert.IsTrue(msgs.Count > 0);
+					for (int i=0; i < msgs.Count; ++i)
+						Assert.IsTrue( msgs[i].Message.IndexOf( "deprecated" ) != -1);
+				}
+			}
+		}
+	}
+	
+	[UXFunction("_unDep")]
+	class UnDep : UnaryOperator
+	{
+		[UXConstructor]
+		public UnDep([UXParameter("Operand")] Expression op) : base(op)
+		{}
+		
+		protected override void OnNewOperand(IListener listener, object operand)
+		{
+			if (operand != null)
+				listener.OnNewData(this, operand);
+			else
+				listener.OnNewData(this, "null");
+		}
+		
+		protected override void OnLostOperand(IListener listener)
+		{
+			listener.OnNewData(this, "lost");
+		}
+	}
+	
+}

--- a/Source/Fuse.Reactive.Expressions/Tests/UnaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/UnaryOperator.Test.uno
@@ -31,6 +31,17 @@ namespace Fuse.Reactive.Test
 				}
 			}
 		}
+		
+		public void Basic()
+		{
+			var p = new UX.UnaryOperator.Basic();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( "[ab]", p.a.StringValue);
+				Assert.AreEqual( "x", p.b.StringValue);
+				Assert.AreEqual( "[hi]", p.c.StringValue);
+			}
+		}
 	}
 	
 	[UXFunction("_unDep")]
@@ -51,6 +62,22 @@ namespace Fuse.Reactive.Test
 		protected override void OnLostOperand(IListener listener)
 		{
 			listener.OnNewData(this, "lost");
+		}
+	}
+
+	
+	[UXFunction("_unJoin")]
+	class UnJoin : UnaryOperator
+	{
+		[UXConstructor]
+		public UnJoin([UXParameter("Operand")] Expression operand)
+			: base(operand, "_unJoin")
+		{}
+		
+		protected override bool Compute(object op, out object result)
+		{	
+			result = "[" + op.ToString() + "]";
+			return true;
 		}
 	}
 	

--- a/Source/Fuse.Reactive.Expressions/Tests/UnaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/UnaryOperator.Test.uno
@@ -74,7 +74,7 @@ namespace Fuse.Reactive.Test
 			: base(operand, "_unJoin")
 		{}
 		
-		protected override bool Compute(object op, out object result)
+		protected override bool TryCompute(object op, out object result)
 		{	
 			result = "[" + op.ToString() + "]";
 			return true;

--- a/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
@@ -27,26 +27,26 @@ namespace Fuse.Reactive
 			@param result the result of the computation
 			@return true if the value could be computed, false otherwise
 		*/
-		protected virtual bool Compute(object operand, out object result)
+		protected virtual bool TryCompute(object operand, out object result)
 		{
-			Fuse.Diagnostics.Deprecated( " No `Compute`, or a deprecated form, overriden. Migrate your code to override the one with `bool` return. ", this );
+			Fuse.Diagnostics.Deprecated( " No `TryCompute`, or a deprecated form, overriden. Migrate your code to override the one with `bool` return. ", this );
 			result = Compute(operand);
 			return true;
 		}
 		
-		/** @deprecated Override the other `Compute` function. 2017-11-29 */
+		/** @deprecated Override `TryCompute` function. 2017-11-29 */
 		protected virtual object Compute(object operand) { return null; }
 
-		protected override sealed bool Compute(Argument[] args, out object result)
+		protected override sealed bool TryCompute(Argument[] args, out object result)
 		{
-			return Compute(args[0].Value, out result);
+			return TryCompute(args[0].Value, out result);
 		}
 		
-		/** @deprecated Override `Compute` or don't derive from `UnaryOperator` if you need argument tracking (which is rare). The typical base would be `Expression` and create a `Subscription` derived from `ExpressionListener`. 2017-12-14 */
+		/** @deprecated Override `TryCompute` or don't derive from `UnaryOperator` if you need argument tracking (which is rare). The typical base would be `Expression` and create a `Subscription` derived from `ExpressionListener`. 2017-12-14 */
 		protected virtual void OnNewOperand(IListener listener, object operand)
 		{
 			object result;
-			if (Compute(operand, out result))
+			if (TryCompute(operand, out result))
 			{
 				listener.OnNewData(this, result);
 			}
@@ -71,7 +71,7 @@ namespace Fuse.Reactive
 	public sealed class Negate: UnaryOperator
 	{
 		public Negate([UXParameter("Operand")] Expression operand): base(operand) {}
-		protected override bool Compute(object operand, out object result)
+		protected override bool TryCompute(object operand, out object result)
 		{
 			result = Marshal.Multiply(operand, -1);
 			return true;

--- a/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
@@ -5,17 +5,20 @@ using Uno.Collections;
 namespace Fuse.Reactive
 {
 	/** Optimized base class for reactive functions/operators that take a single argument/operand. */
-	public abstract class UnaryOperator: Expression
+	public abstract class UnaryOperator: ComputeExpression
 	{
-		public Expression Operand { get; private set; }
-		protected UnaryOperator(Expression operand)
+		public Expression Operand { get { return GetArgument(0); } }
+		protected UnaryOperator(Expression operand, Flags flags = Flags.DeprecatedVirtualFlags )
+			: base( new Expression[]{ operand }, flags )
+		{ }
+			
+		protected UnaryOperator(Expression operand, string name, Flags flags = Flags.None)
+			: base( new Expression[]{ operand }, flags, name )
+		{ }
+		
+		internal override Flags GetFlags()
 		{
-			Operand = operand;
-		}
-
-		public override IDisposable Subscribe(IContext context, IListener listener)
-		{
-			return Subscription.Create(this, context, listener);
+			return IsOperandOptional ? Flags.Optional0 : Flags.None;
 		}
 
 		protected virtual bool IsOperandOptional { get { return false; } }
@@ -34,108 +37,9 @@ namespace Fuse.Reactive
 		/** @deprecated Override the other `Compute` function. 2017-11-29 */
 		protected virtual object Compute(object operand) { return null; }
 
-		protected virtual void OnNewOperand(IListener listener, object operand)
+		protected override sealed bool Compute(Argument[] args, out object result)
 		{
-			object result;
-			if (Compute(operand, out result))
-			{
-				listener.OnNewData(this, result);
-			}
-			else
-			{
-				Fuse.Diagnostics.UserWarning( "Failed to compute value: " + operand, this );
-				listener.OnLostData(this);
-			}
-		}
-		
-		protected virtual void OnLostOperand(IListener listener)
-		{
-			listener.OnLostData(this);
-		}
-		
-		protected class Subscription: InnerListener
-		{
-			UnaryOperator _uo;
-			IListener _listener;
-			object _value;
-			bool _hasValue, _hasData;
-
-			IDisposable _operandSub;
-			protected Subscription(UnaryOperator uo, IListener listener)
-			{
-				_uo = uo;
-				_listener = listener;
-			}
-
-			public static Subscription Create(UnaryOperator uo, IContext context, IListener listener)
-			{
-				var sub = new Subscription(uo, listener);
-				sub.Init(context);
-				return sub;
-			}
-
-			/** Must be called by subclasses at the end of constructor, or when fully initialized.
-				This avoids race condition if the subscription calls back synchronously. */
-			protected void Init(IContext context)
-			{
-				_operandSub = _uo.Operand.Subscribe(context, this);
-				UpdateOperands();
-			}
-
-			public override void Dispose()
-			{
-				base.Dispose();
-				if (_operandSub != null) _operandSub.Dispose();
-				_operandSub = null;
-			}
-
-			protected override void OnNewData(IExpression source, object value)
-			{
-				if (source == _uo.Operand) 
-				{ 
-					_hasValue = true; 
-					_value = value;
-				}
-				UpdateOperands();
-			}
-			
-			protected override void OnLostData(IExpression source)
-			{
-				if (source == _uo.Operand) 
-				{ 
-					_hasValue = false; 
-					_value = null; 
-				}
-				UpdateOperands();
-			}
-			
-			void UpdateOperands()
-			{
-				ClearDiagnostic();
-
-				try
-				{
-					if (_hasValue || _uo.IsOperandOptional)
-					{
-						_hasData = true;
-						_uo.OnNewOperand(_listener, _value);
-					}
-					else if (_hasData)
-					{
-						_hasData = false;
-						_uo.OnLostOperand(_listener);
-					}
-				}
-				catch (MarshalException me)
-				{
-					SetDiagnostic(me.Message, _uo);
-				}
-			}
-
-			protected void PushNewData(object value)
-			{
-				_listener.OnNewData(_uo, value);
-			}
+			return Compute(args[0].Value, out result);
 		}
 	}
 
@@ -149,4 +53,3 @@ namespace Fuse.Reactive
 		}
 	}
 }
-

--- a/Source/Fuse.Reactive.Expressions/VectorFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/VectorFunctions.uno
@@ -24,7 +24,7 @@ namespace Fuse.Reactive
 	class Array: IArray
 	{
 		object[] _items;
-		public Array(VarArgFunction.Argument[] args)
+		public Array(Expression.Argument[] args)
 		{
 			_items = new object[args.Length];
 			for (var i = 0; i < args.Length; i++)


### PR DESCRIPTION
This removes a lot of the redundant code from the expressions. It makes it simpler to implement new expressions, and fixes a few hidden defects in the previously divergent code.

Deprecations warnings will be produced at runtime in most cases (since it can't be detected statically).

There is one removal of old "technically public" API from UnaryOperator. A compatbile addition could be made, but it'd be messy, and those funcions should not have been exposed to begin with (they don't work correctly, nor did Binary/Ternary/QuaternaryOperator expose them).

I didn't manage to simplify all the bits I wanted yet, but this seems like a good merge point.

This PR contains:
- [x] Changelog
- [x] Documentation
- [ ] ~Tests~ Already covered
