### PR TITLE
Feature `LetType`: `LetFloat`, `LetString`, etc...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased
 
+## Let
+- Added specific type version of `Let`, such as `LetFloat` and `LetString`. This improve the ability to connect pieces of the UX together and do animation/transitions in UX without using JavaScript.
+
 ## Instantiator
 - Improved the internals of `Instantiator` (the base for `Each` and `Instance`). This also fixed a few corner cases with templates not updating, but should otherwise not affect user code.
 - Fixed the creation of templates in `Each` / `Instance` when the data context is null/non-extant. It will now not instantiate the templates are all. This prevents some kinds of binding defects and improves efficiency with default templates.
-## Let
-- Added specific type version of `Let`, such as `LetFloat` and `LetString`. This improve the ability to connect pieces of the UX together and do animation/transitions in UX without using JavaScript.
 
 ## Element
 - Fixed an incorrect cascade of `MinWidth` / `MinHeight`. This could only be noticed in certain scenarios using `BoxSizing="FillAspect"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Instantiator
 - Improved the internals of `Instantiator` (the base for `Each` and `Instance`). This also fixed a few corner cases with templates not updating, but should otherwise not affect user code.
 - Fixed the creation of templates in `Each` / `Instance` when the data context is null/non-extant. It will now not instantiate the templates are all. This prevents some kinds of binding defects and improves efficiency with default templates.
+## Let
+- Added specific type version of `Let`, such as `LetFloat` and `LetString`. This improve the ability to connect pieces of the UX together and do animation/transitions in UX without using JavaScript.
 
 ## Element
 - Fixed an incorrect cascade of `MinWidth` / `MinHeight`. This could only be noticed in certain scenarios using `BoxSizing="FillAspect"`.

--- a/Source/Fuse.Common/Tests/FuseTest/DudElement.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/DudElement.uno
@@ -14,10 +14,35 @@ namespace FuseTest
 	{
 		//only one backing value to prevent tests from seeing different values
 		object _value;
-		
+
+		// avoid using this one now, use `FloatValue` for clarity
 		public float Value 
 		{ 
 			get { return (float)_value; }
+			set { _value = value; }
+		}
+		
+		public float FloatValue
+		{
+			get { return (float)_value; }
+			set { _value = value; }
+		}
+		
+		public float2 Float2Value
+		{
+			get { return (float2)_value; }
+			set { _value = value; }
+		}
+		
+		public float3 Float3Value
+		{
+			get { return (float3)_value; }
+			set { _value = value; }
+		}
+		
+		public float4 Float4Value
+		{
+			get { return (float4)_value; }
 			set { _value = value; }
 		}
 		

--- a/Source/Fuse.Nodes/Node.DataContext.uno
+++ b/Source/Fuse.Nodes/Node.DataContext.uno
@@ -147,8 +147,20 @@ namespace Fuse
 		static Dictionary<string, List<IDataListener>> _dataListeners 
 			= new Dictionary<string, List<IDataListener>>();
 
+		bool CheckDataKey( string key )
+		{
+			if (key == null)
+			{
+				Fuse.Diagnostics.InternalError( "null provided as DataContext key" );
+				return false;
+			}
+			return true;
+		}
+		
 		public void OnDataChanged(string key, object newValue)
 		{
+			if (!CheckDataKey(key)) return;
+				
 			List<IDataListener> listeners;
 			if (_dataListeners.TryGetValue(key, out listeners))
 			{
@@ -159,6 +171,8 @@ namespace Fuse
 		
 		public void AddDataListener(string key, IDataListener listener)
 		{
+			if (!CheckDataKey(key)) return;
+				
 			List<IDataListener> listeners;
 			if (!_dataListeners.TryGetValue(key, out listeners))
 			{
@@ -170,6 +184,8 @@ namespace Fuse
 
 		public void RemoveDataListener(string key, IDataListener listener)
 		{
+			if (!CheckDataKey(key)) return;
+				
 			_dataListeners[key].Remove(listener);
 		}
 	}

--- a/Source/Fuse.Reactive.Bindings/Let.uno
+++ b/Source/Fuse.Reactive.Bindings/Let.uno
@@ -250,6 +250,10 @@ namespace Fuse.Reactive
 			
 		This ensures proper propagation of undefined values.  (This is part of the reason this is an experimental API, since we don't really want to distinguish between Expression and Value, but have no choice at the moment).
 		
+		## LetType
+		
+		If you are creating a value of a specific type, and/or need to use `Change` or other animators, consider using one of the @LetType classes instead, such as @LetFloat or @LetString. They have a cleaner conversion mechanism, leading to fewer surprises.
+		
 		@experimental
 		Experimental since there are some fine details about handling observables, nulls, and expressions that aren't quite defined and might subtlely alter the behaviour. For typical use-cases it should be okay though.
 	*/
@@ -319,7 +323,27 @@ namespace Fuse.Reactive
 			ResetObjectValue();
 		}
 	}
-	
+
+	/** 
+		Provides a bindable value for use in UX. This assists in combining animations and transitions in the UX without needing to use JavaScript intermediates. It is not meant to store application state, being intended only for UI level changes and effects.
+		
+		Unlike @Let this enforces a specific value type and is suitable for use with `Change`, `Set`, and other property bindings.
+		
+		These values are two-way bindable (like Observables), for example:
+		
+			<LetString Value="hello" ux:Name="a"/>
+			<TextInput Value="{a}"/>
+			<Text Value="{a}"/>
+			
+		Typing in the `TextInput` will modify the value of `a` and update the `Text` value.
+		
+		## Available types
+		
+		[subclass Fuse.Reactive.LetType]
+		
+		@see Let
+		@experimental Though is is based on the `Let` feature, which is experimental. The `LetType` classes are more predictable and have less conversion issues. It's unlikely the semantics will change -- but will remain experimental so long as `Let` is experimental.
+	*/
 	public abstract class LetType<T> : LetBase
 	{
 		[UXOriginSetter("SetValue")]
@@ -341,6 +365,21 @@ namespace Fuse.Reactive
 			SetObjectValue(value, origin);
 		}
 	}
-	
+
+	/** A @LetType that specifies a `float` value. */
 	public class LetFloat : LetType<float> { }
+	/** A @LetType that specifies a `float2` value. */
+	public class LetFloat2 : LetType<float2> { }
+	/** A @LetType that specifies a `float3` value. */
+	public class LetFloat3 : LetType<float3> { }
+	/** A @LetType that specifies a `float4` value. */
+	public class LetFloat4 : LetType<float4> { }
+	/** A @LetType that specifies a `string` value. */
+	public class LetString : LetType<string> { }
+	/** A @LetType that specifies a `bool` value. */
+	public class LetBool : LetType<bool> { }
+	/** A @LetType that specifies a `Size` value. */
+	public class LetSize : LetType<Size> { }
+	/** A @LetType that specifies a `Size2` value. */
+	public class LetSize2 : LetType<Size2> { }
 }

--- a/Source/Fuse.Reactive.Bindings/Tests/Let.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/Let.Test.uno
@@ -133,5 +133,46 @@ namespace Fuse.Test
 				Assert.AreEqual( true, p.hd.BoolValue );
 			}
 		}
+		
+		[Test]
+		//tests many of the expected binding scenarios for Let...
+		public void Float()
+		{
+			var p = new UX.Let.Float();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( 2, p.ao.Value );
+				Assert.AreEqual( 2, p.bo.Value );
+				
+				p.wt.Value = true;
+				root.StepFrame();
+				Assert.AreEqual( 5, p.ao.Value );
+				Assert.AreEqual( 5, p.bo.Value );
+				
+				p.wt.Value = false;
+				root.StepFrame();
+				Assert.AreEqual( 2, p.ao.Value );
+				Assert.AreEqual( 2, p.bo.Value );
+				
+				p.tl.PulseForward();
+				root.StepFrame();
+				Assert.AreEqual( 3, p.ao.Value );
+				Assert.AreEqual( 3, p.bo.Value );
+				
+				//slider binding
+				for (int i=0; i < 3; ++i)
+				{
+					Assert.AreEqual( 50 + i, p.sl.Value );
+					Assert.AreEqual( 50 + i, p.sv.Value );
+					p.sl.Value = -10 + i;
+					root.PumpDeferred();
+					Assert.AreEqual( -10 + i, p.sv.Value );
+					Assert.AreEqual( -10 + i, p.sl.Value );
+					
+					p.sv.Value = 50 + (i+1);
+					root.PumpDeferred();
+				}
+			}
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Bindings/Tests/Let.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/Let.Test.uno
@@ -1,5 +1,6 @@
 using Uno;
 using Uno.Testing;
+using Uno.UX;
 
 using Fuse;
 
@@ -172,6 +173,138 @@ namespace Fuse.Test
 					p.sv.Value = 50 + (i+1);
 					root.PumpDeferred();
 				}
+			}
+		}
+		
+		[Test]
+		public void String()
+		{
+			var p = new UX.Let.String();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( "abc", p.ta.Value );
+				Assert.AreEqual( "*", p.dn.StringValue );
+				Assert.AreEqual( "", p.de.StringValue );
+				
+				p.ta.Value = "def";
+				root.PumpDeferred();
+				Assert.AreEqual( "def", p.a.Value );
+				
+			}
+		}
+		
+		[Test]
+		public void Float2()
+		{
+			var p = new UX.Let.Float2();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( float2(10,20), p.rc.Value );
+				Assert.AreEqual( float2(10,20), p.b.Value );
+				Assert.AreEqual( float2(10,20), p.db.ObjectValue );
+				
+				p.rc.Value = float2(-10,5);
+				root.PumpDeferred();
+				Assert.AreEqual( float2(-10,5), p.a.Value );
+				Assert.AreEqual( float2(-10,5), p.b.Value );
+				Assert.AreEqual( float2(-10,5), p.db.ObjectValue );
+			}
+		}
+		
+		[Test]
+		public void Float3()
+		{
+			var p = new UX.Let.Float3();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( float3(10,20,30), p.c.Value );
+				Assert.AreEqual( float3(10,20,30), p.b.Value );
+				Assert.AreEqual( float3(10,20,30), p.db.ObjectValue );
+				
+				p.c.Value = float3(-10,5,1);
+				root.PumpDeferred();
+				Assert.AreEqual( float3(-10,5,1), p.a.Value );
+				Assert.AreEqual( float3(-10,5,1), p.b.Value );
+				Assert.AreEqual( float3(-10,5,1), p.db.ObjectValue );
+			}
+		}
+		
+		[Test]
+		public void Float4()
+		{
+			var p = new UX.Let.Float4();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( float4(10,20,30,40), p.c.Value );
+				Assert.AreEqual( float4(10,20,30,40), p.b.Value );
+				Assert.AreEqual( float4(10,20,30,40), p.db.ObjectValue );
+				
+				p.c.Value = float4(-10,5,0,1);
+				root.PumpDeferred();
+				Assert.AreEqual( float4(-10,5,0,1), p.a.Value );
+				Assert.AreEqual( float4(-10,5,0,1), p.b.Value );
+				Assert.AreEqual( float4(-10,5,0,1), p.db.ObjectValue );
+			}
+		}
+		
+		[Test]
+		public void Bool()
+		{
+			var p = new UX.Let.Bool();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(false, p.da.BoolValue);
+				Assert.AreEqual(false, p.t.Value);
+				Assert.AreEqual("f", p.ds.StringValue);
+				
+				p.t.Value = true;
+				root.PumpDeferred();
+				Assert.AreEqual(true, p.da.BoolValue);
+				Assert.AreEqual(true, p.a.Value);
+				Assert.AreEqual("t", p.ds.StringValue);
+			}
+		}
+		
+		[Test]
+		public void Size()
+		{
+			var p = new UX.Let.Size();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( new Size(10, Unit.Unspecified), p.p.X );
+				Assert.AreEqual( new Size(20, Unit.Percent), p.p.Y );
+				Assert.AreEqual( new Size2( new Size(10, Unit.Unspecified), new Size(20,Unit.Percent)), p.p.Offset );
+			}
+		}
+		
+		[Test]
+		//an overly complex chain of conversions and types
+		public void Conversion()
+		{
+			var p = new UX.Let.Conversion();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				//TODO: Once the "size" function is merged from https://github.com/fusetools/fuselibs-public/pull/905
+				//Assert.AreEqual( new Size2( new Size(20, Unit.Percent), new Size(30,Unit.Percent)), p.p1.Offset );
+				Assert.AreEqual( new Size2( new Size(10, Unit.Unspecified), new Size(20,Unit.Points)), p.p2.Offset );
+			}
+		}
+		
+		[Test]
+		//ensures the LetType works with ux:Property (as Let does)
+		public void Property()
+		{
+			var p = new UX.Let.Property();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual( "title", p.lp.sc.Value );
+				Assert.AreEqual( float2(10,20), p.lp.rc.Value );
+				
+				p.lp.sc.Value = "bye";
+				p.lp.rc.Value = float2(5,10);
+				root.PumpDeferred();
+				Assert.AreEqual( "bye", p.ss.Value );
+				Assert.AreEqual( float2(5,10), p.sf2.Value );
 			}
 		}
 	}

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Bool.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Bool.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.Let.Bool">
+	<LetBool Value="false" ux:Name="a"/>
+	
+	<ToggleControl Value="{a}" ux:Name="t"/>
+	
+	<FuseTest.DudElement BoolValue="{a}" ux:Name="da"/>
+	<FuseTest.DudElement StringValue="{= {a} ? 't' : 'f' }" ux:Name="ds"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Conversion.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Conversion.ux
@@ -1,0 +1,13 @@
+<Panel ux:Class="UX.Let.Conversion">
+	<LetFloat Value="10"  ux:Name="a"/>
+	<LetString Value="20" ux:Name="b"/>
+	<LetSize Value="{a}" ux:Name="x"/>
+	<LetSize Value="{b} * 1pt" ux:Name="y"/>
+	
+	<LetFloat2 Value="0.2,0.3" ux:Name="c"/>
+<!-- 	<LetSize2 Value="size({c}) * 100%" ux:Name="s1"/> -->
+	<LetSize2 Value="{x},{y}" ux:Name="s2"/>
+	
+	<Panel Offset="{s1}" ux:Name="p1"/>
+	<Panel Offset="{s2}" ux:Name="p2"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Float.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Float.ux
@@ -1,0 +1,19 @@
+<Panel ux:Class="UX.Let.Float">
+	<LetFloat Value="2" ux:Name="a"/>
+	<FuseTest.DudElement Value="{a}" ux:Name="ao"/>
+	
+	<!-- Creates a two-way binding with {a} -->
+	<LetFloat Value="{a}"  ux:Name="b"/>
+	<FuseTest.DudElement Value="{b}" ux:Name="bo"/>
+	
+	<WhileTrue ux:Name="wt">
+		<Change a.Value="5"/>
+	</WhileTrue>
+	
+	<Timeline ux:Name="tl">
+		<Set b.Value="3"/>
+	</Timeline>
+	
+	<LetFloat Value="50" ux:Name="sv"/>
+	<Slider Value="{sv}" ux:Name="sl" Minimum="-50" Maximum="50"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Float2.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Float2.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.Let.Float2">
+	<LetFloat2 Value="10,20" ux:Name="a"/>
+	<LetFloat2 Value="{a}" ux:Name="b"/>
+	
+	<RangeControl2D Value="{a}" ux:Name="rc"/>
+	
+	<FuseTest.DudElement Float2Value="{b}" ux:Name="db"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Float3.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Float3.ux
@@ -1,0 +1,7 @@
+<Panel ux:Class="UX.Let.Float3">
+	<LetFloat3 Value="10,20,30" ux:Name="a"/>
+	<LetFloat3 Value="{a}" ux:Name="b"/>
+	<LetFloat3 Value="{a}" ux:Name="c"/>
+	
+	<FuseTest.DudElement Float3Value="{b}" ux:Name="db"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Float4.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Float4.ux
@@ -1,0 +1,7 @@
+<Panel ux:Class="UX.Let.Float4">
+	<LetFloat4 Value="10,20,30,40" ux:Name="a"/>
+	<LetFloat4 Value="{a}" ux:Name="b"/>
+	<LetFloat4 Value="{a}" ux:Name="c"/>
+	
+	<FuseTest.DudElement Float4Value="{b}" ux:Name="db"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Property.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Property.ux
@@ -1,0 +1,17 @@
+<Panel ux:Class="UX.Let.Property">
+	<Panel ux:Class="LPPanel">
+		<float2 ux:Property="F2"/>
+		<string ux:Property="S"/>
+		
+		<LetFloat2 Value="{Property this.F2}" ux:Name="f2"/>
+		<LetString Value="{Property this.S}" ux:Name="s"/>
+		
+		<TextInput Value="{s}" ux:Name="sc"/>
+		<RangeControl2D Value="{f2}" ux:Name="rc"/>
+	</Panel>
+
+	<LetFloat2 Value="10,20" ux:Name="sf2"/>
+	<LetString Value="title" ux:Name="ss"/>
+	
+	<LPPanel F2="{sf2}" S="{ss}" ux:Name="lp"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Size.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Size.ux
@@ -1,0 +1,7 @@
+<Panel ux:Class="UX.Let.Size">
+	<LetSize Value="10" ux:Name="x"/>
+	<LetSize Value="20%" ux:Name="y"/>
+	<LetSize2 Value="{x},{y}" ux:Name="s2"/>
+	
+	<Panel Offset="{s2}" X="{x}" Y="{y}" ux:Name="p"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.String.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.String.ux
@@ -1,0 +1,10 @@
+<Panel ux:Class="UX.Let.String">
+	<LetString Value="abc" ux:Name="a"/>
+	
+	<TextInput Value="{a}" ux:Name="ta"/>
+	
+	<LetString ux:Name="n"/>
+	<LetString Value="" ux:Name="e"/>
+	<FuseTest.DudElement StringValue="{= {n} ?? '*' }" ux:Name="dn"/>
+	<FuseTest.DudElement StringValue="{= {e} ?? '*' }" ux:Name="de"/>
+</Panel>


### PR DESCRIPTION
Introduces a feature discussed in #apireview about specific `Let` types. This solves the problem of using `Let` with `Change`, `Set` and in other scenarios where variant types were insufficient.

I've left this all marked as experimental until we have some UX compiler issues resolved. These new features are highly unlikely to require changes though.

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests

  