### PR TITLE
Fix/undo position size feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 ## Element
 - Fixed an incorrect cascade of `MinWidth` / `MinHeight`. This could only be noticed in certain scenarios using `BoxSizing="FillAspect"`.
 - Fixed the `width`, `height`, `x`, and `y` functions to support an element losing its layout. They become undefined in this case, thus allowing a syntax like `width(element) ?? 50`
-- Added `Size` and `Position` to `Element` as an alternate way to control the layout. This is useful for some animation and binding situations.
 
 ## StackPanel
 - Fixed the invalid propagation of MaxWidth/MaxHeight in a StackPanel to its children

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## Element
 - Fixed an incorrect cascade of `MinWidth` / `MinHeight`. This could only be noticed in certain scenarios using `BoxSizing="FillAspect"`.
 - Fixed the `width`, `height`, `x`, and `y` functions to support an element losing its layout. They become undefined in this case, thus allowing a syntax like `width(element) ?? 50`
-- Added `WidthHeight` and `XY` to `Element` as an alternate way to control the layout. This is useful for some animation and binding situations.
+- Added `Size` and `Position` to `Element` as an alternate way to control the layout. This is useful for some animation and binding situations.
 
 ## StackPanel
 - Fixed the invalid propagation of MaxWidth/MaxHeight in a StackPanel to its children

--- a/Source/Fuse.Elements/Element.Layout.Properties.uno
+++ b/Source/Fuse.Elements/Element.Layout.Properties.uno
@@ -57,7 +57,7 @@ namespace Fuse.Elements
 		
 			See @Layout for more details.
 		*/
-		public Size2 WidthHeight
+		public Size2 Size
 		{
 			get { return new Size2(Width, Height); }
 			set
@@ -360,7 +360,7 @@ namespace Fuse.Elements
 		
 			If using this property avoid using `X` or `Y` properties, as this is an combined alias for those properties. Choose the property that works easier for your desired bindined, expressions and animations.
 		*/
-		public Size2 XY
+		public Size2 Position
 		{
 			get { return new Size2(X, Y); }
 			set

--- a/Source/Fuse.Elements/Element.Layout.Properties.uno
+++ b/Source/Fuse.Elements/Element.Layout.Properties.uno
@@ -51,22 +51,6 @@ namespace Fuse.Elements
 			}
 		}
 		
-		/** The combined `Width` and `Height` of the element.
-		
-			If using this property avoid using `Width` or `Height` properties, as this is an combined alias for those properties. Choose the property that works easier for your desired bindined, expressions and animations.
-		
-			See @Layout for more details.
-		*/
-		public Size2 Size
-		{
-			get { return new Size2(Width, Height); }
-			set
-			{
-				Width = value.X;
-				Height = value.Y;
-			}
-		}
-
 		/** The minimum width of the `Element`.
 
 			Used to ensure an element will have at least the given width on-screen.
@@ -356,20 +340,6 @@ namespace Fuse.Elements
 			}
 		}
 		
-		/** The combined `X` and `Y` position of the element.
-		
-			If using this property avoid using `X` or `Y` properties, as this is an combined alias for those properties. Choose the property that works easier for your desired bindined, expressions and animations.
-		*/
-		public Size2 Position
-		{
-			get { return new Size2(X, Y); }
-			set
-			{
-				X = value.X;
-				Y = value.Y;
-			}
-		}
-
 		static readonly Selector _clipToBoundsName = "ClipToBounds";
 
 		/** Clips the child elements to the bounds of this element visually.

--- a/Source/Fuse.Elements/Tests/Element.Test.uno
+++ b/Source/Fuse.Elements/Tests/Element.Test.uno
@@ -8,20 +8,5 @@ namespace Fuse.Elements.Test
 {
 	public class ElementTest : TestBase
 	{
-		[Test]
-		public void PositionSize()
-		{
-			var p = new global::UX.Element.PositionSize();
-			using (var root = TestRootPanel.CreateWithChild(p))
-			{
-				Assert.AreEqual( new Size(20, Unit.Unspecified), p.a.X );
-				Assert.AreEqual( new Size(30, Unit.Percent), p.a.Y );
-				Assert.AreEqual( new Size(40, Unit.Points), p.a.Width );
-				Assert.AreEqual( new Size(50, Unit.Pixels), p.a.Height );
-				
-				Assert.AreEqual( new Size2( new Size(2, Unit.Pixels), new Size(3, Unit.Unspecified)), p.b.Position );
-				Assert.AreEqual( new Size2( new Size(4, Unit.Percent), new Size(5, Unit.Points)), p.b.Size );
-			}
-		}
 	}
 }

--- a/Source/Fuse.Elements/Tests/Element.Test.uno
+++ b/Source/Fuse.Elements/Tests/Element.Test.uno
@@ -19,8 +19,8 @@ namespace Fuse.Elements.Test
 				Assert.AreEqual( new Size(40, Unit.Points), p.a.Width );
 				Assert.AreEqual( new Size(50, Unit.Pixels), p.a.Height );
 				
-				Assert.AreEqual( new Size2( new Size(2, Unit.Pixels), new Size(3, Unit.Unspecified)), p.b.XY );
-				Assert.AreEqual( new Size2( new Size(4, Unit.Percent), new Size(5, Unit.Points)), p.b.WidthHeight );
+				Assert.AreEqual( new Size2( new Size(2, Unit.Pixels), new Size(3, Unit.Unspecified)), p.b.Position );
+				Assert.AreEqual( new Size2( new Size(4, Unit.Percent), new Size(5, Unit.Points)), p.b.Size );
 			}
 		}
 	}

--- a/Source/Fuse.Elements/Tests/UX/Element.PositionSize.ux
+++ b/Source/Fuse.Elements/Tests/UX/Element.PositionSize.ux
@@ -1,4 +1,4 @@
 <Panel ux:Class="UX.Element.PositionSize">
-	<Panel XY="20,30%" WidthHeight="40pt,50px" ux:Name="a"/>
+	<Panel Position="20,30%" Size="40pt,50px" ux:Name="a"/>
 	<Panel X="2px" Y="3" Width="4%" Height="5pt" ux:Name="b"/>
 </Panel>

--- a/Source/Fuse.Elements/Tests/UX/Element.PositionSize.ux
+++ b/Source/Fuse.Elements/Tests/UX/Element.PositionSize.ux
@@ -1,4 +1,0 @@
-<Panel ux:Class="UX.Element.PositionSize">
-	<Panel Position="20,30%" Size="40pt,50px" ux:Name="a"/>
-	<Panel X="2px" Y="3" Width="4%" Height="5pt" ux:Name="b"/>
-</Panel>


### PR DESCRIPTION
This undoes the renaming, and the second commit removes the feature. Once the issue https://github.com/fusetools/fuselibs-public/issues/911 is fixed we can revert the second commit to restore the feature.

I didn't want to revert the entire set of patches, since the original feature contained some non-problematic elements, like the `size()` function.

This PR contains:
- [x] Changelog
- [x] Documentation
- [x] Tests
