### PR TITLE
Use standard conversion errors for operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Deprecated `UnaryOperator.OnNewOperand` and `OnLostOperand`.  These are part of a broken pattern of using unary expressions (and were not present on Binary/Ternary/QuaternaryOperator). You generally shouldn't need this, and should implement `Compute` instead. In the rare cases you need the vrituals you'll need to extend Expression and implement `Subscribe`, using `ExpressionListener` as a way to capture the correct functionality.
 - Moved `VarArgFunction.Argument` to `Expression.Argument`. It's in a base class so still has visibility in `VarArgFunction`.
 - `VarArgFunction.Subscription.OnNewData` and `OnLostData` have been sealed. They should not have been open for overriding before as it conflicts with the inner workings on the class. Only the `OnNewPartialArguments` and `OnNewArguments` should be overridden.
+- Improved error handling on several operators and math functions. Instead of exceptions these should produce the standard conversion/computation warnings for invalid types.
 
 ## Navigation
 - Fixed an issue with `Navigator.Pages` not registering pages correctly in certain initialization orders

--- a/Source/Fuse.Marshal/Computer.uno
+++ b/Source/Fuse.Marshal/Computer.uno
@@ -13,18 +13,6 @@ namespace Fuse
 
 	abstract class Computer
 	{
-		public abstract bool TryAdd(object a, object b, out object result);
-		public abstract bool TrySubtract(object a, object b, out object result);
-		public abstract bool TryMultiply(object a, object b, out object result);
-		public abstract bool TryDivide(object a, object b, out object result);
-		public abstract bool TryLessThan(object a, object b, out bool result);
-		public abstract bool TryLessOrEqual(object a, object b, out bool result);
-		public abstract bool TryGreaterThan(object a, object b, out bool result);
-		public abstract bool TryGreaterOrEqual(object a, object b, out bool result);
-		public abstract bool TryEqualTo(object a, object b, out bool result);
-		public abstract bool TryMin(object a, object b, out object result);
-		public abstract bool TryMax(object a, object b, out object result);
-		
 		public enum TypeOp
 		{
 			Add,
@@ -34,21 +22,7 @@ namespace Fuse
 			Min,
 			Max,
 		}
-		public bool TryOp( TypeOp op, object a, object b, out object result )
-		{
-			switch (op)
-			{
-				case TypeOp.Add: return TryAdd(a,b, out result);
-				case TypeOp.Subtract: return TrySubtract(a,b, out result);
-				case TypeOp.Multiply: return TryMultiply(a,b, out result);
-				case TypeOp.Divide: return TryDivide(a,b, out result);
-				case TypeOp.Min: return TryMin(a,b, out result);
-				case TypeOp.Max: return TryMax(a,b, out result);
-			}
-			
-			result = null;
-			return false;
-		}
+		public abstract bool TryOp( TypeOp op, object a, object b, out object result );
 		
 		public enum BoolOp
 		{
@@ -58,146 +32,19 @@ namespace Fuse
 			GreaterOrEqual,
 			EqualTo,
 		}
-		public bool TryOp( BoolOp op, object a, object b, out bool result )
-		{
-			switch (op)
-			{
-				case BoolOp.LessThan: return TryLessThan(a,b,out result);
-				case BoolOp.LessOrEqual: return TryLessOrEqual(a,b,out result);
-				case BoolOp.GreaterThan: return TryGreaterThan(a,b,out result);
-				case BoolOp.GreaterOrEqual: return TryGreaterOrEqual(a,b,out result);
-				case BoolOp.EqualTo: return TryEqualTo(a,b,out result);
-			}
-			
-			result = false;
-			return false;
-		}
+		public abstract bool TryOp( BoolOp op, object a, object b, out bool result );
 	}
 
 	abstract class Computer<T>: Computer
 	{
-		public bool TryConvert(object o, out T result)
+		public override bool TryOp( TypeOp op, object a, object b, out object result )
 		{
-			return Marshal.TryToType<T>(o, out result);
-		}
-
-		public sealed override bool TryAdd(object a, object b, out object result)
-		{ 
 			T ma = default(T);
 			T mb = default(T);
 			T tr = default(T);
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryAddImpl(ma,mb,out tr))
-			{
-				result = default(T);
-				return false;
-			}
-			result = tr;
-			return true;
-		}
-		public sealed override bool TrySubtract(object a, object b, out object result) 
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			T tr = default(T);
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TrySubtractImpl(ma,mb,out tr))
-			{
-				result = default(T);
-				return false;
-			}
-			result = tr;
-			return true;
-		}
-		public sealed override bool TryMultiply(object a, object b, out object result) 
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			T tr = default(T);
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryMultiplyImpl(ma,mb, out tr))
-			{
-				result = default(T);
-				return false;
-			}
-			result = tr;
-			return true;
-		}
-		public sealed override bool TryDivide(object a, object b, out object result)
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			T tr = default(T);
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryDivideImpl(ma,mb, out tr))
-			{
-				result = default(T);
-				return false;
-			}
-			result = tr;
-			return true;
-		}
-		public sealed override bool TryLessThan(object a, object b, out bool result)
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			result = false;
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
-				return false;
-			return TryLessThanImpl(ma,mb, out result);
-		}
-		public sealed override bool TryLessOrEqual(object a, object b, out bool result)
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			result = false;
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
-				return false;
-			return TryLessOrEqualImpl(ma,mb, out result);
-		}
-		public sealed override bool TryGreaterThan(object a, object b, out bool result)
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			result = false;
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
-				return false;
-			return TryGreaterThanImpl(ma,mb, out result);
-		}
-		public sealed override bool TryGreaterOrEqual(object a, object b, out bool result)
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			result = false;
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
-				return false;
-			return TryGreaterOrEqualImpl(ma,mb, out result);
-		}
-		public sealed override bool TryEqualTo(object a, object b, out bool result) 
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			result = false;
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
-				return false;
-			return TryEqualToImpl(ma,mb, out result);
-		}
-		public sealed override bool TryMin(object a, object b, out object result) 
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			T tr = default(T);
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryMinImpl(ma,mb, out tr))
-			{
-				result = default(T);
-				return false;
-			}
-			result = tr;
-			return true;
-		}
-		public sealed override bool TryMax(object a, object b, out object result) 
-		{ 
-			T ma = default(T);
-			T mb = default(T);
-			T tr = default(T);
-			result = default(T);
-			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryMaxImpl(ma,mb, out tr))
+			if (!Marshal.TryToType<T>(a, out ma) ||
+				!Marshal.TryToType<T>(b, out mb) ||
+				!TryOpImpl(op, ma, mb, out tr))
 			{
 				result = default(T);
 				return false;
@@ -206,88 +53,233 @@ namespace Fuse
 			return true;
 		}
 		
