### PR TITLE
Model: Fix stack overflow in computePath()

### DIFF
--- a/Source/Fuse.Models/FuseJS/Internal/Model.js
+++ b/Source/Fuse.Models/FuseJS/Internal/Model.js
@@ -404,8 +404,8 @@ function Model(initialState, stateInitializer)
 		}
 
 		var cachedPath = null;
-		function getPath() {
-			if (cachedPath === null) { cachedPath = computePath(); }
+		function getPath(visited) {
+			if (cachedPath === null) { cachedPath = computePath(visited); }
 			return cachedPath;
 		} 
 		
@@ -413,16 +413,26 @@ function Model(initialState, stateInitializer)
 		meta.invalidatePath = function() { cachedPath = null; }
 
 		// Finds a valid path to the root TreeObservable, if any
-		function computePath()
+		function computePath(visited)
 		{
+			visited = visited || new Set();
+
+			if (meta.parents.indexOf(null) >= 0) {
+				// We are the root node
+				return [];
+			}
+			
 			for (var i = 0; i < meta.parents.length; i++) {
-				if (meta.parents[i] === null) { return [] }
-				else 
-				{
-					var arr = meta.parents[i].meta.getPath();
-					if (arr instanceof Array) {
-						return arr.concat(meta.parents[i].key);
-					}	
+				var parent = meta.parents[i];
+
+				if(visited.has(parent.meta))
+					continue;
+
+				visited.add(parent.meta);
+				
+				var arr = parent.meta.getPath(visited);
+				if (arr instanceof Array) {
+					return arr.concat(parent.key);
 				}
 			}
 		}

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -598,6 +598,25 @@ namespace Fuse.Models.Test
 			}
 		}
 
+		[Test]
+		public void ParentLoop()
+		{
+			var e = new UX.Model.ParentLoop();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				e.detachCycle.Perform();
+				root.StepFrameJS();
+
+				e.attachCycle.Perform();
+				root.StepFrameJS();
+				
+				e.changeCycleData.Perform();
+				root.StepFrameJS();
+
+				// There are no assertions, since failure is triggered by a stack overflow in the JavaScript VM
+			}
+		}
+
 		static List<T> ChildrenOfType<T>(Visual n) where T : Node
 		{
 			var l = new List<T>();

--- a/Source/Fuse.Models/Tests/UX/ParentLoop.js
+++ b/Source/Fuse.Models/Tests/UX/ParentLoop.js
@@ -1,0 +1,26 @@
+class Cycle {
+	constructor() {
+		this.itself = this;
+		this.data = "foo";
+	}
+}
+
+let globalCycle = new Cycle();
+
+export default class Root {
+	constructor() {
+		this.attachCycle();
+	}
+
+	detachCycle() {
+		this.cycle = null;
+	}
+
+	attachCycle() {
+		this.cycle = globalCycle;
+	}
+
+	changeCycleData() {
+		this.cycle.data = "bar";
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/ParentLoop.ux
+++ b/Source/Fuse.Models/Tests/UX/ParentLoop.ux
@@ -1,0 +1,5 @@
+<Panel ux:Class="UX.Model.ParentLoop" Model="UX/ParentLoop">
+	<FuseTest.Invoke ux:Name="detachCycle" Handler="{detachCycle}" />
+	<FuseTest.Invoke ux:Name="attachCycle" Handler="{attachCycle}" />
+	<FuseTest.Invoke ux:Name="changeCycleData" Handler="{changeCycleData}" />
+</Panel>


### PR DESCRIPTION
This fixes a bug where computePath() would look at the first valid parent of a node, and traverse upward from there. This could lead it to get into a cycle. We now keep track of visited parents, so that we only visit each meta node at most once.

Fixes #902 

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests

  