### PR TITLE
Fuse.Android/Fuse.Platform: work-around crash on startup

### DIFF
--- a/Source/Fuse.Android/AndroidApp.uno
+++ b/Source/Fuse.Android/AndroidApp.uno
@@ -37,8 +37,6 @@ namespace Fuse
 
 		public App()
 		{
-			Fuse.Platform.SystemUI.OnCreate();
-
 			Fuse.Android.StatusBarConfig.SetStatusBarColor(float4(0));
 
 			Fuse.Controls.TextControl.TextRendererFactory = Fuse.Android.TextRenderer.Create;

--- a/Source/Fuse.Platform/Android/SystemUI.uno
+++ b/Source/Fuse.Platform/Android/SystemUI.uno
@@ -391,6 +391,8 @@ namespace Fuse.Platform
 		[Foreign(Language.Java)]
 		static void SetAsRootView(Java.Object view)
 		@{
+			@{Fuse.Platform.SystemUI.OnCreate():Call()};
+
 			final View uview = (View)view;
 			com.fuse.Activity.getRootActivity().runOnUiThread(new Runnable() { public void run() {
 				if (uview==null)


### PR DESCRIPTION
It seems some bad assumptions about static-initializer order has
been made, causing a crash if Fuse.Android.AppRoot gets initialized
before the Fuse.App-constructor is run.

So let's work around it, by calling SystemUI.OnCreate from inside
SystemUI.SetAsRootView() instead.

This is a nasty hack, but it fixes the start-up issue. The code
needs to be made more robust, though.