-		public virtual bool TryAddImpl(T a, T b, out T result) { result = default(T); return false; }
-		public virtual bool TrySubtractImpl(T a, T b, out T result) { result = default(T); return false; }
-		public virtual bool TryMultiplyImpl(T a, T b, out T result) { result = default(T); return false; }
-		public virtual bool TryDivideImpl(T a, T b, out T result) { result = default(T); return false; }
-		public virtual bool TryLessThanImpl(T a, T b, out bool result) { result = false; return false; }
-		public virtual bool TryLessOrEqualImpl(T a, T b, out bool result) { result = false; return false; }
-		public virtual bool TryGreaterThanImpl(T a, T b, out bool result) { result = false; return false; }
-		public virtual bool TryGreaterOrEqualImpl(T a, T b, out bool result) { result = false; return false; }
-		public virtual bool TryEqualToImpl(T a, T b, out bool result) { result = false; return false; }
-		public virtual bool TryMinImpl(T a, T b, out T result) { result = default(T); return false; }
-		public virtual bool TryMaxImpl(T a, T b, out T result) { result = default(T); return false; }
+		protected abstract bool TryOpImpl( TypeOp op, T a, T b, out T result );
+		
+		public bool TryConvert(object o, out T result)
+		{
+			return Marshal.TryToType<T>(o, out result);
+		}
+
+		public override bool TryOp( BoolOp op, object a, object b, out bool result)
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			result = false;
+			if (!Marshal.TryToType<T>(a, out ma) ||
+				!Marshal.TryToType<T>(b, out mb))
+				return false;
+			return TryOpImpl(op, ma,mb, out result);
+		}
+		
+		protected abstract bool TryOpImpl( BoolOp op, T a, T b, out bool result );
 	}
 
 	class StringComputer: Computer<string>
 	{
-		public override bool TryAddImpl(string a, string b, out string result) { result = a+b; return true; }
-		public override bool TryEqualToImpl(string a, string b, out bool result) { result = a==b; return true; }
+		protected override bool TryOpImpl( TypeOp op, string a, string b, out string result )
+		{
+			switch(op)
+			{
+				case TypeOp.Add: result = a + b; return true;
+			}
+			
+			result = null;
+			return false;
+		}
+		
+		protected override bool TryOpImpl( BoolOp op, string a, string b, out bool result )
+		{
+			switch(op)
+			{
+				case BoolOp.EqualTo: result = a == b; return true;
+			}
+			
+			result = false;
+			return false;
+		}
 	}
 
 	class NumberComputer: Computer<double>
 	{
-		public override bool TryAddImpl(double a, double b, out double result ) { result = a+b; return true; }
-		public override bool TrySubtractImpl(double a, double b, out double result ) { result = a-b; return true; }
-		public override bool TryMultiplyImpl(double a, double b, out double result) { result = a*b; return true; }
-		public override bool TryDivideImpl(double a, double b, out double result) { result = a/b; return true; }
-		public override bool TryLessThanImpl(double a, double b, out bool result ) { result = a<b; return true; }
-		public override bool TryLessOrEqualImpl(double a, double b, out bool result ) { result = a<=b; return true; }
-		public override bool TryGreaterThanImpl(double a, double b, out bool result ) { result =  a>b; return true; }
-		public override bool TryGreaterOrEqualImpl(double a, double b, out bool result ) { result = a>=b; return true; }
-		public override bool TryEqualToImpl(double a, double b, out bool result ) { result = a==b; return true; }
-		public override bool TryMinImpl(double a, double b, out double result) { result = Math.Min(a, b); return true; }
-		public override bool TryMaxImpl(double a, double b, out double result) { result = Math.Max(a, b); return true; }
+		protected override bool TryOpImpl( TypeOp op, double a, double b, out double result )
+		{
+			switch(op)
+			{
+				case TypeOp.Add: result = a + b; return true;
+				case TypeOp.Subtract: result = a - b; return true;
+				case TypeOp.Multiply: result = a * b; return true;
+				case TypeOp.Divide: result = a/b; return true;
+				case TypeOp.Min: result = Math.Min(a,b); return true;
+				case TypeOp.Max: result = Math.Max(a,b); return true;
+			}
+			
+			result = 0;
+			return false;
+		}
+		
+		protected override bool TryOpImpl( BoolOp op, double a, double b, out bool result )
+		{
+			switch(op)
+			{
+				case BoolOp.EqualTo: result = a == b; return true;
+				case BoolOp.LessThan: result = a < b; return true;
+				case BoolOp.LessOrEqual: result = a <= b; return true;
+				case BoolOp.GreaterThan: result = a > b; return true;
+				case BoolOp.GreaterOrEqual: result = a >= b; return true;
+			}
+			
+			result = false;
+			return false;
+		}
 	}
 
 	class SizeComputer: Computer<Size>
 	{
-		public override bool TryAddImpl(Size a, Size b, out Size result) { result = a+b; return true; }
-		public override bool TrySubtractImpl(Size a, Size b, out Size result) { result = a-b; return true; }
-		public override bool TryMultiplyImpl(Size a, Size b, out Size result) { result = a*b; return true; }
-		public override bool TryDivideImpl(Size a, Size b, out Size result) { result = a/b; return true; }
-		public override bool TryLessThanImpl(Size a, Size b, out bool result ) { result = a.Value < b.Value; return true; }
-		public override bool TryLessOrEqualImpl(Size a, Size b, out bool result ) { result = a.Value <= b.Value; return true; }
-		public override bool TryGreaterThanImpl(Size a, Size b, out bool result ) { result = a.Value > b.Value; return true; }
-		public override bool TryGreaterOrEqualImpl(Size a, Size b, out bool result ) { result = a.Value >= b.Value; return true; }
-		public override bool TryEqualToImpl(Size a, Size b, out bool result ) { result = a==b; return true; }
-		public override bool TryMinImpl(Size a, Size b, out Size result) { result = new Size(Math.Min(a.Value, b.Value), Size.Combine(a.Unit, b.Unit)); return true; }
-		public override bool TryMaxImpl(Size a, Size b, out Size result) { result = new Size(Math.Max(a.Value, b.Value), Size.Combine(a.Unit, b.Unit)); return true; }
+		protected override bool TryOpImpl( TypeOp op, Size a, Size b, out Size result )
+		{
+			switch(op)
+			{
+				case TypeOp.Add: result = a + b; return true;
+				case TypeOp.Subtract: result = a - b; return true;
+				case TypeOp.Multiply: result = a * b; return true;
+				case TypeOp.Divide: result = a/b; return true;
+				case TypeOp.Min: 
+					result = new Size(Math.Min(a.Value, b.Value), Size.Combine(a.Unit, b.Unit)); 
+					return true;
+				case TypeOp.Max:
+					result = new Size(Math.Max(a.Value, b.Value), Size.Combine(a.Unit, b.Unit)); 
+					return true;
+			}
+			
+			result =  new Size();
+			return false;
+		}
+	
+		protected override bool TryOpImpl( BoolOp op, Size a, Size b, out bool result )
+		{
+			switch(op)
+			{
+				case BoolOp.EqualTo: result = a == b; return true;
+				case BoolOp.LessThan: result = a.Value < b.Value; return true;
+				case BoolOp.LessOrEqual: result = a.Value <= b.Value; return true;
+				case BoolOp.GreaterThan: result = a.Value > b.Value; return true;
+				case BoolOp.GreaterOrEqual: result = a.Value >= b.Value; return true;
+			}
+			
+			result = false;
+			return false;
+		}
 	}
 
 	class Size2Computer: Computer<Size2>
 	{
-		public override bool TryAddImpl(Size2 a, Size2 b, out Size2 result) { result = a+b; return true; }
-		public override bool TrySubtractImpl(Size2 a, Size2 b, out Size2 result) { result = a-b; return true; }
-		public override bool TryMultiplyImpl(Size2 a, Size2 b, out Size2 result) { result = a*b; return true; }
-		public override bool TryDivideImpl(Size2 a, Size2 b, out Size2 result) { result = a/b; return true; }
-		public override bool TryEqualToImpl(Size2 a, Size2 b, out bool result ) { result = a==b; return true; }
+		protected override bool TryOpImpl( TypeOp op, Size2 a, Size2 b, out Size2 result )
+		{
+			switch(op)
+			{
+				case TypeOp.Add: result = a + b; return true;
+				case TypeOp.Subtract: result = a - b; return true;
+				case TypeOp.Multiply: result = a * b; return true;
+				case TypeOp.Divide: result = a/b; return true;
+			}
+			
+			result = new Size2();
+			return false;
+		}
+		
+		protected override bool TryOpImpl( BoolOp op, Size2 a, Size2 b, out bool result )
+		{
+			switch(op)
+			{
+				case BoolOp.EqualTo: result = a == b; return true;
+			}
+			
+			result = false;
+			return false;
+		}
 	}
 
 	class Float2Computer: Computer<float2>
 	{
-		public override bool TryAddImpl(float2 a, float2 b, out float2 result) { result = a+b; return true; }
-		public override bool TrySubtractImpl(float2 a, float2 b, out float2 result) { result = a-b; return true; }
-		public override bool TryMultiplyImpl(float2 a, float2 b, out float2 result) { result = a*b; return true; }
-		public override bool TryDivideImpl(float2 a, float2 b, out float2 result) { result = a/b; return true; }
-		public override bool TryEqualToImpl(float2 a, float2 b, out bool result ) { result = a==b; return true; }
+		protected override bool TryOpImpl( TypeOp op, float2 a, float2 b, out float2 result )
+		{
+			switch(op)
+			{
+				case TypeOp.Add: result = a + b; return true;
+				case TypeOp.Subtract: result = a - b; return true;
+				case TypeOp.Multiply: result = a * b; return true;
+				case TypeOp.Divide: result = a/b; return true;
+			}
+			
+			result = float2(0);
+			return false;
+		}
+		
+		protected override bool TryOpImpl( BoolOp op, float2 a, float2 b, out bool result )
+		{
+			switch(op)
+			{
+				case BoolOp.EqualTo: result = a == b; return true;
+			}
+			
+			result = false;
+			return false;
+		}
 	}
 
 	class Float3Computer: Computer<float3>
 	{
-		public override bool TryAddImpl(float3 a, float3 b, out float3 result) { result = a+b; return true; }
-		public override bool TrySubtractImpl(float3 a, float3 b, out float3 result) { result = a-b; return true; }
-		public override bool TryMultiplyImpl(float3 a, float3 b, out float3 result) { result = a*b; return true; }
-		public override bool TryDivideImpl(float3 a, float3 b, out float3 result) { result = a/b; return true; }
-		public override bool TryEqualToImpl(float3 a, float3 b, out bool result ) { result = a==b; return true; }
+		protected override bool TryOpImpl( TypeOp op, float3 a, float3 b, out float3 result )
+		{
+			switch(op)
+			{
+				case TypeOp.Add: result = a + b; return true;
+				case TypeOp.Subtract: result = a - b; return true;
+				case TypeOp.Multiply: result = a * b; return true;
+				case TypeOp.Divide: result = a/b; return true;
+			}
+			
+			result = float3(0);
+			return false;
+		}
+		
+		protected override bool TryOpImpl( BoolOp op, float3 a, float3 b, out bool result )
+		{
+			switch(op)
+			{
+				case BoolOp.EqualTo: result = a == b; return true;
+			}
+			
+			result = false;
+			return false;
+		}
 	}
 
 	class Float4Computer: Computer<float4>
 	{
-		public override bool TryAddImpl(float4 a, float4 b, out float4 result) { result = a+b; return true; }
-		public override bool TrySubtractImpl(float4 a, float4 b, out float4 result) { result = a-b; return true; }
-		public override bool TryMultiplyImpl(float4 a, float4 b, out float4 result) { result = a*b; return true; }
-		public override bool TryDivideImpl(float4 a, float4 b, out float4 result) { result = a/b; return true; }
-		public override bool TryEqualToImpl(float4 a, float4 b, out bool result ) { result = a==b; return true; }
+		protected override bool TryOpImpl( TypeOp op, float4 a, float4 b, out float4 result )
+		{
+			switch(op)
+			{
+				case TypeOp.Add: result = a + b; return true;
+				case TypeOp.Subtract: result = a - b; return true;
+				case TypeOp.Multiply: result = a * b; return true;
+				case TypeOp.Divide: result = a/b; return true;
+			}
+			
+			result = float4(0);
+			return false;
+		}
+		
+		protected override bool TryOpImpl( BoolOp op, float4 a, float4 b, out bool result )
+		{
+			switch(op)
+			{
+				case BoolOp.EqualTo: result = a == b; return true;
+			}
+			
+			result = false;
+			return false;
+		}
 	}
 }

