### PR TITLE
Fixes router.goBack with duplicate path items

### DIFF
--- a/CHANGELOG/router_goback_doublepush.md
+++ b/CHANGELOG/router_goback_doublepush.md
@@ -1,0 +1,2 @@
+## Router
+- Fixed `goBack` to properly modify the route with two duplicate routes in the history

--- a/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
@@ -712,6 +712,33 @@ namespace Fuse.Navigation.Test
 				Assert.AreEqual( "?9,ii.bub", GetRecursiveText(p.nav.Active));
 			}
 		}
+		
+		[Test]
+		//Based on https://github.com/fusetools/fuselibs-public/issues/939
+		public void DoublePushGoBack()
+		{
+			var p = new UX.Router.DoublePushGoBack();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual( "one", SafeFormat(p.router.GetHistoryRoute(0)) );
+				Assert.AreEqual( null, p.router.GetHistoryRoute(1) );
+				
+				p.callPush.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "two?{}", SafeFormat(p.router.GetHistoryRoute(0)) );
+				Assert.AreEqual( "two?{}", SafeFormat(p.router.GetHistoryRoute(1)) );
+				Assert.AreEqual( "one", SafeFormat(p.router.GetHistoryRoute(2)) );
+				Assert.AreEqual( null, p.router.GetHistoryRoute(3) );
+				
+				p.callGoBack.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual( "two?{}", SafeFormat(p.router.GetHistoryRoute(0)) );
+				Assert.AreEqual( "one", SafeFormat(p.router.GetHistoryRoute(1)) );
+				Assert.AreEqual( null, p.router.GetHistoryRoute(2) );
+			}
+		}
+		
 	}
 }
 	

--- a/Source/Fuse.Controls.Navigation/Tests/UX/Router.DoublePushGoBack.ux
+++ b/Source/Fuse.Controls.Navigation/Tests/UX/Router.DoublePushGoBack.ux
@@ -1,0 +1,20 @@
+<Panel ux:Class="UX.Router.DoublePushGoBack">
+	<JavaScript>
+		exports.push = function() {
+			router.push("two", {})
+			router.push("two", {})
+		}
+	
+		exports.goBack = function() {
+			router.goBack()
+		}
+	</JavaScript>
+	<Router ux:Name="router" />
+	<Navigator DefaultPath="one">
+		<Panel ux:Template="one" />
+		<Panel ux:Template="two" />
+	</Navigator>
+
+	<FuseTest.Invoke Handler="{push}" ux:Name="callPush"/>
+	<FuseTest.Invoke Handler="{goBack}" ux:Name="callGoBack"/>
+</Panel>

--- a/Source/Fuse.Navigation/Router.uno
+++ b/Source/Fuse.Navigation/Router.uno
@@ -426,8 +426,8 @@ namespace Fuse.Navigation
 				return null;
 			
 			//pushing/goto up to the leaf route can reuse existing matching pages
-			bool leafPush = r.SubRoute == null && operation == RoutingOperation.Push;
-			bool reusePage = canReuse && didTransition == RoutingResult.NoChange && !leafPush;
+			bool leafOp = r.SubRoute == null && operation != RoutingOperation.Goto;
+			bool reusePage = canReuse && didTransition == RoutingResult.NoChange && !leafOp;
 			if (reusePage)
 				page = outlet.GetCurrent(out pageVisual);
 			


### PR DESCRIPTION
fixes https://github.com/fusetools/fuselibs-public/issues/939

This PR contains:
- [x] Changelog
- [ ] ~Documentation~ -- no api change
- [x] Tests
