### PR TITLE
Fuse.Reactive.Expressions: implement LogicalNot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Expressions
 - Added support for boolean `==` and `!=` expressions, which can be used for things like negating boolean expressions.
+- Added support for the logical not operator. This means you can do "!someBoolean" to logically negate it.
 - Fixed negation operator (`-`, eg. `-someValue`).
 
 ### DatePicker/TimePicker
 - Fixed an Uno reflection bug that caused these pickers to crash in preview.
+
 ### ScrollView
 - Fixed bug where ScrollView's inside a NativeViewHost would scroll to fast
 - Fixed bug where the scrolling indicator in a native ScrollView would not show on iOS

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/UnaryOperator.Basic.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/UnaryOperator.Basic.ux
@@ -1,7 +1,14 @@
 <Panel ux:Class="UX.UnaryOperator.Basic">
 	<FuseTest.Data Value=" 'hi' " ux:Name="v"/>
+	<FuseTest.Data StringValue="{= true }" ux:Name="truth"/>
+	<FuseTest.Data StringValue="{= false }" ux:Name="falsehood"/>
 	
 	<FuseTest.DudElement StringValue="{= _unJoin('ab') }" ux:Name="a"/>
 	<FuseTest.DudElement StringValue="{= _unJoin({none}) ?? 'x' }" ux:Name="b"/>
 	<FuseTest.DudElement StringValue="{= _unJoin({v}) }" ux:Name="c"/>
+
+	<FuseTest.DudElement BoolValue="{truth}" ux:Name="d"/>
+	<FuseTest.DudElement BoolValue="!{truth}" ux:Name="e"/>
+	<FuseTest.DudElement BoolValue="{falsehood}" ux:Name="f"/>
+	<FuseTest.DudElement BoolValue="!{falsehood}" ux:Name="g"/>
 </Panel>

--- a/Source/Fuse.Reactive.Expressions/Tests/UnaryOperator.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/UnaryOperator.Test.uno
@@ -40,6 +40,11 @@ namespace Fuse.Reactive.Test
 				Assert.AreEqual( "[ab]", p.a.StringValue);
 				Assert.AreEqual( "x", p.b.StringValue);
 				Assert.AreEqual( "[hi]", p.c.StringValue);
+
+				Assert.AreEqual(true, p.d.BoolValue);
+				Assert.AreEqual(false, p.e.BoolValue);
+				Assert.AreEqual(false, p.f.BoolValue);
+				Assert.AreEqual(true, p.g.BoolValue);
 			}
 		}
 	}

--- a/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
+++ b/Source/Fuse.Reactive.Expressions/UnaryOperator.uno
@@ -77,4 +77,22 @@ namespace Fuse.Reactive
 			return Marshal.TryMultiply(operand, -1, out result);
 		}
 	}
+
+	public sealed class LogicalNot: UnaryOperator
+	{
+		[UXConstructor]
+		public LogicalNot([UXParameter("Operand")] Expression operand): base(operand) {}
+
+		protected override bool TryCompute(object operand, out object result)
+		{
+			bool areEqual;
+			if (!Marshal.TryEqualTo(operand, true, out areEqual))
+			{
+				result = false;
+				return false;
+			}
+			result = !areEqual;
+			return true;
+		}
+	}
 }


### PR DESCRIPTION
Being able to use the logical not operator seems neat, and we already
have support in the parser. Seems we're just missing the actual
implementation, so let's add that.

Fixes #915.

This PR contains:
- [x] Changelog
- [x] Tests