--- a/Source/Fuse.Marshal/Computer.uno
+++ b/Source/Fuse.Marshal/Computer.uno
@@ -13,122 +13,233 @@ namespace Fuse
 
 	abstract class Computer
 	{
-		public abstract object Add(object a, object b);
-		public abstract object Subtract(object a, object b);
-		public abstract object Multiply(object a, object b);
-		public abstract object Divide(object a, object b);
-		public abstract bool LessThan(object a, object b);
-		public abstract bool LessOrEqual(object a, object b);
-		public abstract bool GreaterThan(object a, object b);
-		public abstract bool GreaterOrEqual(object a, object b);
-		public abstract bool EqualTo(object a, object b);
-		public abstract object Min(object a, object b);
-		public abstract object Max(object a, object b);
+		public abstract bool TryAdd(object a, object b, out object result);
+		public abstract bool TrySubtract(object a, object b, out object result);
+		public abstract bool TryMultiply(object a, object b, out object result);
+		public abstract bool TryDivide(object a, object b, out object result);
+		public abstract bool TryLessThan(object a, object b, out bool result);
+		public abstract bool TryLessOrEqual(object a, object b, out bool result);
+		public abstract bool TryGreaterThan(object a, object b, out bool result);
+		public abstract bool TryGreaterOrEqual(object a, object b, out bool result);
+		public abstract bool TryEqualTo(object a, object b, out bool result);
+		public abstract bool TryMin(object a, object b, out object result);
+		public abstract bool TryMax(object a, object b, out object result);
 	}
 
 	abstract class Computer<T>: Computer
 	{
-		public abstract T Convert(object o);
-		public sealed override object Add(object a, object b) { return Add(Convert(a), Convert(b)); }
-		public sealed override object Subtract(object a, object b) { return Subtract(Convert(a), Convert(b)); }
-		public sealed override object Multiply(object a, object b) { return Multiply(Convert(a), Convert(b)); }
-		public sealed override object Divide(object a, object b) { return Divide(Convert(a), Convert(b)); }
-		public sealed override bool LessThan(object a, object b) { return LessThan(Convert(a), Convert(b)); }
-		public sealed override bool LessOrEqual(object a, object b) { return LessOrEqual(Convert(a), Convert(b)); }
-		public sealed override bool GreaterThan(object a, object b) { return GreaterThan(Convert(a), Convert(b)); }
-		public sealed override bool GreaterOrEqual(object a, object b) { return GreaterOrEqual(Convert(a), Convert(b)); }
-		public sealed override bool EqualTo(object a, object b) { return EqualTo(Convert(a), Convert(b)); }
-		public sealed override object Min(object a, object b) { return Min(Convert(a), Convert(b)); }
-		public sealed override object Max(object a, object b) { return Max(Convert(a), Convert(b)); }
-		public virtual T Add(T a, T b) { throw new ComputeException("Add", a, b); }
-		public virtual T Subtract(T a, T b) { throw new ComputeException("Subtract", a, b); }
-		public virtual T Multiply(T a, T b) { throw new ComputeException("Multiply", a, b); }
-		public virtual T Divide(T a, T b) { throw new ComputeException("Divide", a, b); }
-		public virtual bool LessThan(T a, T b) { throw new ComputeException("LessThan", a, b); }
-		public virtual bool LessOrEqual(T a, T b) { throw new ComputeException("LessOrEqual", a, b); }
-		public virtual bool GreaterThan(T a, T b) { throw new ComputeException("GreaterThan", a, b); }
-		public virtual bool GreaterOrEqual(T a, T b) { throw new ComputeException("GreaterOrEqual", a, b); }
-		public virtual bool EqualTo(T a, T b) { throw new ComputeException("EqualTo", a, b); }
-		public virtual T Min(T a, T b) { throw new ComputeException("Min", a, b); }
-		public virtual T Max(T a, T b) { throw new ComputeException("Max", a, b); }
+		public bool TryConvert(object o, out T result)
+		{
+			return Marshal.TryToType<T>(o, out result);
+		}
+
+		public sealed override bool TryAdd(object a, object b, out object result)
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			T tr = default(T);
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryAddImpl(ma,mb,out tr))
+			{
+				result = default(T);
+				return false;
+			}
+			result = tr;
+			return true;
+		}
+		public sealed override bool TrySubtract(object a, object b, out object result) 
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			T tr = default(T);
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TrySubtractImpl(ma,mb,out tr))
+			{
+				result = default(T);
+				return false;
+			}
+			result = tr;
+			return true;
+		}
+		public sealed override bool TryMultiply(object a, object b, out object result) 
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			T tr = default(T);
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryMultiplyImpl(ma,mb, out tr))
+			{
+				result = default(T);
+				return false;
+			}
+			result = tr;
+			return true;
+		}
+		public sealed override bool TryDivide(object a, object b, out object result)
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			T tr = default(T);
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryDivideImpl(ma,mb, out tr))
+			{
+				result = default(T);
+				return false;
+			}
+			result = tr;
+			return true;
+		}
+		public sealed override bool TryLessThan(object a, object b, out bool result)
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			result = false;
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
+				return false;
+			return TryLessThanImpl(ma,mb, out result);
+		}
+		public sealed override bool TryLessOrEqual(object a, object b, out bool result)
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			result = false;
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
+				return false;
+			return TryLessOrEqualImpl(ma,mb, out result);
+		}
+		public sealed override bool TryGreaterThan(object a, object b, out bool result)
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			result = false;
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
+				return false;
+			return TryGreaterThanImpl(ma,mb, out result);
+		}
+		public sealed override bool TryGreaterOrEqual(object a, object b, out bool result)
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			result = false;
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
+				return false;
+			return TryGreaterOrEqualImpl(ma,mb, out result);
+		}
+		public sealed override bool TryEqualTo(object a, object b, out bool result) 
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			result = false;
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb))
+				return false;
+			return TryEqualToImpl(ma,mb, out result);
+		}
+		public sealed override bool TryMin(object a, object b, out object result) 
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			T tr = default(T);
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryMinImpl(ma,mb, out tr))
+			{
+				result = default(T);
+				return false;
+			}
+			result = tr;
+			return true;
+		}
+		public sealed override bool TryMax(object a, object b, out object result) 
+		{ 
+			T ma = default(T);
+			T mb = default(T);
+			T tr = default(T);
+			result = default(T);
+			if (!TryConvert(a,out ma) || !TryConvert(b, out mb) || !TryMaxImpl(ma,mb, out tr))
+			{
+				result = default(T);
+				return false;
+			}
+			result = tr;
+			return true;
+		}
+		
+		public virtual bool TryAddImpl(T a, T b, out T result) { result = default(T); return false; }
+		public virtual bool TrySubtractImpl(T a, T b, out T result) { result = default(T); return false; }
+		public virtual bool TryMultiplyImpl(T a, T b, out T result) { result = default(T); return false; }
+		public virtual bool TryDivideImpl(T a, T b, out T result) { result = default(T); return false; }
+		public virtual bool TryLessThanImpl(T a, T b, out bool result) { result = false; return false; }
+		public virtual bool TryLessOrEqualImpl(T a, T b, out bool result) { result = false; return false; }
+		public virtual bool TryGreaterThanImpl(T a, T b, out bool result) { result = false; return false; }
+		public virtual bool TryGreaterOrEqualImpl(T a, T b, out bool result) { result = false; return false; }
+		public virtual bool TryEqualToImpl(T a, T b, out bool result) { result = false; return false; }
+		public virtual bool TryMinImpl(T a, T b, out T result) { result = default(T); return false; }
+		public virtual bool TryMaxImpl(T a, T b, out T result) { result = default(T); return false; }
 	}
 
 	class StringComputer: Computer<string>
 	{
-		public override string Convert(object obj) { return obj.ToString(); }
-		public override string Add(string a, string b) { return a+b; }
-		public override bool EqualTo(string a, string b) { return a==b; }
+		public override bool TryAddImpl(string a, string b, out string result) { result = a+b; return true; }
+		public override bool TryEqualToImpl(string a, string b, out bool result) { result = a==b; return true; }
 	}
 
 	class NumberComputer: Computer<double>
 	{
-		public override double Convert(object obj) { return Marshal.ToDouble(obj); }
-		public override double Add(double a, double b) { return a+b; }
-		public override double Subtract(double a, double b) { return a-b; }
-		public override double Multiply(double a, double b) { return a*b; }
-		public override double Divide(double a, double b) { return a/b; }
-		public override bool LessThan(double a, double b) { return a<b; }
-		public override bool LessOrEqual(double a, double b) { return a<=b; }
-		public override bool GreaterThan(double a, double b) { return a>b; }
-		public override bool GreaterOrEqual(double a, double b) { return a>=b; }
-		public override bool EqualTo(double a, double b) { return a==b; }
-		public override double Min(double a, double b) { return Math.Min(a, b); }
-		public override double Max(double a, double b) { return Math.Max(a, b); }
+		public override bool TryAddImpl(double a, double b, out double result ) { result = a+b; return true; }
+		public override bool TrySubtractImpl(double a, double b, out double result ) { result = a-b; return true; }
+		public override bool TryMultiplyImpl(double a, double b, out double result) { result = a*b; return true; }
+		public override bool TryDivideImpl(double a, double b, out double result) { result = a/b; return true; }
+		public override bool TryLessThanImpl(double a, double b, out bool result ) { result = a<b; return true; }
+		public override bool TryLessOrEqualImpl(double a, double b, out bool result ) { result = a<=b; return true; }
+		public override bool TryGreaterThanImpl(double a, double b, out bool result ) { result =  a>b; return true; }
+		public override bool TryGreaterOrEqualImpl(double a, double b, out bool result ) { result = a>=b; return true; }
+		public override bool TryEqualToImpl(double a, double b, out bool result ) { result = a==b; return true; }
+		public override bool TryMinImpl(double a, double b, out double result) { result = Math.Min(a, b); return true; }
+		public override bool TryMaxImpl(double a, double b, out double result) { result = Math.Max(a, b); return true; }
 	}
 
 	class SizeComputer: Computer<Size>
 	{
-		public override Size Convert(object obj) { return Marshal.ToSize(obj); }
-		public override Size Add(Size a, Size b) { return a+b; }
-		public override Size Subtract(Size a, Size b) { return a-b; }
-		public override Size Multiply(Size a, Size b) { return a*b; }
-		public override Size Divide(Size a, Size b) { return a/b; }
-		public override bool LessThan(Size a, Size b) { return a.Value < b.Value; }
-		public override bool LessOrEqual(Size a, Size b) { return a.Value <= b.Value; }
-		public override bool GreaterThan(Size a, Size b) { return a.Value > b.Value; }
-		public override bool GreaterOrEqual(Size a, Size b) { return a.Value >= b.Value; }
-		public override bool EqualTo(Size a, Size b) { return a==b; }
-		public override Size Min(Size a, Size b) { return new Size(Math.Min(a.Value, b.Value), Size.Combine(a.Unit, b.Unit)); }
-		public override Size Max(Size a, Size b) { return new Size(Math.Max(a.Value, b.Value), Size.Combine(a.Unit, b.Unit)); }
+		public override bool TryAddImpl(Size a, Size b, out Size result) { result = a+b; return true; }
+		public override bool TrySubtractImpl(Size a, Size b, out Size result) { result = a-b; return true; }
+		public override bool TryMultiplyImpl(Size a, Size b, out Size result) { result = a*b; return true; }
+		public override bool TryDivideImpl(Size a, Size b, out Size result) { result = a/b; return true; }
+		public override bool TryLessThanImpl(Size a, Size b, out bool result ) { result = a.Value < b.Value; return true; }
+		public override bool TryLessOrEqualImpl(Size a, Size b, out bool result ) { result = a.Value <= b.Value; return true; }
+		public override bool TryGreaterThanImpl(Size a, Size b, out bool result ) { result = a.Value > b.Value; return true; }
+		public override bool TryGreaterOrEqualImpl(Size a, Size b, out bool result ) { result = a.Value >= b.Value; return true; }
+		public override bool TryEqualToImpl(Size a, Size b, out bool result ) { result = a==b; return true; }
+		public override bool TryMinImpl(Size a, Size b, out Size result) { result = new Size(Math.Min(a.Value, b.Value), Size.Combine(a.Unit, b.Unit)); return true; }
+		public override bool TryMaxImpl(Size a, Size b, out Size result) { result = new Size(Math.Max(a.Value, b.Value), Size.Combine(a.Unit, b.Unit)); return true; }
 	}
 
 	class Size2Computer: Computer<Size2>
 	{
-		public override Size2 Convert(object obj) { return Marshal.ToSize2(obj); }
-		public override Size2 Add(Size2 a, Size2 b) { return a+b; }
-		public override Size2 Subtract(Size2 a, Size2 b) { return a-b; }
-		public override Size2 Multiply(Size2 a, Size2 b) { return a*b; }
-		public override Size2 Divide(Size2 a, Size2 b) { return a/b; }
-		public override bool EqualTo(Size2 a, Size2 b) { return a==b; }
+		public override bool TryAddImpl(Size2 a, Size2 b, out Size2 result) { result = a+b; return true; }
+		public override bool TrySubtractImpl(Size2 a, Size2 b, out Size2 result) { result = a-b; return true; }
+		public override bool TryMultiplyImpl(Size2 a, Size2 b, out Size2 result) { result = a*b; return true; }
+		public override bool TryDivideImpl(Size2 a, Size2 b, out Size2 result) { result = a/b; return true; }
+		public override bool TryEqualToImpl(Size2 a, Size2 b, out bool result ) { result = a==b; return true; }
 	}
 
 	class Float2Computer: Computer<float2>
 	{
-		public override float2 Convert(object obj) { return Marshal.ToFloat2(obj); }
-		public override float2 Add(float2 a, float2 b) { return a+b; }
-		public override float2 Subtract(float2 a, float2 b) { return a-b; }
-		public override float2 Multiply(float2 a, float2 b) { return a*b; }
-		public override float2 Divide(float2 a, float2 b) { return a/b; }
-		public override bool EqualTo(float2 a, float2 b) { return a==b; }
+		public override bool TryAddImpl(float2 a, float2 b, out float2 result) { result = a+b; return true; }
+		public override bool TrySubtractImpl(float2 a, float2 b, out float2 result) { result = a-b; return true; }
+		public override bool TryMultiplyImpl(float2 a, float2 b, out float2 result) { result = a*b; return true; }
+		public override bool TryDivideImpl(float2 a, float2 b, out float2 result) { result = a/b; return true; }
+		public override bool TryEqualToImpl(float2 a, float2 b, out bool result ) { result = a==b; return true; }
 	}
 
 	class Float3Computer: Computer<float3>
 	{
-		public override float3 Convert(object obj) { return Marshal.ToFloat3(obj); }
-		public override float3 Add(float3 a, float3 b) { return a+b; }
-		public override float3 Subtract(float3 a, float3 b) { return a-b; }
-		public override float3 Multiply(float3 a, float3 b) { return a*b; }
-		public override float3 Divide(float3 a, float3 b) { return a/b; }
-		public override bool EqualTo(float3 a, float3 b) { return a==b; }
+		public override bool TryAddImpl(float3 a, float3 b, out float3 result) { result = a+b; return true; }
+		public override bool TrySubtractImpl(float3 a, float3 b, out float3 result) { result = a-b; return true; }
+		public override bool TryMultiplyImpl(float3 a, float3 b, out float3 result) { result = a*b; return true; }
+		public override bool TryDivideImpl(float3 a, float3 b, out float3 result) { result = a/b; return true; }
+		public override bool TryEqualToImpl(float3 a, float3 b, out bool result ) { result = a==b; return true; }
 	}
 
 	class Float4Computer: Computer<float4>
 	{
-		public override float4 Convert(object obj) { return Marshal.ToFloat4(obj); }
-		public override float4 Add(float4 a, float4 b) { return a+b; }
-		public override float4 Subtract(float4 a, float4 b) { return a-b; }
-		public override float4 Multiply(float4 a, float4 b) { return a*b; }
-		public override float4 Divide(float4 a, float4 b) { return a/b; }
-		public override bool EqualTo(float4 a, float4 b) { return a==b; }
+		public override bool TryAddImpl(float4 a, float4 b, out float4 result) { result = a+b; return true; }
+		public override bool TrySubtractImpl(float4 a, float4 b, out float4 result) { result = a-b; return true; }
+		public override bool TryMultiplyImpl(float4 a, float4 b, out float4 result) { result = a*b; return true; }
+		public override bool TryDivideImpl(float4 a, float4 b, out float4 result) { result = a/b; return true; }
+		public override bool TryEqualToImpl(float4 a, float4 b, out bool result ) { result = a==b; return true; }
 	}
 }

