### PR TITLE
Model: Fix pushing an array onto an array

### DIFF
--- a/Source/Fuse.Models/FuseJS/Internal/Model.js
+++ b/Source/Fuse.Models/FuseJS/Internal/Model.js
@@ -467,7 +467,7 @@ function Model(initialState, stateInitializer)
 			node.splice(index, 0, null);
 			node[index] = item = wrap(index, item)
 			
-			TreeObservable.insertAt.apply(store, getPath().concat(index, item));
+			TreeObservable.insertAt.apply(store, getPath().concat([index, item]));
 			changesDetected++;
 		}
 
@@ -476,7 +476,7 @@ function Model(initialState, stateInitializer)
 				var index = node.length;
 				node.push(null);
 				node[index] = item = wrap(index, item);
-				TreeObservable.add.apply(store, getPath().concat(item));
+				TreeObservable.add.apply(store, getPath().concat([item]));
 			}
 			
 			changesDetected++;

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -12,6 +12,20 @@ namespace Fuse.Models.Test
 	public class ModelTest : ModelTestBase
 	{
 		[Test]
+		public void NestedArray()
+		{
+			var e = new UX.Model.NestedArray();
+			using(var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("", GetRecursiveText(e));
+				e.push.Perform(); // Throws if test fails
+				root.StepFrameJS();
+				Assert.AreEqual("0,1,2", GetRecursiveText(e));
+			}
+		}
+
+		[Test]
 		public void ReplaceAt() 
 		{
 			var e = new UX.Model.ReplaceAt();

--- a/Source/Fuse.Models/Tests/UX/NestedArray.js
+++ b/Source/Fuse.Models/Tests/UX/NestedArray.js
@@ -1,0 +1,9 @@
+export default class {
+	constructor() {
+		this.array = [];
+	}
+
+	push() {
+		this.array.push([0,1,2]);
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/NestedArray.ux
+++ b/Source/Fuse.Models/Tests/UX/NestedArray.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.Model.NestedArray" Model="UX/NestedArray">
+	<Each Items="{array}">
+		<Each Items="{}">
+			<Text Value="{}" />
+		</Each>
+	</Each>
+	<FuseTest.Invoke ux:Name="push" Handler="{push}" />
+</Panel>


### PR DESCRIPTION
This fixes a severe bug in Model where we get a crash when pushing an array onto an array.

`Array.prototype.concat()` is recursive up to one level.
This means that if one of the arguments is an array, then its elements,
rather than the array itself, will be appended to the original array.
This changes it to always wrap the value in a single-element array,
which gives us the intended behavior.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [x] Tests
