### PR TITLE
Fuse.Scripting: restore the old NativeEvent.RaiseAsync API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 # 1.6
 
+## 1.6.1
+
+### Fuse.Scripting
+- Restore accidentally broken NativeEvent.RaiseAsync() API.
+
 ## 1.6.0
 
 ### Image

--- a/Source/Fuse.Scripting/NativeEvent.uno
+++ b/Source/Fuse.Scripting/NativeEvent.uno
@@ -50,6 +50,15 @@ namespace Fuse.Scripting
 				threadWorker.Invoke(new CallDiscardingResultClosure(_jsFunction, _eventArgsQueue.Dequeue()).Run);
 		}
 
+		[Obsolete("Use `RaiseAsync(IThreadWorker, params object[])` instead")]
+		public void RaiseAsync(params object[] args)
+		{
+			if(Context != null || _queueEventsBeforeEvaluation)
+				_eventArgsQueue.Enqueue(args);
+
+			DispatchQueue(Context.ThreadWorker);
+		}
+
 		public void RaiseAsync(IThreadWorker threadWorker, params object[] args)
 		{
 			if(Context != null || _queueEventsBeforeEvaluation)


### PR DESCRIPTION
This was an unintended hard API-breakage, but luckily it's pretty
simple to fix.

We mark the API as obsolete, so people can forward-port their code
to be correct.

Fixes #979.

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [ ] ~Tests~