--- a/Source/Fuse.Marshal/Computer.uno
+++ b/Source/Fuse.Marshal/Computer.uno
@@ -24,6 +24,54 @@ namespace Fuse
 		public abstract bool TryEqualTo(object a, object b, out bool result);
 		public abstract bool TryMin(object a, object b, out object result);
 		public abstract bool TryMax(object a, object b, out object result);
+		
+		public enum TypeOp
+		{
+			Add,
+			Subtract,
+			Multiply,
+			Divide,
+			Min,
+			Max,
+		}
+		public bool TryOp( TypeOp op, object a, object b, out object result )
+		{
+			switch (op)
+			{
+				case TypeOp.Add: return TryAdd(a,b, out result);
+				case TypeOp.Subtract: return TrySubtract(a,b, out result);
+				case TypeOp.Multiply: return TryMultiply(a,b, out result);
+				case TypeOp.Divide: return TryDivide(a,b, out result);
+				case TypeOp.Min: return TryMin(a,b, out result);
+				case TypeOp.Max: return TryMax(a,b, out result);
+			}
+			
+			result = null;
+			return false;
+		}
+		
+		public enum BoolOp
+		{
+			LessThan,
+			LessOrEqual,
+			GreaterThan,
+			GreaterOrEqual,
+			EqualTo,
+		}
+		public bool TryOp( BoolOp op, object a, object b, out bool result )
+		{
+			switch (op)
+			{
+				case BoolOp.LessThan: return TryLessThan(a,b,out result);
+				case BoolOp.LessOrEqual: return TryLessOrEqual(a,b,out result);
+				case BoolOp.GreaterThan: return TryGreaterThan(a,b,out result);
+				case BoolOp.GreaterOrEqual: return TryGreaterOrEqual(a,b,out result);
+				case BoolOp.EqualTo: return TryEqualTo(a,b,out result);
+			}
+			
+			result = false;
+			return false;
+		}
 	}
 
 	abstract class Computer<T>: Computer

