### PR TITLE
Make stuff/uno pack use same versioning scheme

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -5,12 +5,7 @@ cd "`dirname "$SELF"`" || exit 1
 PATH="Stuff:$PATH"
 OUT="upload"
 
-# Detect version
-if [ -n "$RELEASE_VERSION" ]; then
-    VERSION="$RELEASE_VERSION"
-else
-    VERSION=$(cat VERSION.txt)"-local"
-fi
+VERSION=$(cat VERSION.txt)
 
 # Detect revision
 if [ -n "$BUILD_VCS_NUMBER" ]; then
@@ -28,13 +23,16 @@ fi
 # use commit SHA as prerelease suffix
 case $BRANCH in
 release-*)
-    SUFFIX=
+    UNO_SUFFIX=
+    STUFF_SUFFIX="--suffix=-$VERSION"
     ;;
 master)
-    SUFFIX="--suffix=master-$REVISION"
+    UNO_SUFFIX="--suffix=master-$REVISION"
+    STUFF_SUFFIX="--suffix=-$VERSION-master-$REVISION"
     ;;
 *)
-    SUFFIX="--suffix=dev-$REVISION"
+    UNO_SUFFIX="--suffix=dev-$REVISION"
+    STUFF_SUFFIX="--suffix=-$VERSION-dev-$REVISION"
     ;;
 esac
 
@@ -49,18 +47,18 @@ for f in Source/*; do
     if [ -f "$project" ]; then
         uno pack "$project" \
             --out-dir="$OUT" \
-            $SUFFIX
+            $UNO_SUFFIX
     fi
 done
 
 stuff pack ProjectTemplates \
     --name=ProjectTemplates \
-    --suffix=-$VERSION \
+    $STUFF_SUFFIX \
     --output-dir=ProjectTemplatesUpload
 
 stuff pack Tests/AutomaticTestApp \
     --name=AutomaticTestApp \
-    --suffix=-$VERSION \
+    $STUFF_SUFFIX \
     --output-dir=AutomaticTestAppUpload
 
 # Build standalone release


### PR DESCRIPTION
This should change the versioning of artifacts built with `stuff pack`
to be the same as for artifacts built with `uno pack`. In particular,
`AutomaticTestApp.stuff` and `ProjectTemplates.stuff` will now get the
same version numbers as `fuselibs.packages`. This will make things less
confusing for consumers of these packages.

### Testing

#### Locally
I've tested this locally, here are examples from applying the patch to master, a release branch and another branch:

##### master
Before:
```
Creating upload/Polyfills.Window-1.6.0-rc1-master-070b904.upk  0.26 s
Creating ProjectTemplatesUpload/ProjectTemplates-1.6.0-rc1-local.zip
```
After:
```
Creating upload/Polyfills.Window-1.6.0-rc1-master-bc5baca.upk  0.24 s
Creating ProjectTemplatesUpload/ProjectTemplates-1.6.0-rc1-master-bc5baca.zip
```

##### release branch
Before:
```
Creating upload/Polyfills.Window-1.6.0-rc1.upk  0.24 s
Creating ProjectTemplatesUpload/ProjectTemplates-1.6.0-rc1-local.zip
```
After:
```
Creating upload/Polyfills.Window-1.6.0-rc1.upk  0.23 s
Creating ProjectTemplatesUpload/ProjectTemplates-1.6.0-rc1.zip
```

##### feature branch
Before:
```
Creating upload/Polyfills.Window-1.6.0-rc1-dev-070b904.upk  0.24 s
Creating ProjectTemplatesUpload/ProjectTemplates-1.6.0-rc1-local.zip
```
After:
```
Creating upload/Polyfills.Window-1.6.0-rc1-dev-793254c.upk  0.23 s
Creating ProjectTemplatesUpload/ProjectTemplates-1.6.0-rc1-dev-793254c.zip
```

#### In CI

Obviously, I'm not able to test the behaviour of my PR in branches with these names in our CI servers, which is where it really matters. But I've checked which types of version numbers our CI server produces for each type of branch:

```
master: -1.6.0-rc1-master-c8bc166
release: -1.6.0-rc1
other: -1.4.0-rc1-dev-7d6fc20
```

So the new versioning scheme should work both locally and in CI.