### PR TITLE
Model: Fix dangling parent bug

### DIFF
--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -617,6 +617,20 @@ namespace Fuse.Models.Test
 			}
 		}
 
+		[Test]
+		public void DisconnectOnUpdate()
+		{
+			var e = new UX.Model.DisconnectOnUpdate();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				e.step1.Perform();
+				root.StepFrameJS();
+
+				e.step2.Perform();
+				root.StepFrameJS();
+			}
+		}
+
 		static List<T> ChildrenOfType<T>(Visual n) where T : Node
 		{
 			var l = new List<T>();

--- a/Source/Fuse.Models/Tests/UX/DisconnectOnUpdate.js
+++ b/Source/Fuse.Models/Tests/UX/DisconnectOnUpdate.js
@@ -1,0 +1,39 @@
+let throwOnParentGetter = false;
+class Parent {
+	constructor(child) {
+		this.child = child;
+	}
+
+	get foo() {
+		if(throwOnParentGetter)
+			throw new Error("Evaluated getter of dangling parent.");
+	}
+}
+
+class Child {
+	constructor() {
+		this.data = "foo";
+	}
+}
+
+export default class Root {
+	constructor() {
+		this.child = new Child();
+		this.parent = new Parent(this.child);
+	}
+
+	step1() {
+		this.parent.child = 0;
+		// Change root.parent.child to be a primitive value (not an object).
+		// This would trigger a bad code path in the differ where the parent
+		// would be left dangling in the child's parent list.
+	}
+
+	step2() {
+		throwOnParentGetter = true;
+		this.child.data = "bar";
+		// Change something to trigger re-evaluation of getters upwards the parent graph.
+		// If <parent> was left dangling as a parent of <child>, its getters
+		// will also be re-evaluated, which will throw an error and fail the test.
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/DisconnectOnUpdate.ux
+++ b/Source/Fuse.Models/Tests/UX/DisconnectOnUpdate.ux
@@ -1,0 +1,4 @@
+<Panel ux:Class="UX.Model.DisconnectOnUpdate" Model="UX/DisconnectOnUpdate">
+	<FuseTest.Invoke ux:Name="step1" Handler="{step1}" />
+	<FuseTest.Invoke ux:Name="step2" Handler="{step2}" />
+</Panel>


### PR DESCRIPTION
This fixes a bug where, if the value of a property changed from an object reference to a primitive value, the parent would be left dangling in its former child's parent list.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [x] Tests