--- a/Source/Fuse.Marshal/Marshal.Compute.uno
+++ b/Source/Fuse.Marshal/Marshal.Compute.uno
@@ -43,260 +43,138 @@ namespace Fuse
 			return a;
 		}
 
-		public static bool TryAdd(object a, object b, out object result)
+		static bool TryOp(Computer.TypeOp op, object a, object b, out object result)
 		{
 			result = null;
 			if (a == null || b == null) return false;
 			a = TryConvertArrayToVector(a);
 			var ta = a.GetType();
 			var tb = b.GetType();
-
-			//TODO: doesn't the _computer handle this?
-			if (ta == typeof(string) || tb == typeof(string))
-			{
-				result = a.ToString() + b.ToString();
-				return true;
-			}
-			
 			var t = DominantType(ta, tb);
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.TryAdd(a, b, out result);
+				return c.TryOp(op, a, b, out result);
 			return false;
+		}
+		
+		public static bool TryAdd(object a, object b, out object result) 
+		{ return TryOp( Computer.TypeOp.Add, a, b, out result ); }
+		
+		public static bool TrySubtract(object a, object b, out object result) 
+		{ return TryOp( Computer.TypeOp.Subtract, a, b, out result ); }
+		
+		public static bool TryMultiply(object a, object b, out object result) 
+		{ return TryOp( Computer.TypeOp.Multiply, a, b, out result ); }
+		
+		public static bool TryDivide(object a, object b, out object result) 
+		{ return TryOp( Computer.TypeOp.Divide, a, b, out result ); }
+		
+		public static bool TryMin(object a, object b, out object result) 
+		{ return TryOp( Computer.TypeOp.Min, a, b, out result ); }
+		
+		public static bool TryMax(object a, object b, out object result) 
+		{ return TryOp( Computer.TypeOp.Max, a, b, out result ); }
+		
+		static bool TryOp(Computer.BoolOp op, object a, object b, out bool result)
+		{
+			result = false;
+			if (a == null || b == null) return false;
+			var t = DominantType(a.GetType(), b.GetType());
+
+			Computer c;
+			if (_computers.TryGetValue(t, out c)) 
+				return c.TryOp(op, a, b, out result);
+			return false;
+		}
+		
+		public static bool TryLessThan(object a, object b, out bool result)
+		{ return TryOp(Computer.BoolOp.LessThan, a, b, out result ); }
+		
+		public static bool TryLessOrEqual(object a, object b, out bool result)
+		{ return TryOp(Computer.BoolOp.LessOrEqual, a, b, out result ); }
+
+		public static bool TryGreaterThan(object a, object b, out bool result)
+		{ return TryOp(Computer.BoolOp.GreaterThan, a, b, out result ); }
+
+		public static bool TryGreaterOrEqual(object a, object b, out bool result)
+		{ return TryOp(Computer.BoolOp.GreaterOrEqual, a, b, out result ); }
+		
+		public static bool TryEqualTo(object a, object b, out bool result)
+		{ return TryOp(Computer.BoolOp.EqualTo, a, b, out result ); }
+
+
+		[Obsolete]
+		static object DepOp(Computer.TypeOp op, object a, object b)
+		{
+			object result = null;
+			if (!TryOp(op, a,b,out result))
+				throw new ComputeException("" + op, a, b);
+			return result;
 		}
 		
 		[Obsolete]
 		/** @deprecated Use TryAdd instead. 2018-01-02*/
 		public static object Add(object a, object b)
-		{
-			object result = null;
-			if (!TryAdd(a,b,out result))
-				throw new ComputeException("Add", a, b);
-			return result;
-		}
-
-		public static bool TrySubtract(object a, object b, out object result)
-		{
-			result = null;
-			if (a == null || b == null) return false;
-			a = TryConvertArrayToVector(a);
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TrySubtract(a, b, out result);
-			return false;
-		}
-			
+		{ return DepOp( Computer.TypeOp.Add, a, b); }
+		
 		[Obsolete]
-		/** @deprecated Use TrySubtract instead. 2018-01-02 */
+		/** @deprecated Use TrySubtract instead. 2018-01-02*/
 		public static object Subtract(object a, object b)
-		{
-			object result = null;
-			if (!TrySubtract(a,b,out result))
-				throw new ComputeException("Subtract", a, b);
-			return result;
-		}
-
-		public static bool TryMultiply(object a, object b, out object result)
-		{
-			result = null;
-			if (a == null || b == null) return false;
-			a = TryConvertArrayToVector(a);
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TryMultiply(a, b, out result);
-			return false;
-		}
-			
+		{ return DepOp( Computer.TypeOp.Subtract, a, b); }
+		
 		[Obsolete]
-		/** @deprecated Use TryMultiply instead. 2018-01-02 */
+		/** @deprecated Use TryMultiply instead. 2018-01-02*/
 		public static object Multiply(object a, object b)
-		{
-			object result;
-			if (!TryMultiply(a,b,out result))
-				throw new ComputeException("Multiply", a, b);
-			return result;
-		}
-
-		public static bool TryDivide(object a, object b, out object result)
-		{
-			result = null;
-			if (a == null || b == null) return false;
-			a = TryConvertArrayToVector(a);
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TryDivide(a, b, out result);
-			return true;
-		}
-			
+		{ return DepOp( Computer.TypeOp.Multiply, a, b); }
+		
 		[Obsolete]
-		/** @deprecated Use TryDivide instead. 2018-01-02 */
+		/** @deprecated Use TryDivide instead. 2018-01-02*/
 		public static object Divide(object a, object b)
+		{ return DepOp( Computer.TypeOp.Divide, a, b); }
+		
+		[Obsolete]
+		/** @deprecated Use TryMin instead. 2018-01-02*/
+		public static object Min(object a, object b)
+		{ return DepOp( Computer.TypeOp.Min, a, b); }
+		
+		[Obsolete]
+		/** @deprecated Use TryMax instead. 2018-01-02*/
+		public static object Max(object a, object b)
+		{ return DepOp( Computer.TypeOp.Max, a, b); }
+		
+		[Obsolete]
+		static object DepOp(Computer.BoolOp op, object a, object b)
 		{
-			object result;
-			if (!TryDivide(a,b,out result))
-				throw new ComputeException("Divide", a, b);
+			bool result;
+			if (!TryOp(op,a,b, out result))
+				throw new ComputeException("" + op, a, b);
 			return result;
-		}
-
-		public static bool TryLessThan(object a, object b, out bool result)
-		{
-			result = false;
-			if (a == null || b == null) return false;
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TryLessThan(a, b, out result);
-			return true;
 		}
 		
 		[Obsolete]
 		/** @deprecated Use TryLessThan instead. 2018-01-02 */
 		public static object LessThan(object a, object b)
