### PR TITLE
Feature `Element.Position` and `Size`, and `size()` expression function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Element
 - Fixed an incorrect cascade of `MinWidth` / `MinHeight`. This could only be noticed in certain scenarios using `BoxSizing="FillAspect"`.
 - Fixed the `width`, `height`, `x`, and `y` functions to support an element losing its layout. They become undefined in this case, thus allowing a syntax like `width(element) ?? 50`
+- Added `Position` and `Size` to `Element` as an alternate way to control the layout. This is useful for some animation and binding situations.
 
 ## StackPanel
 - Fixed the invalid propagation of MaxWidth/MaxHeight in a StackPanel to its children

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Moved `VarArgFunction.Argument` to `Expression.Argument`. It's in a base class so still has visibility in `VarArgFunction`.
 - `VarArgFunction.Subscription.OnNewData` and `OnLostData` have been sealed. They should not have been open for overriding before as it conflicts with the inner workings on the class. Only the `OnNewPartialArguments` and `OnNewArguments` should be overridden.
 - Improved error handling on several operators and math functions. Instead of exceptions these should produce the standard conversion/computation warnings for invalid types.
+- Added `size()` function to force conversion to a `Size` or `Size2` type. Useful when dealing with unknown types and some operators that would otherwise result in the undesired conversion.
 
 ## Navigation
 - Fixed an issue with `Navigator.Pages` not registering pages correctly in certain initialization orders

--- a/Source/Fuse.Common/Tests/FuseTest/DudElement.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/DudElement.uno
@@ -1,4 +1,5 @@
 using Uno;
+using Uno.UX;
 
 using Fuse;
 using Fuse.Controls;
@@ -79,6 +80,18 @@ namespace FuseTest
 		public bool BoolValue
 		{
 			get { return (bool)_value; }
+			set { _value = value; }
+		}
+		
+		public Size SizeValue
+		{
+			get { return (Size)_value; }
+			set { _value = value; }
+		}
+		
+		public Size2 Size2Value
+		{
+			get { return (Size2)_value; }
 			set { _value = value; }
 		}
 		

--- a/Source/Fuse.Controls.Panels/GraphicsView.ux.uno
+++ b/Source/Fuse.Controls.Panels/GraphicsView.ux.uno
@@ -268,12 +268,20 @@ namespace Fuse.Controls
 			}
 		}
 
-		public float2 Size
+		[Obsolete]
+		/** Deprecated use ActualSize instead. 2018-01-02 */
+		public new float2 Size
 		{
 			get { return ActualSize; }
 		}
 
+		[Obsolete]
+		/** Deprecated use ActualPixelSize instead. 2018-01-02 */
 		public float2 PixelSize
+		{
+			get { return ActualPixelSize; }
+		}
+		public float2 ActualPixelSize
 		{
 			get { return ActualSize * PixelsPerPoint; }
 		}

--- a/Source/Fuse.Controls.Primitives/Behaviors/Shadow.uno
+++ b/Source/Fuse.Controls.Primitives/Behaviors/Shadow.uno
@@ -171,7 +171,7 @@ namespace Fuse.Controls
 						Width = new Size(100, Unit.Percent),
 						Height = new Size(100, Unit.Percent),
 						Color = _color,
-						Size = _size
+						ShadowSize = _size
 					};
 
 					// TODO: move into ShadowElement?

--- a/Source/Fuse.Controls.Primitives/ShadowElement.uno
+++ b/Source/Fuse.Controls.Primitives/ShadowElement.uno
@@ -50,7 +50,7 @@ namespace Fuse.Controls.Primitives
 		}
 
 		float _size;
-		public float Size
+		public float ShadowSize
 		{
 			get { return _size; }
 			set

--- a/Source/Fuse.Controls.Video/Video.uno
+++ b/Source/Fuse.Controls.Video/Video.uno
@@ -447,7 +447,7 @@ namespace Fuse.Controls
 		}
 
 		/*** The position of the video in seconds */
