### PR TITLE
Model: Fix parent refs on array manipulation

### DIFF
--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -25,6 +25,22 @@ namespace Fuse.Models.Test
 			}
 		}
 
+		public void ArrayParentMeta()
+		{
+			var e = new UX.Model.ArrayParentMeta();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("foo,bar,baz", GetRecursiveText(e));
+				e.step1.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual("foo,baz", GetRecursiveText(e));
+				e.step2.Perform();
+				root.StepFrameJS(); // Throws if test fails
+				Assert.AreEqual("baz,baz", GetRecursiveText(e));
+			}
+		}
+
 		[Test]
 		public void ReplaceAt() 
 		{

--- a/Source/Fuse.Models/Tests/UX/ArrayParentMeta.js
+++ b/Source/Fuse.Models/Tests/UX/ArrayParentMeta.js
@@ -1,0 +1,17 @@
+export default class {
+	constructor() {
+		this.array = [
+			{ str: "foo" },
+			{ str: "bar" },
+			{ str: "baz" }
+		];
+	}
+
+	step1() {
+		this.array.splice(1, 1);
+	}
+
+	step2() {
+		this.array[0] = { str: "baz" };
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/ArrayParentMeta.ux
+++ b/Source/Fuse.Models/Tests/UX/ArrayParentMeta.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.Model.ArrayParentMeta" Model="UX/ArrayParentMeta">
+	<Each Items="{array}">
+		<Text Value="{str}" />
+	</Each>
+
+	<FuseTest.Invoke ux:Name="step1" Handler="{step1}" />
+	<FuseTest.Invoke ux:Name="step2" Handler="{step2}" />
+</Panel>


### PR DESCRIPTION
Whenever an element is inserted or removed from an array,
the indices of later elements are also adjusted.
However, for every node in the model graph, we also keep track of which
nodes have a property that refers to this node. These parent references
were not adjusted accordingly.

Now, when we do an `insertAt` or `removeRange`, the parent references
of elements that appear after the index we insert/remove at will be
adjusted accordingly.

Fixes #958

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [x] Tests