-		{
-			bool result;
-			if (!TryLessThan(a,b, out result))
-				throw new ComputeException("LessThan", a, b);
-			return result;
-		}
-			
-		public static bool TryLessOrEqual(object a, object b, out bool result)
-		{
-			result = false;
-			if (a == null || b == null) return false;
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TryLessOrEqual(a, b, out result);
-			return true;
-		}
+		{ return DepOp(Computer.BoolOp.LessThan, a, b); }
 		
 		[Obsolete]
 		/** @deprecated Use TryLessOrEqual instead. 2018-01-02 */
 		public static object LessOrEqual(object a, object b)
-		{
-			bool result;
-			if (!TryLessOrEqual(a,b, out result))
-				throw new ComputeException("LessOrEqual", a, b);
-			return result;
-		}
-
-		public static bool TryGreaterThan(object a, object b, out bool result)
-		{
-			result = false;
-			if (a == null || b == null) return false;
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TryGreaterThan(a, b, out result);
-			return true;
-		}
+		{ return DepOp(Computer.BoolOp.LessOrEqual, a, b); }
 		
 		[Obsolete]
 		/** @deprecated Use TryGreaterThan instead. 2018-01-02 */
 		public static object GreaterThan(object a, object b)
-		{
-			bool result;
-			if (!TryGreaterThan(a,b, out result))
-				throw new ComputeException("GreaterThan", a, b);
-			return result;
-		}
-
-		public static bool TryGreaterOrEqual(object a, object b, out bool result)
-		{
-			result = false;
-			if (a == null || b == null) return false;
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TryGreaterOrEqual(a, b, out result);
-			return true;
-		}
+		{ return DepOp(Computer.BoolOp.GreaterThan, a, b); }
 		
 		[Obsolete]
 		/** @deprecated Use TryGreaterOrEqual instead. 2018-01-02 */
 		public static object GreaterOrEqual(object a, object b)
-		{
-			bool result;
-			if (!TryGreaterOrEqual(a,b, out result))
-				throw new ComputeException("GreaterOrEqual", a, b);
-			return result;
-		}
-		
-		public static bool TryEqualTo(object a, object b, out bool result)
-		{
-			result = false;
-			if (a == null || b == null) return false;
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TryEqualTo(a, b, out result);
-			return true;
-		}
+		{ return DepOp(Computer.BoolOp.GreaterOrEqual, a, b); }
 		
 		[Obsolete]
 		/** @deprecated Use TryEqualTo instead. 2018-01-02 */
 		public static object EqualTo(object a, object b)
-		{
-			bool result;
-			if (!TryEqualTo(a,b, out result))
-				throw new ComputeException("Equal", a, b);
-			return result;
-		}
-		
-		public static bool TryMin(object a, object b, out object result)
-		{
-			result = null;
-			if (a == null || b == null) return false;
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TryMin(a, b, out result);
-			return true;
-		}
-
-		[Obsolete]
-		/** @deprecated Use TryMin instead. 2018-01-02 */
-		public static object Min(object a, object b)
-		{
-			object result;
-			if (!TryMin(a,b,out result))
-				throw new ComputeException("Min", a, b);
-			return result;
-		}
-
-		public static bool TryMax(object a, object b, out object result)
-		{
-			result = null;
-			if (a == null || b == null) return false;
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.TryMax(a, b, out result);
-			return true;
-		}
-			
-		[Obsolete]
-		/** @deprecated Use TryMax instead. 2018-01-02 */
-		public static object Max(object a, object b)
-		{
-			object result;
-			if (!TryMax(a,b,out result))
-				throw new ComputeException("Max", a, b);
-			return result;
-		}
+		{ return DepOp(Computer.BoolOp.EqualTo, a, b); }
 	}
 }

--- a/Source/Fuse.Marshal/Marshal.Compute.uno
+++ b/Source/Fuse.Marshal/Marshal.Compute.uno
@@ -43,147 +43,238 @@ namespace Fuse
 			return a;
 		}
 
-		public static object Add(object a, object b)
+		public static bool TryAdd(object a, object b, out object result)
 		{
-			if (a == null || b == null) return null;
+			result = null;
+			if (a == null || b == null) return false;
 			a = TryConvertArrayToVector(a);
 			var ta = a.GetType();
 			var tb = b.GetType();
 
+			//TODO: doesn't the _computer handle this?
 			if (ta == typeof(string) || tb == typeof(string))
-				return a.ToString() + b.ToString();
+			{
+				result = a.ToString() + b.ToString();
+				return true;
+			}
 			
 			var t = DominantType(ta, tb);
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.Add(a, b);
+				return c.TryAdd(a, b, out result);
+			return false;
+		}
 			
-			throw new ComputeException("Add", a, b);
+		public static object Add(object a, object b)
+		{
+			object result = null;
+			if (!TryAdd(a,b,out result))
+				throw new ComputeException("Add", a, b);
+			return result;
 		}
 
+		public static bool TrySubtract(object a, object b, out object result)
+		{
+			result = null;
+			if (a == null || b == null) return false;
+			a = TryConvertArrayToVector(a);
+			var t = DominantType(a.GetType(), b.GetType());
+
+			Computer c;
+			if (_computers.TryGetValue(t, out c)) 
+				return c.TrySubtract(a, b, out result);
+			return false;
+		}
+			
 		public static object Subtract(object a, object b)
 		{
-			if (a == null || b == null) return null;
+			object result = null;
+			if (!TrySubtract(a,b,out result))
+				throw new ComputeException("Subtract", a, b);
+			return result;
+		}
+
+		public static bool TryMultiply(object a, object b, out object result)
+		{
+			result = null;
+			if (a == null || b == null) return false;
 			a = TryConvertArrayToVector(a);
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.Subtract(a, b);
-			
-			throw new ComputeException("Subtract", a, b);
+				return c.TryMultiply(a, b, out result);
+			return false;
 		}
-
+			
 		public static object Multiply(object a, object b)
 		{
-			if (a == null || b == null) return null;
+			object result;
+			if (!TryMultiply(a,b,out result))
+				throw new ComputeException("Multiply", a, b);
+			return result;
+		}
+
+		public static bool TryDivide(object a, object b, out object result)
+		{
+			result = null;
+			if (a == null || b == null) return false;
 			a = TryConvertArrayToVector(a);
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.Multiply(a, b);
-			
-			throw new ComputeException("Multiply", a, b);
+				return c.TryDivide(a, b, out result);
+			return true;
 		}
-
+			
 		public static object Divide(object a, object b)
 		{
-			if (a == null || b == null) return null;
-			a = TryConvertArrayToVector(a);
+			object result;
+			if (!TryDivide(a,b,out result))
+				throw new ComputeException("Divide", a, b);
+			return result;
+		}
+
+		public static bool TryLessThan(object a, object b, out bool result)
+		{
+			result = false;
+			if (a == null || b == null) return false;
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.Divide(a, b);
-			
-			throw new ComputeException("Divide", a, b);
+				return c.TryLessThan(a, b, out result);
+			return true;
 		}
-
+		
 		public static object LessThan(object a, object b)
 		{
-			if (a == null || b == null) return null;
+			bool result;
+			if (!TryLessThan(a,b, out result))
+				throw new ComputeException("LessThan", a, b);
+			return result;
+		}
+			
+		public static bool TryLessOrEqual(object a, object b, out bool result)
+		{
+			result = false;
+			if (a == null || b == null) return false;
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.LessThan(a, b);
-			
-			throw new ComputeException("LessThan", a, b);
+				return c.TryLessOrEqual(a, b, out result);
+			return true;
 		}
-
+		
 		public static object LessOrEqual(object a, object b)
 		{
-			if (a == null || b == null) return null;
+			bool result;
+			if (!TryLessOrEqual(a,b, out result))
+				throw new ComputeException("LessOrEqual", a, b);
+			return result;
+		}
+
+		public static bool TryGreaterThan(object a, object b, out bool result)
+		{
+			result = false;
+			if (a == null || b == null) return false;
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.LessOrEqual(a, b);
-			
-			throw new ComputeException("LessOrEqual", a, b);
+				return c.TryGreaterThan(a, b, out result);
+			return true;
 		}
-
-
+		
 		public static object GreaterThan(object a, object b)
 		{
-			if (a == null || b == null) return null;
+			bool result;
+			if (!TryGreaterThan(a,b, out result))
+				throw new ComputeException("GreaterThan", a, b);
+			return result;
+		}
+
+		public static bool TryGreaterOrEqual(object a, object b, out bool result)
+		{
+			result = false;
+			if (a == null || b == null) return false;
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.GreaterThan(a, b);
-			
-			throw new ComputeException("GreaterThan", a, b);
+				return c.TryGreaterOrEqual(a, b, out result);
+			return true;
 		}
