### PR TITLE
fixes invalid page reuse for context based pages (1.6 version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Unreleased
 
-
 # 1.6
 
 ## 1.6.1
 
 ### Fuse.Scripting
 - Restore accidentally broken NativeEvent.RaiseAsync() API.
+## Navigator
+- Fixed the invalid reuse of an existing page if the context does not match
 
 ## 1.6.0
 

--- a/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
@@ -185,7 +185,7 @@ namespace Fuse.Controls
 			var pd = PageData.Get(v);
 			if (pd == null)
 				return null;
-				
+			
 			return pd.Context;
 		}
 	}

--- a/Source/Fuse.Controls.Navigation/Navigator.uno
+++ b/Source/Fuse.Controls.Navigation/Navigator.uno
@@ -218,7 +218,7 @@ namespace Fuse.Controls
 					return new PrepareResult{ Page = curPage, Routing = RoutingResult.NoChange };
 					
 				// https://github.com/fusetools/fuselibs/issues/2982
-				var compat = CompatibleParameter(routerPage.Parameter, curPage.RouterPage.Parameter);
+				var compat = CompatibleParameter(routerPage.Parameter, curPage.RouterPage.Parameter) && routerPage.Context == curPage.RouterPage.Context;
 					
 				//reusable page with parameter change
 				var reuse = operation == RoutingOperation.Goto && IsReuseLevel(curPageVisual, ReuseType.Any);

--- a/Source/Fuse.Controls.Navigation/PageControl.uno
+++ b/Source/Fuse.Controls.Navigation/PageControl.uno
@@ -196,9 +196,12 @@ namespace Fuse.Controls
 				return RoutingResult.Change;
 				
 			pageVisual = useVisual;
-			if (useVisual.Parameter == routerPage.Parameter)
+			var pageData = PageData.GetOrCreate(pageVisual);
+			if (useVisual.Parameter == routerPage.Parameter &&
+				routerPage.Context == pageData.Context)
 				return RoutingResult.NoChange;
 				
+			//TODO: Navigator only returns MinorChange here, never Change
 			return CompatibleParameter(useVisual.Parameter, routerPage.Parameter) ?
 				RoutingResult.MinorChange : RoutingResult.Change;
 		}
@@ -213,8 +216,10 @@ namespace Fuse.Controls
 				return RoutingResult.Invalid;
 
 			pageVisual = useVisual;
-			bool same = useVisual.Parameter == routerPage.Parameter;
-			PageData.GetOrCreate(useVisual).AttachRouterPage(routerPage);
+			var pageData = PageData.GetOrCreate(useVisual);
+			bool same = useVisual.Parameter == routerPage.Parameter &&
+				pageData.Context == routerPage.Context;
+			pageData.AttachRouterPage(routerPage);
 			if (useVisual == Active) 
 				return same ? RoutingResult.NoChange : RoutingResult.MinorChange;
 			

--- a/Source/Fuse.Controls.Navigation/Tests/Navigator.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Navigator.Test.uno
@@ -837,6 +837,26 @@ namespace Fuse.Navigation.Test
 			}
 		}
 		
+		[Test]
+		//different context's should be treated like different parameters
+		public void ContextNoReuse()
+		{
+			var p = new UX.Navigator.ContextNoReuse();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual( "dog", GetRecursiveText(p.theNav));
+				
+				p.callPushTwo.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "dog,cat", GetRecursiveText(p.theNav));
+				
+				p.callReplaceThree.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "dog,weasel", GetRecursiveText(p.theNav));
+			}
+		}
+		
 		RouterPage _lastPage;
 		string _lastOperationStyle;
 		NavigationGotoMode _lastGotoMode;

--- a/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
@@ -685,7 +685,7 @@ namespace Fuse.Navigation.Test
 			using (var root = TestRootPanel.CreateWithChild(p))
 			{
 				p.gotoR.Pulse();
-				root.StepFrame();
+				root.StepFrameJS();
 				Assert.AreEqual( "5", GetText(p.nav.Active));
 				
 				p.pushSecond.Pulse();

--- a/Source/Fuse.Controls.Navigation/Tests/UX/Navigator.ContextNoReuse.ux
+++ b/Source/Fuse.Controls.Navigation/Tests/UX/Navigator.ContextNoReuse.ux
@@ -1,0 +1,32 @@
+<Panel ux:Class="UX.Navigator.ContextNoReuse">
+	<JavaScript>
+		var Observable = require("FuseJS/Observable")
+		
+		exports.pages = Observable({ 
+			$path: "MyPage",
+			value: "dog" ,
+		})
+		
+		exports.pushTwo = function() {
+			exports.pages.add({
+				$path: "MyPage",
+				value: "cat",
+			})
+		}
+		
+		exports.replaceThree = function() {
+			exports.pages.replaceAt( exports.pages.length - 1, {
+				$path: "MyPage",
+				value: "weasel",
+			})
+		}
+	</JavaScript>
+	<Navigator Pages="{pages}" ux:Name="theNav" Transition="None">
+		<Panel ux:Template="MyPage">
+			<Text Value="{value}"/>
+		</Panel>
+		
+		<FuseTest.Invoke Handler="{pushTwo}" ux:Name="callPushTwo"/>
+		<FuseTest.Invoke Handler="{replaceThree}" ux:Name="callReplaceThree"/>
+	</Navigator>
+</Panel>

--- a/Source/Fuse.Controls.Navigation/Tests/UX/Router.ModifyObject.ux
+++ b/Source/Fuse.Controls.Navigation/Tests/UX/Router.ModifyObject.ux
@@ -29,7 +29,7 @@
 			<PageControl>
 				<Panel ux:Name="first">
 					<WhileActive>
-						<Text Value="1.{title}"/>
+						<Text Value="1.{= {title} ?? 'nope' }"/>
 					</WhileActive>
 				</Panel>
 				<Panel ux:Name="second">

--- a/Source/Fuse.Navigation/PageData.uno
+++ b/Source/Fuse.Navigation/PageData.uno
@@ -45,8 +45,8 @@ namespace Fuse.Navigation
 			}
 			
 			this.RouterPage = rp;
-			visual.Prepare(rp.Parameter);
 			UpdateContextData( visual, rp.Context );
+			visual.Prepare(rp.Parameter);
 			
 			if (RouterPageChanged != null)
 				RouterPageChanged( this, rp );


### PR DESCRIPTION
*NOTE*: This fix has been merged into master already. We considered it too risky for 1.6 for now, but it remains here in case it becomes a more serious problem.

rebase on release-1.6 based on @duckers request

This replaces https://github.com/fusetools/fuselibs-public/pull/946

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [x] Tests
