### PR TITLE
Android: fix ImageView transform issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### Image
+- Fixed issue where `<Image />` inside a `<NativeViewHost />` on android could display incorrectly
+
 ### ScrollView
 - Fixed bug where ScrollView's inside a NativeViewHost would scroll to fast
 - Fixed bug where the scrolling indicator in a native ScrollView would not show on iOS

--- a/Source/Fuse.Controls.Native/Android/ImageView.uno
+++ b/Source/Fuse.Controls.Native/Android/ImageView.uno
@@ -141,13 +141,17 @@ namespace Fuse.Controls.Native.Android
 
 		public void UpdateImageTransform(float density, float2 origin, float2 scale, float2 drawSize)
 		{
-			SetImageSize(drawSize * density);
-			SetImageMatrix(
+			var imagePos = (int2)Math.Ceil(origin * density);
+			var imageSize = (int2)Math.Ceil(drawSize * density);
+			var imageScale = scale * density;
+			UpdateImageTransform(
 				_imageView,
-				origin.X * density,
-				origin.Y * density,
-				scale.X * density,
-				scale.Y * density);
+				imagePos.X,
+				imagePos.Y,
+				imageSize.X,
+				imageSize.Y,
+				imageScale.X,
+				imageScale.Y);
 		}
 
 		IDisposable _imageHandle;
@@ -224,27 +228,19 @@ namespace Fuse.Controls.Native.Android
 			wh.set(1, imageView.getMeasuredHeight());
 		@}
 
-		void SetImageSize(float2 size)
-		{
-			var wh = new int[]{ (int)size.X, (int)size.Y };
-			SetImageSize(_imageView, wh);
-		}
-
 		[Foreign(Language.Java)]
-		static void SetImageSize(Java.Object handle, int[] wh)
+		static void UpdateImageTransform(Java.Object handle, int x, int y, int w, int h, float scaleX, float scaleY)
 		@{
 			android.widget.ImageView imageView = (android.widget.ImageView)handle;
-			imageView.setLayoutParams(new android.widget.RelativeLayout.LayoutParams(wh.get(0), wh.get(1)));
-		@}
 
-		[Foreign(Language.Java)]
-		static void SetImageMatrix(Java.Object handle, float x, float y, float scaleX, float scaleY)
-		@{
-			android.widget.ImageView imageView = (android.widget.ImageView)handle;
+			android.widget.FrameLayout.LayoutParams lp = new android.widget.FrameLayout.LayoutParams(w, h);
+			lp.setMargins(x, y, 0, 0);
+			imageView.setLayoutParams(lp);
+
 			float[] m = new float[]
 			{
-				scaleX, 0.0f, 	x,
-				0.0f,	scaleY, y,
+				scaleX, 0.0f, 	0.0f,
+				0.0f,	scaleY, 0.0f,
 				0.0f,	0.0f,	1.0f
 			};
 			android.graphics.Matrix matrix = new android.graphics.Matrix();
@@ -278,24 +274,24 @@ namespace Fuse.Controls.Native.Android
 		[Foreign(Language.Java)]
 		static Java.Object Create(Java.Object container)
 		@{
-			android.widget.RelativeLayout relativeLayout = (android.widget.RelativeLayout)container;
+			android.widget.FrameLayout frameLayout = (android.widget.FrameLayout)container;
 			android.widget.ImageView imageView = new android.widget.ImageView(com.fuse.Activity.getRootActivity());
 			imageView.setScaleType(android.widget.ImageView.ScaleType.MATRIX);
-			imageView.setLayoutParams(new android.widget.RelativeLayout.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT, android.view.ViewGroup.LayoutParams.MATCH_PARENT));
-			relativeLayout.addView(imageView);
+			imageView.setLayoutParams(new android.widget.FrameLayout.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT, android.view.ViewGroup.LayoutParams.MATCH_PARENT));
+			frameLayout.addView(imageView);
 			return imageView;
 		@}
 
 		[Foreign(Language.Java)]
 		static Java.Object CreateContainer()
 		@{
-			android.widget.RelativeLayout relativeLayout = new android.widget.RelativeLayout(com.fuse.Activity.getRootActivity());
-			relativeLayout.setFocusable(true);
-			relativeLayout.setFocusableInTouchMode(true);
-			relativeLayout.setClipToPadding(true);
-			relativeLayout.setClipChildren(true);
-			relativeLayout.setLayoutParams(new android.widget.RelativeLayout.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT, android.view.ViewGroup.LayoutParams.MATCH_PARENT));
-			return relativeLayout;
+			android.widget.FrameLayout frameLayout = new android.widget.FrameLayout(com.fuse.Activity.getRootActivity());
+			frameLayout.setFocusable(true);
+			frameLayout.setFocusableInTouchMode(true);
+			frameLayout.setClipToPadding(true);
+			frameLayout.setClipChildren(true);
+			frameLayout.setLayoutParams(new android.widget.FrameLayout.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT, android.view.ViewGroup.LayoutParams.MATCH_PARENT));
+			return frameLayout;
 		@}
 
 	}


### PR DESCRIPTION
The native imageview was transformed incorrectly, making native images
in certain cases be clipped and not match how it would look in a
GraphicsView

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