-
+		
 		public static object GreaterOrEqual(object a, object b)
 		{
-			if (a == null || b == null) return null;
+			bool result;
+			if (!TryGreaterOrEqual(a,b, out result))
+				throw new ComputeException("GreaterOrEqual", a, b);
+			return result;
+		}
+		
+		public static bool TryEqualTo(object a, object b, out bool result)
+		{
+			result = false;
+			if (a == null || b == null) return false;
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.GreaterOrEqual(a, b);
-			
-			throw new ComputeException("GreaterOrEqual", a, b);
+				return c.TryEqualTo(a, b, out result);
+			return true;
 		}
-
+		
 		public static object EqualTo(object a, object b)
 		{
-			if (a == null || b == null) return null;
+			bool result;
+			if (!TryEqualTo(a,b, out result))
+				throw new ComputeException("Equal", a, b);
+			return result;
+		}
+		
+		public static bool TryMin(object a, object b, out object result)
+		{
+			result = null;
+			if (a == null || b == null) return false;
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.EqualTo(a, b);
-			
-			throw new ComputeException("EqualTo", a, b);
+				return c.TryMin(a, b, out result);
+			return true;
 		}
 
 		public static object Min(object a, object b)
 		{
-			if (a == null || b == null) return null;
-			var t = DominantType(a.GetType(), b.GetType());
-
-			Computer c;
-			if (_computers.TryGetValue(t, out c)) 
-				return c.Min(a, b);
-			
-			throw new ComputeException("Min", a, b);
+			object result;
+			if (!TryMin(a,b,out result))
+				throw new ComputeException("Min", a, b);
+			return result;
 		}
 
-		public static object Max(object a, object b)
+		public static bool TryMax(object a, object b, out object result)
 		{
-			if (a == null || b == null) return null;
+			result = null;
+			if (a == null || b == null) return false;
 			var t = DominantType(a.GetType(), b.GetType());
 
 			Computer c;
 			if (_computers.TryGetValue(t, out c)) 
-				return c.Max(a, b);
+				return c.TryMax(a, b, out result);
+			return true;
+		}
 			
-			throw new ComputeException("Max", a, b);
+		public static object Max(object a, object b)
+		{
+			object result;
+			if (!TryMax(a,b,out result))
+				throw new ComputeException("Max", a, b);
+			return result;
 		}
 	}
 }

--- a/Source/Fuse.Marshal/Marshal.Compute.uno
+++ b/Source/Fuse.Marshal/Marshal.Compute.uno
@@ -65,7 +65,9 @@ namespace Fuse
 				return c.TryAdd(a, b, out result);
 			return false;
 		}
-			
+		
+		[Obsolete]
+		/** @deprecated Use TryAdd instead. 2018-01-02*/
 		public static object Add(object a, object b)
 		{
 			object result = null;
@@ -87,6 +89,8 @@ namespace Fuse
 			return false;
 		}
 			
+		[Obsolete]
+		/** @deprecated Use TrySubtract instead. 2018-01-02 */
 		public static object Subtract(object a, object b)
 		{
 			object result = null;
@@ -108,6 +112,8 @@ namespace Fuse
 			return false;
 		}
 			
+		[Obsolete]
+		/** @deprecated Use TryMultiply instead. 2018-01-02 */
 		public static object Multiply(object a, object b)
 		{
 			object result;
@@ -129,6 +135,8 @@ namespace Fuse
 			return true;
 		}
 			
+		[Obsolete]
+		/** @deprecated Use TryDivide instead. 2018-01-02 */
 		public static object Divide(object a, object b)
 		{
 			object result;
@@ -149,6 +157,8 @@ namespace Fuse
 			return true;
 		}
 		
+		[Obsolete]
+		/** @deprecated Use TryLessThan instead. 2018-01-02 */
 		public static object LessThan(object a, object b)
 		{
 			bool result;
@@ -169,6 +179,8 @@ namespace Fuse
 			return true;
 		}
 		
+		[Obsolete]
+		/** @deprecated Use TryLessOrEqual instead. 2018-01-02 */
 		public static object LessOrEqual(object a, object b)
 		{
 			bool result;
@@ -189,6 +201,8 @@ namespace Fuse
 			return true;
 		}
 		
+		[Obsolete]
+		/** @deprecated Use TryGreaterThan instead. 2018-01-02 */
 		public static object GreaterThan(object a, object b)
 		{
 			bool result;
@@ -209,6 +223,8 @@ namespace Fuse
 			return true;
 		}
 		
+		[Obsolete]
+		/** @deprecated Use TryGreaterOrEqual instead. 2018-01-02 */
 		public static object GreaterOrEqual(object a, object b)
 		{
 			bool result;
@@ -229,6 +245,8 @@ namespace Fuse
 			return true;
 		}
 		
+		[Obsolete]
+		/** @deprecated Use TryEqualTo instead. 2018-01-02 */
 		public static object EqualTo(object a, object b)
 		{
 			bool result;
@@ -249,6 +267,8 @@ namespace Fuse
 			return true;
 		}
 
+		[Obsolete]
+		/** @deprecated Use TryMin instead. 2018-01-02 */
 		public static object Min(object a, object b)
 		{
 			object result;
@@ -269,6 +289,8 @@ namespace Fuse
 			return true;
 		}
 			
+		[Obsolete]
+		/** @deprecated Use TryMax instead. 2018-01-02 */
 		public static object Max(object a, object b)
 		{
 			object result;

--- a/Source/Fuse.Reactive.Expressions/MathFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/MathFunctions.uno
@@ -12,8 +12,7 @@ namespace Fuse.Reactive
 			
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = Marshal.Min(left, right);
-			return true;
+			return Marshal.TryMin(left, right, out result);
 		}
 	}
 
@@ -26,8 +25,7 @@ namespace Fuse.Reactive
 			
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = Marshal.Max(left, right);
-			return true;
+			return Marshal.TryMax(left, right, out result);
 		}
 	}
 	

--- a/Source/Fuse.Reactive.Expressions/Operators.uno
+++ b/Source/Fuse.Reactive.Expressions/Operators.uno
@@ -30,8 +30,7 @@ namespace Fuse.Reactive
 			base(left, right, "+") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = Marshal.Add(left, right);
-			return true;
+			return Marshal.TryAdd(left, right, out result);
 		}
 	}
 
@@ -42,8 +41,7 @@ namespace Fuse.Reactive
 			base(left, right, "-") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = Marshal.Subtract(left, right);
-			return true;
+			return Marshal.TrySubtract(left, right, out result);
 		}
 	}
 
@@ -54,8 +52,7 @@ namespace Fuse.Reactive
 			base(left, right, "*") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = Marshal.Multiply(left, right);
-			return true;
+			return Marshal.TryMultiply(left, right, out result);
 		}
 	}
 
@@ -66,8 +63,7 @@ namespace Fuse.Reactive
 			base(left, right,"/") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = Marshal.Divide(left, right);
-			return true;
+			return Marshal.TryDivide(left, right, out result);
 		}
 	}
 
@@ -98,8 +94,10 @@ namespace Fuse.Reactive
 			base(left, right,"<") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = Marshal.LessThan(left, right);
-			return true;
+			bool v = false;
+			var r = Marshal.TryLessThan(left, right, out v);
+			result = v;
+			return r;
 		}
 	}
 
@@ -110,8 +108,10 @@ namespace Fuse.Reactive
 			base(left, right, ">") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = Marshal.GreaterThan(left, right);
-			return true;
+			bool v = false;
+			var r = Marshal.TryGreaterThan(left, right, out v);
+			result = v;
+			return r;
 		}
 	}
 
@@ -122,10 +122,10 @@ namespace Fuse.Reactive
 			: base(left, right,">=") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = null;
-			if (left == null || right == null) return false;
-			result = (bool)Marshal.GreaterThan(left, right) || (bool)Marshal.EqualTo(left, right);
-			return true;
+			bool v = false;
+			var r = Marshal.TryGreaterOrEqual(left, right, out v);
+			result = v;
+			return r;
 		}
 	}
 
@@ -136,10 +136,10 @@ namespace Fuse.Reactive
 			base(left, right,"<=") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = null;
-			if (left == null || right == null) return false;
-			result = (bool)Marshal.LessThan(left, right) || (bool)Marshal.EqualTo(left, right);
-			return true;
+			bool v = false;
+			var r = Marshal.TryLessOrEqual(left, right, out v);
+			result = v;
+			return r;
 		}
 	}
 
@@ -150,8 +150,10 @@ namespace Fuse.Reactive
 			base(left, right,"==") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = Marshal.EqualTo(left, right);
-			return true;
+			bool v = false;
+			var r = Marshal.TryEqualTo(left, right, out v);
+			result = v;
+			return r;
 		}
 	}
 
