### PR TITLE
fixes the linearGradient on dotnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## LinearGradient
+- Fixes invalid gradients in desktop preview (DotNet targets)
+
 ## Expressions
 - Added support for boolean `==` and `!=` expressions, which can be used for things like negating expressions.
 


### PR DESCRIPTION
This needs to be tested on Windows: I tested only DotNet on OSX.  I'm including  reference photo (CoreGraphics output, which is the same as the DotNet output on OSX).

_Note: The fix isn't complete per-se, you can still create gradients that fail by making the gradient line not cross the fill region. It's not a normal use-case, and would take more effort to fix than I think is desired now._

Test project: https://github.com/mortoray/fork-sandbox/tree/master/Jan2018/LinearGrad

<img width="758" alt="screen shot 2018-01-17 at 11 36 10" src="https://user-images.githubusercontent.com/1308999/35038484-3f415948-fb7b-11e7-8bca-0f613811bd2c.png">

fixes https://github.com/fusetools/fuselibs-public/issues/936
fixes https://github.com/fusetools/fuselibs-public/issues/841

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [ ] ~Tests~