-		public double Position
+		public new double Position
 		{
 			get { return Playback != null ? Playback.Position : 0.0; }
 			set { if (Playback != null) Playback.Position = value; }

--- a/Source/Fuse.Controls/Viewport.uno
+++ b/Source/Fuse.Controls/Viewport.uno
@@ -255,7 +255,7 @@ namespace Fuse.Elements
 				dc.PushCullFace(CullFace);
 
 			if (Mode == ViewportMode.RenderToTexture) {
-				var pxSize = PixelSize;
+				var pxSize = ((ICommonViewport)this).PixelSize;
 				var fb = FramebufferPool.Lock( int2((int)pxSize.X,(int)pxSize.Y), Format.RGBA8888, true );
 				dc.PushRenderTargetViewport(fb, this);
 
@@ -353,19 +353,19 @@ namespace Fuse.Elements
 		bool IsDisabled { get { return Mode == ViewportMode.Disabled; } }
 
 		//ICommonViewport
-		public float PixelsPerPoint
+		public float ICommonViewport.PixelsPerPoint
 		{
 			get { return Parent.Viewport.PixelsPerPoint; }
 		}
-		public float2 Size
+		public float2 ICommonViewport.Size
 		{
 			get { return IsDisabled ? Parent.Viewport.Size : ActualSize; }
 		}
-		public float2 PixelSize
+		public float2 ICommonViewport.PixelSize
 		{
-			get { return IsDisabled ? Parent.Viewport.PixelSize : ActualSize * PixelsPerPoint; }
+			get { return IsDisabled ? Parent.Viewport.PixelSize : ActualSize * ((ICommonViewport)this).PixelsPerPoint; }
 		}
-		public float4x4 ViewTransform 
+		public float4x4 ICommonViewport.ViewTransform 
 		{
 			get { return IsDisabled ? Parent.Viewport.ViewTransform : FrustumViewport.ViewTransform; }
 		}

--- a/Source/Fuse.Elements/Element.Layout.Properties.uno
+++ b/Source/Fuse.Elements/Element.Layout.Properties.uno
@@ -7,7 +7,7 @@ namespace Fuse.Elements
 {
 	public abstract partial class Element
 	{
-		Size _width = Size.Auto;
+		Size _width = Uno.UX.Size.Auto;
 		/** The width of the `Element`.
 
 			Used to ensure an element will have a specific width on-screen.
@@ -29,7 +29,7 @@ namespace Fuse.Elements
 			}
 		}
 
-		Size _height = Size.Auto;
+		Size _height = Uno.UX.Size.Auto;
 		/** The height of the `Element`.
 
 			Used to ensure an element will have a specific height on-screen.
@@ -50,6 +50,22 @@ namespace Fuse.Elements
 				}
 			}
 		}
+		
+		/** The combined `Width` and `Height` of the element.
+		
+			If using this property avoid using `Width` or `Height` properties, as this is an combined alias for those properties. Choose the property that works easier for your desired bindined, expressions and animations.
+		
+			See @Layout for more details.
+		*/
+		public Size2 Size
+		{
+			get { return new Size2(Width, Height); }
+			set
+			{
+				Width = value.X;
+				Height = value.Y;
+			}
+		}
 
 		/** The minimum width of the `Element`.
 
@@ -61,12 +77,12 @@ namespace Fuse.Elements
 		*/
 		public Size MinWidth
 		{
-			get { return Get(FastProperty1.MinWidth, Size.Auto); }
+			get { return Get(FastProperty1.MinWidth, Uno.UX.Size.Auto); }
 			set 
 			{ 
 				if (MinWidth != value)
 				{
-					Set(FastProperty1.MinWidth, value, Size.Auto); 
+					Set(FastProperty1.MinWidth, value, Uno.UX.Size.Auto); 
 					InvalidateLayout();
 				}
 			}
@@ -82,12 +98,12 @@ namespace Fuse.Elements
 		*/
 		public Size MinHeight
 		{
-			get { return Get(FastProperty1.MinHeight, Size.Auto); }
+			get { return Get(FastProperty1.MinHeight, Uno.UX.Size.Auto); }
 			set 
 			{ 
 				if (MinHeight != value)
 				{
-					Set(FastProperty1.MinHeight, value, Size.Auto); 
+					Set(FastProperty1.MinHeight, value, Uno.UX.Size.Auto); 
 					InvalidateLayout();
 				}
 			}
@@ -103,12 +119,12 @@ namespace Fuse.Elements
 		*/
 		public Size MaxWidth
 		{
-			get { return Get(FastProperty1.MaxWidth, Size.Auto); }
+			get { return Get(FastProperty1.MaxWidth, Uno.UX.Size.Auto); }
 			set 
 			{ 
 				if (MaxWidth != value)
 				{
-					Set(FastProperty1.MaxWidth, value, Size.Auto); 
+					Set(FastProperty1.MaxWidth, value, Uno.UX.Size.Auto); 
 					InvalidateLayout();
 				}
 			}
@@ -124,12 +140,12 @@ namespace Fuse.Elements
 		*/
 		public Size MaxHeight
 		{
-			get { return Get(FastProperty1.MaxHeight, Size.Auto); }
+			get { return Get(FastProperty1.MaxHeight, Uno.UX.Size.Auto); }
 			set 
 			{ 
 				if (MaxHeight != value)
 				{
-					Set(FastProperty1.MaxHeight, value, Size.Auto); 
+					Set(FastProperty1.MaxHeight, value, Uno.UX.Size.Auto); 
 					InvalidateLayout();
 				}
 			}
@@ -312,12 +328,12 @@ namespace Fuse.Elements
 		*/
 		public Size X
 		{
-			get { return Get(FastProperty1.X, Size.Auto); }
+			get { return Get(FastProperty1.X, Uno.UX.Size.Auto); }
 			set 
 			{
 				if (X != value)
 				{
-					Set(FastProperty1.X, value, Size.Auto);
+					Set(FastProperty1.X, value, Uno.UX.Size.Auto);
 					InvalidateLayout();	
 				} 
 			}
@@ -329,14 +345,28 @@ namespace Fuse.Elements
 		*/
 		public Size Y
 		{
-			get { return Get(FastProperty1.Y, Size.Auto); }
+			get { return Get(FastProperty1.Y, Uno.UX.Size.Auto); }
 			set 
 			{
 				if (Y != value)
 				{
-					Set(FastProperty1.Y, value, Size.Auto);
+					Set(FastProperty1.Y, value, Uno.UX.Size.Auto);
 					InvalidateLayout();	
 				} 
+			}
+		}
+		
+		/** The combined `X` and `Y` position of the element.
+		
+			If using this property avoid using `X` or `Y` properties, as this is an combined alias for those properties. Choose the property that works easier for your desired bindined, expressions and animations.
+		*/
+		public Size2 Position
+		{
+			get { return new Size2(X, Y); }
+			set
+			{
+				X = value.X;
+				Y = value.Y;
 			}
 		}
 

--- a/Source/Fuse.Elements/LimitBoxSizing.uno
+++ b/Source/Fuse.Elements/LimitBoxSizing.uno
@@ -63,12 +63,12 @@ namespace Fuse.Elements
 		*/
 		public Size LimitHeight
 		{
-			get { return Get(FastProperty1.LimitHeight, Size.Auto); }
+			get { return Get(FastProperty1.LimitHeight, Uno.UX.Size.Auto); }
 			set 
 			{ 
 				if (LimitHeight != value)
 				{
-					Set(FastProperty1.LimitHeight, value, Size.Auto); 
+					Set(FastProperty1.LimitHeight, value, Uno.UX.Size.Auto); 
 					InvalidateLayout();
 				}
 			}
@@ -81,12 +81,12 @@ namespace Fuse.Elements
 		*/
 		public Size LimitWidth
 		{
-			get { return Get(FastProperty1.LimitWidth, Size.Auto); }
+			get { return Get(FastProperty1.LimitWidth, Uno.UX.Size.Auto); }
 			set 
 			{ 
 				if (LimitWidth != value )
 				{
-					Set(FastProperty1.LimitWidth, value, Size.Auto); 
+					Set(FastProperty1.LimitWidth, value, Uno.UX.Size.Auto); 
 					InvalidateLayout();
 				}
 			}

--- a/Source/Fuse.Elements/Tests/Element.Test.uno
+++ b/Source/Fuse.Elements/Tests/Element.Test.uno
@@ -1,0 +1,27 @@
+using Uno;
+using Uno.UX;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Elements.Test
+{
+	public class ElementTest : TestBase
+	{
+		[Test]
+		public void PositionSize()
+		{
+			var p = new global::UX.Element.PositionSize();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( new Size(20, Unit.Unspecified), p.a.X );
+				Assert.AreEqual( new Size(30, Unit.Percent), p.a.Y );
+				Assert.AreEqual( new Size(40, Unit.Points), p.a.Width );
+				Assert.AreEqual( new Size(50, Unit.Pixels), p.a.Height );
+				
+				Assert.AreEqual( new Size2( new Size(2, Unit.Pixels), new Size(3, Unit.Unspecified)), p.b.Position );
+				Assert.AreEqual( new Size2( new Size(4, Unit.Percent), new Size(5, Unit.Points)), p.b.Size );
+			}
+		}
+	}
+}

--- a/Source/Fuse.Elements/Tests/UX/Element.PositionSize.ux
+++ b/Source/Fuse.Elements/Tests/UX/Element.PositionSize.ux
@@ -1,0 +1,4 @@
+<Panel ux:Class="UX.Element.PositionSize">
+	<Panel Position="20,30%" Size="40pt,50px" ux:Name="a"/>
+	<Panel X="2px" Y="3" Width="4%" Height="5pt" ux:Name="b"/>
+</Panel>

--- a/Source/Fuse.Marshal/Marshal.Cast.uno
+++ b/Source/Fuse.Marshal/Marshal.Cast.uno
@@ -301,36 +301,111 @@ namespace Fuse
 
 		public static Size ToSize(object o)
 		{
-			if (o is Size) return (Size)o;
-			else if (o is Size2) return ((Size2)o).X;
-			else if (o is string) return StringToSize((string)o);
-			else return ToFloat(o);
+			Size a = new Size();
+			if (!TryToSize(o, out a))
+				throw new MarshalException(o, typeof(Size));
+			return a;
+		}
+			
+		public static bool TryToSize(object o, out Size result)
+		{
+			result = new Size();
+			
+			if (o is Size) 
+			{
+				result = (Size)o;
+				return true;
+			}
+			if (o is Size2) 
+			{
+				result = ((Size2)o).X;
+				return true;
+			}
+			if (o is string)
+				return TryStringToSize((string)o, out result);
+				
+			float v;
+			if (!TryToFloat(o, out v))
+				return false;
+			result = new Size(v, Unit.Unspecified);
+			return true;
 		}
 
 		public static Size2 ToSize2(object o)
 		{
-			if (o is Size2) return (Size2) o;
-			else if (o is Size) return new Size2((Size)o, (Size)o);
-			else if (o is string) return StringToSize2((string)o);
-			else if (o is IArray) return ToSize2(ToVector((IArray)o));
-			else return new Size2(ToFloat2(o).X, ToFloat2(o).Y);
+			Size2 a = new Size2();
+			if (!TryToSize2(o, out a))
+				throw new MarshalException(o, typeof(Size2));
+			return a;
 		}
-
-		static Size2 StringToSize2(string o)
+		
+		public static bool TryToSize2(object o, out Size2 result)
 		{
+			result = new Size2();
+			
+			if (o is Size2) 
+			{
+				result = (Size2) o;
+				return true;
+			}
+			if (o is Size)
+			{
+				result = new Size2((Size)o, (Size)o);
+				return true;
+			}
+			if (o is string) 
+				return TryStringToSize2((string)o, out result);
+			
+			if (o is IArray)
+			{
+				var arr = (IArray)o;
+				if (arr.Length != 2)
+					return false;
+				Size a = new Size();
+				Size b = new Size();
+				if (!TryToSize(arr[0], out a) || !TryToSize(arr[1], out b))
+					return false;
+					
+				result = new Size2(a,b);
+				return true;
+			}
+			
+			float2 v;
+			if (!TryToType<float2>(o,out v))
+				return false;
+			result = new Size2(v.X, v.Y);
+			return true;
+		}
+		
+		static bool TryStringToSize2(string o, out Size2 result)
+		{
+			result = new Size2();
+			
 			if (o.Contains(","))
 			{
 				var p = o.Split(',');
-				return new Size2(StringToSize(p[0]), StringToSize(p[1]));
+				if (p.Length !=2)
+					return false;
+					
+				Size a = new Size();
+				Size b = new Size();
+				if (!TryStringToSize(p[0], out a) ||
+					!TryStringToSize(p[1], out b))
+					return false;
+				result = new Size2(a,b);
+				return true;
 			}
 			else
 			{
-				var s = StringToSize(o);
-				return new Size2(s, s);
+				Size a;
+				if (!TryStringToSize(o, out a))
+					return false;
+				result = new Size2(a,a);
+				return true;
 			}
 		}
 
-		static Size StringToSize(string o)
+		static bool TryStringToSize(string o, out Size result)
 		{
 			var s = o.Trim();
 			var unit = Unit.Unspecified;
@@ -341,10 +416,12 @@ namespace Fuse
 			float v;
 			if (!float.TryParse(s, out v))
 			{
-				throw new MarshalException(o, typeof(Size));
+				result = new Size();
+				return false;
 			}
 
-			return new Size(v, unit);
+			result = new Size(v, unit);
+			return true;
 		}
 	}
 }

--- a/Source/Fuse.Marshal/Marshal.Cast.uno
+++ b/Source/Fuse.Marshal/Marshal.Cast.uno
@@ -369,7 +369,7 @@ namespace Fuse
 			if (o is IArray)
 			{
 				var arr = (IArray)o;
-				if (arr.Length != 2)
+				if (arr.Length < 2) // See not below on TryToZeroFloat about why we can't do != 2 here
 					return false;
 				Size a = new Size();
 				Size b = new Size();
@@ -383,7 +383,8 @@ namespace Fuse
 			
 			float4 v;
 			int vc;
-			if (!TryToZeroFloat4(o, out v, out vc) || vc < 1 || vc > 2)
+			//ideally we'd also fail if `vc > 2`, but there's a strange check in `MarshalTest.TestVector` expecting long values to convert to Size/Size2 !
+			if (!TryToZeroFloat4(o, out v, out vc) || vc < 1)
 				return false;
 			if (vc == 1)
 				result = new Size2(v.X, v.X);

--- a/Source/Fuse.Marshal/Marshal.Cast.uno
+++ b/Source/Fuse.Marshal/Marshal.Cast.uno
@@ -341,20 +341,30 @@ namespace Fuse
 		
 		public static bool TryToSize2(object o, out Size2 result)
 		{
+			int ignore;
+			return TryToSize2(o, out result, out ignore);
+		}
+		
+		/** Convert to a Size type up to Size2 returning the count of the elements provided in the input. */
+		public static bool TryToSize2(object o, out Size2 result, out int count)
+		{
 			result = new Size2();
+			count = 0;
 			
 			if (o is Size2) 
 			{
 				result = (Size2) o;
+				count = 2;
 				return true;
 			}
 			if (o is Size)
 			{
 				result = new Size2((Size)o, (Size)o);
+				count = 1;
 				return true;
 			}
 			if (o is string) 
-				return TryStringToSize2((string)o, out result);
+				return TryStringToSize2((string)o, out result, out count);
 			
 			if (o is IArray)
 			{
@@ -367,19 +377,26 @@ namespace Fuse
 					return false;
 					
 				result = new Size2(a,b);
+				count = 2;
 				return true;
 			}
 			
-			float2 v;
-			if (!TryToType<float2>(o,out v))
+			float4 v;
+			int vc;
+			if (!TryToZeroFloat4(o, out v, out vc) || vc < 1 || vc > 2)
 				return false;
-			result = new Size2(v.X, v.Y);
+			if (vc == 1)
+				result = new Size2(v.X, v.X);
+			else
+				result = new Size2(v.X, v.Y);
+			count = vc;
 			return true;
 		}
-		
-		static bool TryStringToSize2(string o, out Size2 result)
+
+		static bool TryStringToSize2(string o, out Size2 result, out int count)
 		{
 			result = new Size2();
+			count = 0;
 			
 			if (o.Contains(","))
 			{
@@ -393,6 +410,7 @@ namespace Fuse
 					!TryStringToSize(p[1], out b))
 					return false;
 				result = new Size2(a,b);
+				count = 2;
 				return true;
 			}
 			else
@@ -401,6 +419,7 @@ namespace Fuse
 				if (!TryStringToSize(o, out a))
 					return false;
 				result = new Size2(a,a);
+				count = 1;
 				return true;
 			}
 		}

--- a/Source/Fuse.Marshal/Tests/Marshal.Test.uno
+++ b/Source/Fuse.Marshal/Tests/Marshal.Test.uno
@@ -169,6 +169,7 @@ namespace Fuse
 			Assert.AreEqual(r*Marshal.ToFloat4(v), Marshal.ToFloat4(Marshal.Multiply(vr, v)));
 			Assert.AreEqual(r/Marshal.ToFloat4(v), Marshal.ToFloat4(Marshal.Divide(vr, v)));
 
+			//It's somewhat questionable that a float4 can convert to a Size/Size2, but alas, it was supported before :(
 			Assert.AreEqual(new Size2(r.X, r.Y), Marshal.ToSize2(v));
 			Assert.AreEqual(new Size(r.X, Unit.Unspecified), Marshal.ToSize(v));
 

--- a/Source/Fuse.Reactive.Expressions/ConversionFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/ConversionFunctions.uno
@@ -37,7 +37,17 @@ namespace Fuse.Reactive
 	}
 	
 	[UXFunction("size")]
-	/** Forces conversion to a Size or Size2 depending on input size. */
+	/** Forces conversion to a Size or Size2 depending on input size.
+	
+		This is useful when using operators that may not be able to infer the desired types. For example:
+		
+			<JavaScript>
+				exports.jsArray = [0.2, 0.4]
+			</JavaScript>
+			<Panel Offset="size({jsArray}) * 100%"/>
+			
+		This function follows the conversion rules as though the operand was being converted directly to a `Size` or `Size2` property type. If the input is a `float2`, array, or already a Size2, then it will be converted to a `Size2`, otherwise a `Size` type.
+	*/
 	public sealed class ToSize : UnaryOperator
 	{
 		[UXConstructor]
@@ -49,8 +59,17 @@ namespace Fuse.Reactive
 			result = null;
 			if (operand == null)
 				return false;
+
+			Size2 r;
+			int rc;
+			if (!Marshal.TryToSize2(operand, out r, out rc))
+				return false;
 				
-			return false;
+			if (rc == 1)
+				result = r.X;
+			else
+				result = r;
+			return true;
 		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/ConversionFunctions.uno
+++ b/Source/Fuse.Reactive.Expressions/ConversionFunctions.uno
@@ -35,4 +35,22 @@ namespace Fuse.Reactive
 			return true;
 		}
 	}
+	
+	[UXFunction("size")]
+	/** Forces conversion to a Size or Size2 depending on input size. */
+	public sealed class ToSize : UnaryOperator
+	{
+		[UXConstructor]
+		public ToSize([UXParameter("Operand")] Expression operand)
+			: base(operand, "size") { }
+			
+		protected override bool TryCompute(object operand, out object result)
+		{
+			result = null;
+			if (operand == null)
+				return false;
+				
+			return false;
+		}
+	}
 }

--- a/Source/Fuse.Reactive.Expressions/Tests/ConversionFunctions.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/ConversionFunctions.Test.uno
@@ -77,7 +77,7 @@ namespace Fuse.Reactive.Test
 		
 		[Test]
 		//doesn't use the conversion operators but implicitly uses the size conversion code
-		public void BasicSize()
+		public void SizeBasic()
 		{
 			var p = new UX.ConversionFunctions.SizeBasic();
 			using (var root = TestRootPanel.CreateWithChild(p))
@@ -101,6 +101,39 @@ namespace Fuse.Reactive.Test
 				Assert.AreEqual( new Size(10, Unit.Unspecified), p.a1.SizeValue );
 				Assert.AreEqual( new Size2(new Size(20, Unit.Unspecified),
 					new Size(30, Unit.Percent)), p.a2.Size2Value );
+			}
+		}
+		
+		[Test]
+		public void SizeOp()
+		{
+			var p = new UX.ConversionFunctions.SizeOp();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				
+				Assert.AreEqual( new Size(10, Unit.Unspecified), p.s1.SizeValue );
+				Assert.AreEqual( new Size(10, Unit.Points), p.s2.SizeValue);
+				Assert.AreEqual( new Size(10, Unit.Percent), p.s3.SizeValue);
+				Assert.AreEqual( new Size(10, Unit.Pixels), p.s4.SizeValue);
+				
+				Assert.AreEqual( new Size2(new Size(10, Unit.Unspecified),
+					new Size(10, Unit.Unspecified)), p.ss1.Size2Value );
+				//Assert.AreEqual( new Size2(new Size(10, Unit.Points),
+				//	new Size(20, Unit.Pixels)), p.ss2.Size2Value );
+				Assert.AreEqual( new Size2(new Size(20, Unit.Unspecified),
+					new Size(30, Unit.Percent)), p.ss3.Size2Value );
+				Assert.AreEqual( new Size2(new Size(50, Unit.Unspecified),
+					new Size(60, Unit.Unspecified)), p.ss4.Size2Value );
+					
+				Assert.AreEqual( new Size(10, Unit.Unspecified), p.a1.SizeValue );
+				Assert.AreEqual( new Size2(new Size(20, Unit.Unspecified),
+					new Size(30, Unit.Percent)), p.a2.Size2Value );
+					
+				Assert.AreEqual( new Size2(new Size(10, Unit.Percent),
+					new Size(20, Unit.Percent)), p.a3.Size2Value );
+				Assert.AreEqual( new Size2(new Size(5, Unit.Pixels),
+					new Size(10, Unit.Pixels)), p.a4.Size2Value );
 			}
 		}
 	}

--- a/Source/Fuse.Reactive.Expressions/Tests/ConversionFunctions.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/ConversionFunctions.Test.uno
@@ -74,5 +74,34 @@ namespace Fuse.Reactive.Test
 				Assert.Contains( "Failed to compute", d[1].Message );
 			}
 		}