@@ -162,9 +164,13 @@ namespace Fuse.Reactive
 			base(left, right, "!=") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
-			result = null;
-			if (left == null || right == null) return false;
-			result = !(bool)Marshal.EqualTo(left, right);
+			bool v;
+			if (!Marshal.TryEqualTo(left, right, out v))
+			{
+				result = false;
+				return false;
+			}
+			result = !v;
 			return true;
 		}
 	}

--- a/Source/Fuse.Reactive.Expressions/Operators.uno
+++ b/Source/Fuse.Reactive.Expressions/Operators.uno
@@ -23,6 +23,29 @@ namespace Fuse.Reactive
 		}
 	}
 
+	public sealed class Concat : InfixOperator
+	{
+		[UXConstructor]
+		public Concat([UXParameter("Left")] Expression left, [UXParameter("Right")] Expression right) : 
+			base(left, right, "++") {}
+		protected override bool TryCompute(object left, object right, out object result)
+		{
+			return TryComputeImpl(left, right, out result);
+		}
+		
+		static internal bool TryComputeImpl(object left, object right, out object result)
+		{
+			result = null;
+			string a = null, b = null;
+			if (!Marshal.TryToType<string>(left, out a) ||
+				!Marshal.TryToType<string>(right, out b))
+				return false;
+				
+			result = a + b;
+			return true;
+		}
+	}
+	
 	public sealed class Add: InfixOperator
 	{
 		[UXConstructor]
@@ -30,6 +53,11 @@ namespace Fuse.Reactive
 			base(left, right, "+") {}
 		protected override bool TryCompute(object left, object right, out object result)
 		{
+			//Workaround for UX emitting `Add` instead of `Concat`
+			//https://github.com/fusetools/fuselibs-public/issues/897
+			if (left is string || right is string)
+				return Concat.TryComputeImpl(left, right, out result);
+				
 			return Marshal.TryAdd(left, right, out result);
 		}
 	}

--- a/Source/Fuse.Reactive.Expressions/Tests/MathFunctions.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/MathFunctions.Test.uno
@@ -226,6 +226,46 @@ namespace Fuse.Reactive.Test
 				Assert.AreEqual(float4(10,10,20,15), p.clamp.Float4);
 			}
 		}
+		
+		[Test]
+		public void Add()
+		{
+			var p = new UX.MathFunctions.Add();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( 13.0, p.c.Object ); //this is expecting a double
+				Assert.AreEqual( float2(13,27), p.c2.Object );
+				Assert.AreEqual( float3(13,27,35), p.c3.Object );
+				Assert.AreEqual( float4(13,27,35,46), p.c4.Object );
+			}
+		}
+		
+		[Test]
+		//functions where the conversion was being handled by the Marshal class. This is just a base sanity check
+		public void MarshalFunctions()
+		{
+			var p = new UX.MathFunctions.MarshalFunctions();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( float2(13,27), p.add.Object );
+				Assert.AreEqual( float2(7,13), p.sub.Object );
+				Assert.AreEqual( float2(30,140), p.mul.Object );
+				Assert.AreEqual( float2(10f/3, 20f/7), p.div.Object );
+				
+				Assert.AreEqual( 5.0, p.min.Object );
+				Assert.AreEqual( 10.0, p.max.Object );
+			
+				Assert.AreEqual( false, p.lt.Object );
+				Assert.AreEqual( true, p.gt.Object );
+				Assert.AreEqual( false, p.lte.Object );
+				Assert.AreEqual( true, p.gte.Object );
+				Assert.AreEqual( false, p.eq.Object );
+				Assert.AreEqual( true, p.neq.Object );
+				
+				Assert.AreEqual( false, p.and.Object );
+				Assert.AreEqual( true, p.or.Object );
+			}
+		}
 	
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
@@ -41,5 +41,17 @@ namespace Fuse.Reactive.Expressions.Test
 				Assert.Contains("Failed to compute value", diagnostics[1].Message);
 			}
 		}
+		
+		[Test]
+		//basic test for types handled by Marshal
+		public void Marshal()
+		{
+			var p = new UX.StringFunctions.Marshal();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( "ab", p.str.Object );
+				Assert.AreEqual( "a3", p.num.Object );
+			}
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/StringFunctions.Test.uno
@@ -53,5 +53,16 @@ namespace Fuse.Reactive.Expressions.Test
 				Assert.AreEqual( "a3", p.num.Object );
 			}
 		}
+		
+		[Test]
+		public void Concat()
+		{
+			var p = new UX.StringFunctions.Concat();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( "1-2", p.txt.Value );
+				Assert.AreEqual( "23", p.obj.Object );
+			}
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/MathFunctions.Add.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/MathFunctions.Add.ux
@@ -1,0 +1,17 @@
+<Panel ux:Class="UX.MathFunctions.Add">
+	<FuseTest.Value Integer="10" ux:Name="a"/>
+	<FuseTest.Value Integer="3" ux:Name="b"/>
+	<FuseTest.Value Object="{Property a.Object} + {Property b.Object}" ux:Name="c"/>
+	
+	<Let Value="float( (10,20) )" ux:Name="a2"/>
+	<Let Value="float( (3,7) )" ux:Name="b2"/>
+	<FuseTest.Value Object="{a2} + {b2}" ux:Name="c2"/>
+	
+	<Let Value="float( (10,20,30) )" ux:Name="a3"/>
+	<Let Value="float( (3,7,5) )" ux:Name="b3"/>
+	<FuseTest.Value Object="{a3} + {b3}" ux:Name="c3"/>
+	
+	<Let Value="float( (10,20,30,40) )" ux:Name="a4"/>
+	<Let Value="float( (3,7,5,6) )" ux:Name="b4"/>
+	<FuseTest.Value Object="{a4} + {b4}" ux:Name="c4"/>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/MathFunctions.MarshalFunctions.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/MathFunctions.MarshalFunctions.ux
@@ -1,0 +1,27 @@
+<Panel ux:Class="UX.MathFunctions.MarshalFunctions">
+	<Let Value="float( (10,20) )" ux:Name="a2"/>
+	<Let Value="float( (3,7) )" ux:Name="b2"/>
+	
+	<Let Value="float(10)" ux:Name="a"/>
+	<Let Value="float(5)" ux:Name="b"/>
+	
+	<Let Value=" 1 == 0 " ux:Name="f"/>
+	<Let Value=" 1 == 1 " ux:Name="t"/>
+	
+	<FuseTest.Value Object="{a2} + {b2}" ux:Name="add"/>
+	<FuseTest.Value Object="{a2} - {b2}" ux:Name="sub"/>
+	<FuseTest.Value Object="{a2} * {b2}" ux:Name="mul"/>
+	<FuseTest.Value Object="{a2} / {b2}" ux:Name="div"/>
+	<FuseTest.Value Object="min({a},{b})" ux:Name="min"/>
+	<FuseTest.Value Object="max({a}, {b})" ux:Name="max"/>
+	
+	<FuseTest.Value Object="{a} &lt; {b}" ux:Name="lt"/>
+	<FuseTest.Value Object="{a} &gt; {b}" ux:Name="gt"/>
+	<FuseTest.Value Object="{a} &lt;= {b}" ux:Name="lte"/>
+	<FuseTest.Value Object="{a} &gt;= {b}" ux:Name="gte"/>
+	<FuseTest.Value Object="{a} == {b}" ux:Name="eq"/>
+	<FuseTest.Value Object="{a} != {b}" ux:Name="neq"/>
+	
+	<FuseTest.Value Object="{t} &amp;&amp; {f}" ux:Name="and"/>
+	<FuseTest.Value Object="{t} || {f}" ux:Name="or"/>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.Concat.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.Concat.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.StringFunctions.Concat">
+	<Let Value="{= 1 }" ux:Name="a"/>
+	<Let Value="{= 2 }" ux:Name="b"/>
+	
+	<Text Value="{a}-{b}" ux:Name="txt"/>
+	<FuseTest.Value Object=" '2' + '3' " ux:Name="obj"/>
+
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.Marshal.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/StringFunctions.Marshal.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.StringFunctions.Marshal">
+	<Let Value=" 'a' " ux:Name="a"/>
+	<Let Value=" 'b' " ux:Name="b"/>
+	<Let Value="{= 3 }" ux:Name="c"/>
+	
+	<FuseTest.Value Object="{a} + {b}" ux:Name="str"/>
+	<FuseTest.Value Object="{a} + {c}" ux:Name="num"/>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
@@ -73,8 +73,7 @@ namespace Fuse.Reactive
 		public Negate([UXParameter("Operand")] Expression operand): base(operand) {}
 		protected override bool TryCompute(object operand, out object result)
 		{
-			result = Marshal.Multiply(operand, -1);
-			return true;
+			return Marshal.TryMultiply(operand, -1, out result);
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/fusetools/fuselibs-public/issues/801
Workaround for https://github.com/fusetools/fuselibs-public/issues/897 was implemented differently than before.

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [x] Tests
