### PR TITLE
ImageSource: added Transform property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## ImageSource
+- Added `Transform` property. Useful for ImageSources that requires a transform to be displayed correctly (For example photos caputred with front faceing camera)
+
 ## Let
 - Added specific type version of `Let`, such as `LetFloat` and `LetString`. This improve the ability to connect pieces of the UX together and do animation/transitions in UX without using JavaScript.
 

--- a/Source/Fuse.Controls.Primitives/Image.Visual.uno
+++ b/Source/Fuse.Controls.Primitives/Image.Visual.uno
@@ -132,12 +132,13 @@ namespace Fuse.Controls
 			}
 			else
 			{
-				var imageTransform = TransformFromImageOrientation(Source.Orientation);
+				var sourceTransform = Source.Transform;
+				var orientationTransform = TransformFromImageOrientation(Source.Orientation);
 
 				ImageElementDraw.Impl.
 					Draw(dc, this, _drawOrigin, _drawSize,
 						_uvClip.XY, _uvClip.ZW - _uvClip.XY,
-						 imageTransform,
+						Matrix.Mul(sourceTransform, orientationTransform),
 						tex, Container.ResampleMode,
 						color);
 			}

--- a/Source/Fuse.Elements/Resources/ImageSource.uno
+++ b/Source/Fuse.Elements/Resources/ImageSource.uno
@@ -153,6 +153,7 @@ namespace Fuse.Resources
 		public abstract int2 PixelSize { get; }
 		public abstract ImageSourceState State { get; }
 		public abstract texture2D GetTexture();
+		public virtual float3x3 Transform { get { return float3x3.Identity; } }
 		public virtual void Reload() {}
 
 		//We can't use just `Density` here: https://stackoverflow.com/questions/82437/why-is-it-impossible-to-override-a-getter-only-property-and-add-a-setter


### PR DESCRIPTION
Useful for ImageSources that needs to be transformed to display
correctly. For example photos captured with frontfacing camera

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
