### PR TITLE
rename Size ->WidthHeight and Position -> XY to avoid name conflicts …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## Element
 - Fixed an incorrect cascade of `MinWidth` / `MinHeight`. This could only be noticed in certain scenarios using `BoxSizing="FillAspect"`.
 - Fixed the `width`, `height`, `x`, and `y` functions to support an element losing its layout. They become undefined in this case, thus allowing a syntax like `width(element) ?? 50`
-- Added `Position` and `Size` to `Element` as an alternate way to control the layout. This is useful for some animation and binding situations.
+- Added `WidthHeight` and `XY` to `Element` as an alternate way to control the layout. This is useful for some animation and binding situations.
 
 ## StackPanel
 - Fixed the invalid propagation of MaxWidth/MaxHeight in a StackPanel to its children

--- a/Source/Fuse.Controls.Primitives/Behaviors/Shadow.uno
+++ b/Source/Fuse.Controls.Primitives/Behaviors/Shadow.uno
@@ -129,7 +129,7 @@ namespace Fuse.Controls
 				_size = value;
 
 				if (_rectangle != null)
-					_rectangle.Size = _size;
+					_rectangle.ShadowSize = _size;
 
 				if (_dropShadow != null)
 					_dropShadow.Size = _size;

--- a/Source/Fuse.Elements/Element.Layout.Properties.uno
+++ b/Source/Fuse.Elements/Element.Layout.Properties.uno
@@ -57,7 +57,7 @@ namespace Fuse.Elements
 		
 			See @Layout for more details.
 		*/
-		public Size2 Size
+		public Size2 WidthHeight
 		{
 			get { return new Size2(Width, Height); }
 			set
@@ -360,7 +360,7 @@ namespace Fuse.Elements
 		
 			If using this property avoid using `X` or `Y` properties, as this is an combined alias for those properties. Choose the property that works easier for your desired bindined, expressions and animations.
 		*/
-		public Size2 Position
+		public Size2 XY
 		{
 			get { return new Size2(X, Y); }
 			set

--- a/Source/Fuse.Elements/Tests/Element.Test.uno
+++ b/Source/Fuse.Elements/Tests/Element.Test.uno
@@ -19,8 +19,8 @@ namespace Fuse.Elements.Test
 				Assert.AreEqual( new Size(40, Unit.Points), p.a.Width );
 				Assert.AreEqual( new Size(50, Unit.Pixels), p.a.Height );
 				
-				Assert.AreEqual( new Size2( new Size(2, Unit.Pixels), new Size(3, Unit.Unspecified)), p.b.Position );
-				Assert.AreEqual( new Size2( new Size(4, Unit.Percent), new Size(5, Unit.Points)), p.b.Size );
+				Assert.AreEqual( new Size2( new Size(2, Unit.Pixels), new Size(3, Unit.Unspecified)), p.b.XY );
+				Assert.AreEqual( new Size2( new Size(4, Unit.Percent), new Size(5, Unit.Points)), p.b.WidthHeight );
 			}
 		}
 	}

--- a/Source/Fuse.Elements/Tests/UX/Element.PositionSize.ux
+++ b/Source/Fuse.Elements/Tests/UX/Element.PositionSize.ux
@@ -1,4 +1,4 @@
 <Panel ux:Class="UX.Element.PositionSize">
-	<Panel Position="20,30%" Size="40pt,50px" ux:Name="a"/>
+	<Panel XY="20,30%" WidthHeight="40pt,50px" ux:Name="a"/>
 	<Panel X="2px" Y="3" Width="4%" Height="5pt" ux:Name="b"/>
 </Panel>


### PR DESCRIPTION
…-- keep other changes since ultimately we do want the Size/Position names

** Briefly describe changes and the motivation behind them here **

This PR updates the:
- [x] Changelog
- [x] Documentation
- [x] Tests