+		
+		[Test]
+		//doesn't use the conversion operators but implicitly uses the size conversion code
+		public void BasicSize()
+		{
+			var p = new UX.ConversionFunctions.SizeBasic();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				
+				Assert.AreEqual( new Size(10, Unit.Unspecified), p.s1.SizeValue );
+				Assert.AreEqual( new Size(10, Unit.Points), p.s2.SizeValue);
+				Assert.AreEqual( new Size(10, Unit.Percent), p.s3.SizeValue);
+				Assert.AreEqual( new Size(10, Unit.Pixels), p.s4.SizeValue);
+				
+				Assert.AreEqual( new Size2(new Size(10, Unit.Unspecified),
+					new Size(10, Unit.Unspecified)), p.ss1.Size2Value );
+				Assert.AreEqual( new Size2(new Size(10, Unit.Points),
+					new Size(20, Unit.Pixels)), p.ss2.Size2Value );
+				Assert.AreEqual( new Size2(new Size(20, Unit.Unspecified),
+					new Size(30, Unit.Percent)), p.ss3.Size2Value );
+				Assert.AreEqual( new Size2(new Size(50, Unit.Unspecified),
+					new Size(60, Unit.Unspecified)), p.ss4.Size2Value );
+					
+				Assert.AreEqual( new Size(10, Unit.Unspecified), p.a1.SizeValue );
+				Assert.AreEqual( new Size2(new Size(20, Unit.Unspecified),
+					new Size(30, Unit.Percent)), p.a2.Size2Value );
+			}
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/ConversionFunctions.SizeBasic.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/ConversionFunctions.SizeBasic.ux
@@ -1,0 +1,20 @@
+<Panel ux:Class="UX.ConversionFunctions.SizeBasic">
+	<JavaScript>
+		module.exports = {
+			one: 10,
+			two: [ 20, "30%" ],
+		}
+	</JavaScript>
+	<FuseTest.DudElement SizeValue="10" ux:Name="s1"/>
+	<FuseTest.DudElement SizeValue="10pt" ux:Name="s2"/>
+	<FuseTest.DudElement SizeValue="10%" ux:Name="s3"/>
+	<FuseTest.DudElement SizeValue="10px" ux:Name="s4"/>
+	
+	<FuseTest.DudElement Size2Value="10" ux:Name="ss1"/>
+	<FuseTest.DudElement Size2Value="10pt,20px" ux:Name="ss2"/>
+	<FuseTest.DudElement Size2Value=" '20,30%' " ux:Name="ss3"/>
+	<FuseTest.DudElement Size2Value="float( (50,60) )" ux:Name="ss4"/>
+	
+	<FuseTest.DudElement SizeValue="{one}" ux:Name="a1"/>
+	<FuseTest.DudElement Size2Value="{two}" ux:Name="a2"/>
+</Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/ConversionFunctions.SizeOp.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/ConversionFunctions.SizeOp.ux
@@ -1,0 +1,24 @@
+<Panel ux:Class="UX.ConversionFunctions.SizeOp">
+	<JavaScript>
+		module.exports = {
+			one: 10,
+			two: [ 20, "30%" ],
+			sz: [ 0.1, 0.2 ],
+		}
+	</JavaScript>
+	<FuseTest.DudElement SizeValue="size(10)" ux:Name="s1"/>
+	<FuseTest.DudElement SizeValue="size(10pt)" ux:Name="s2"/>
+	<FuseTest.DudElement SizeValue="size(10%)" ux:Name="s3"/>
+	<FuseTest.DudElement SizeValue="size(10px)" ux:Name="s4"/>
+	
+	<FuseTest.DudElement Size2Value="size(10)" ux:Name="ss1"/>
+	<!-- <FuseTest.DudElement Size2Value="size( (10pt,20px) )" ux:Name="ss2"/> -->
+	<FuseTest.DudElement Size2Value="size( '20,30%' )" ux:Name="ss3"/>
+	<FuseTest.DudElement Size2Value="size( float( (50,60) ) )" ux:Name="ss4"/>
+	
+	<FuseTest.DudElement SizeValue="size({one})" ux:Name="a1"/>
+	<FuseTest.DudElement Size2Value="size({two})" ux:Name="a2"/>
+	
+	<FuseTest.DudElement Size2Value="size({sz}) * 100%" ux:Name="a3"/>
+	<FuseTest.DudElement Size2Value="50px * size({sz})" ux:Name="a4"/>
+</Panel>


### PR DESCRIPTION
Adds some new functionality for simplified Element positioning/animation in some scenarios.

The Position/Size are hidden by derived classes in a few places. A few have new names/deprecated the old. Only `Video` doesn't have a new name. We can't solve this immediately (other than to deprecate Video.Progress with a new name). User's will have to use the old properties, or wrap the item in a panel.

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
