### PR TITLE
Fixes binding to the "prime data context"

### DIFF
--- a/CHANGELOG/data_context_lost.md
+++ b/CHANGELOG/data_context_lost.md
@@ -1,0 +1,2 @@
+## DataContext
+- Removed some deprecated methods and classes from `Node`: `IDataListener`, `OnDataChanged`. These were not meant to be public.

--- a/CHANGELOG/data_context_lost.md
+++ b/CHANGELOG/data_context_lost.md
@@ -1,3 +1,4 @@
 ## DataContext
 - Removed some deprecated methods and classes from `Node`: `IDataListener`, `OnDataChanged`. These were not meant to be public.
 - Deprecated `{}` in favour of the new `data()` function. `{}` had unusual binding rules and would often not bind to the intended context. `data()` always binds to the prime data context, it's unambiguous and predictable.
+- Fixed the object provided to JavaScript callbacks in `args.data`. It will now always be the prime data context, not just the next contextual data.

--- a/CHANGELOG/data_context_lost.md
+++ b/CHANGELOG/data_context_lost.md
@@ -1,2 +1,3 @@
 ## DataContext
 - Removed some deprecated methods and classes from `Node`: `IDataListener`, `OnDataChanged`. These were not meant to be public.
+- Deprecated `{}` in favour of the new `data()` function. `{}` had unusual binding rules and would often not bind to the intended context. `data()` always binds to the prime data context, it's unambiguous and predictable.

--- a/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
+++ b/Source/Fuse.Controls.Navigation/NavigationControl.Pages.uno
@@ -176,17 +176,19 @@ namespace Fuse.Controls
 			FullUpdatePages();
 		}
 		
-		object Node.ISubtreeDataProvider.GetData(Node n)
+		ContextDataResult ISubtreeDataProvider.TryGetDataProvider( Node n, DataType type, out object provider )
 		{
+			provider = null;
 			var v = n as Visual;
 			if (v == null)
-				return null;
+				return ContextDataResult.Continue;
 				
 			var pd = PageData.Get(v);
 			if (pd == null)
-				return null;
+				return ContextDataResult.Continue;
 			
-			return pd.Context;
+			provider = pd.Context;
+			return type == DataType.Prime ? ContextDataResult.NullProvider : ContextDataResult.Continue;
 		}
 	}
 	

--- a/Source/Fuse.Controls.Navigation/PageIndicator.uno
+++ b/Source/Fuse.Controls.Navigation/PageIndicator.uno
@@ -25,7 +25,7 @@ namespace Fuse.Controls
 				</JavaScript>
 				<PageControl ux:Name="nav">
 					<Each Items="{pages}">
-						<Page Color="{}">
+						<Page Color="data()">
 							
 						</Page>
 					</Each>

--- a/Source/Fuse.Models/Tests/UX/Each.ux
+++ b/Source/Fuse.Models/Tests/UX/Each.ux
@@ -1,7 +1,7 @@
 <Panel ux:Class="UX.Model.Each" Model="UX/Each">
 	<Panel ux:Name="a">
 		<Each Items="{simple}">
-			<FuseTest.DudElement StringValue="{}"/>
+			<FuseTest.DudElement StringValue="{= data() }"/>
 		</Each>
 	</Panel>
 	

--- a/Source/Fuse.Models/Tests/UX/EmptyList.ux
+++ b/Source/Fuse.Models/Tests/UX/EmptyList.ux
@@ -6,12 +6,12 @@
     <FuseTest.Invoke Handler="{emptyPromise}" ux:Name="callEmptyPromise" />
     <StackPanel ux:Name="collector1">
         <Each Items="{items}">
-            <Text Value="{}" />
+            <Text Value="{= data() }" />
         </Each>
     </StackPanel>
     <StackPanel ux:Name="collector2">
         <Each Items="{promisedItems}">
-            <Text Value="{}" />
+            <Text Value="{= data() }" />
         </Each>
     </StackPanel>
 </Panel>

--- a/Source/Fuse.Nodes/Fuse.Nodes.unoproj
+++ b/Source/Fuse.Nodes/Fuse.Nodes.unoproj
@@ -33,6 +33,7 @@
     "Fuse.Motion",
     "Fuse.Navigation",
     "Fuse.Reactive.Bindings",
+    "Fuse.Reactive.Bindings.Test",
     "Fuse.Scripting.JavaScript",
     "Fuse.Scripting.JavaScript.Test",
     "Fuse.Selection",

--- a/Source/Fuse.Nodes/Node.DataContext.uno
+++ b/Source/Fuse.Nodes/Node.DataContext.uno
@@ -248,7 +248,7 @@ namespace Fuse
 			if (key == "")
 			{
 				//DEPRECATED: 2018-01-30
-				//Fuse.Diagnostics.UserError( "Binding to an empty key, `{}`, are deprecated due to ambiguity. Use the `data()` expression instead.", this);
+				Fuse.Diagnostics.UserError( "Binding to an empty key, `{}`, is deprecated due to ambiguity. Use the `data()` expression instead.", this);
 			}
 				
 			var dw = new NodeDataSubscription(this, DataType.Key, key, listener);

--- a/Source/Fuse.Nodes/Node.DataContext.uno
+++ b/Source/Fuse.Nodes/Node.DataContext.uno
@@ -8,7 +8,7 @@ namespace Fuse
 		/** When implemented by a `Node`, it indicates that the node provides data for its siblings. 
 			@hide
 		*/
-		//these, and the next interface, are not meant to be public
+		//these, and the next interface, and associated types, are not meant to be public
 		//UNO: https://github.com/fusetools/uno/issues/1524
 		public interface ISiblingDataProvider
 		{
@@ -26,7 +26,9 @@ namespace Fuse
 		/** @hide */
 		public enum DataType
 		{
+			/** A string key in the context */
 			Key,
+			/** A prime data context */
 			Prime,
 		}
 
@@ -41,7 +43,7 @@ namespace Fuse
 			NullProvider,
 		}
 		
-		internal bool TryGetFirstData(out object result)
+		internal bool TryGetPrimeDataContext(out object result)
 		{
 			IObject providerIgnore = null;
 			return TryFindData( DataType.Prime, null, out result, out providerIgnore );

--- a/Source/Fuse.Nodes/Node.DataContext.uno
+++ b/Source/Fuse.Nodes/Node.DataContext.uno
@@ -44,7 +44,7 @@ namespace Fuse
 		internal bool TryGetFirstData(out object result)
 		{
 			IObject providerIgnore = null;
-			return TryFindData( DataType.Key, "", out result, out providerIgnore );
+			return TryFindData( DataType.Prime, null, out result, out providerIgnore );
 		}
 
 		bool AcquireData(DataType type, string key, object data, out object result, out IObject provider)

--- a/Source/Fuse.Reactive.Bindings/DataFunction.uno
+++ b/Source/Fuse.Reactive.Bindings/DataFunction.uno
@@ -6,7 +6,16 @@ namespace Fuse.Reactive
 	/**
 		Binds to the prime context data of this node.
 		
-		Behavior's like @With, @Each, and @Instance introduce a prime data context for their children.  @JavaScript and the `Model` tag do not introduce a prime data context.
+		Behaviors like @With, @Each, and @Instance introduce a prime data context for their children.  @JavaScript and the `Model` tag do not introduce a prime data context.
+		
+		Use `data()` when you wish to bind directly to the prime data context. This is for when your data contains a simple value rather than a data structure.
+		
+			<JavaScript>
+				exports.items = Observable(1,2,3)
+			</JavaScript>
+			<Each Items="{items}">
+				<Text Value="{= data() }"/>
+			</Each>
 	*/
 	[UXFunction("data")]
 	public class DataFunction : Expression

--- a/Source/Fuse.Reactive.Bindings/DataFunction.uno
+++ b/Source/Fuse.Reactive.Bindings/DataFunction.uno
@@ -1,0 +1,81 @@
+using Uno;
+using Uno.UX;
+
+namespace Fuse.Reactive
+{
+	/**
+		Binds to the prime context data of this node.
+		
+		Behavior's like @With, @Each, and @Instance introduce a prime data context for their children.  @JavaScript and the `Model` tag do not introduce a prime data context.
+	*/
+	[UXFunction("data")]
+	public class DataFunction : Expression
+	{
+		[UXConstructor]
+		public DataFunction()
+		{
+		}
+		
+		public override string ToString()
+		{
+			return "data()";
+		}
+		
+		public override IDisposable Subscribe(IContext context, IListener listener)
+		{
+			var sub = new Subscription(this, listener, context.Node);
+			sub.Init();
+			return sub;
+		}
+		
+		class Subscription : IDisposable, Node.IDataListener
+		{
+			DataFunction _expr;
+			IListener _listener;
+			Node _node;
+			
+			Node.NodeDataSubscription _dataSub;
+			
+			public Subscription(DataFunction expr, IListener listener, Node node)
+			{
+				_expr = expr;
+				_listener = listener;
+				_node = node;
+			}
+			
+			public void Init()
+			{
+				_dataSub = _node.SubscribePrimeDataContext(this);
+				UpdateData();
+			}
+			
+			void Node.IDataListener.OnDataChanged()
+			{
+				UpdateData();
+			}
+			
+			void UpdateData()
+			{
+				if (_dataSub == null)
+					return;
+					
+				if (!_dataSub.HasData)
+					_listener.OnLostData(_expr);
+				else
+					_listener.OnNewData(_expr, _dataSub.Data);
+			}
+			
+			public void Dispose()
+			{
+				if (_dataSub != null)
+				{
+					_dataSub.Dispose();
+					_dataSub = null;
+				}
+				_expr = null;
+				_listener = null;
+				_node = null;
+			}
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Bindings/Docs/DataBindingRemarks.md
+++ b/Source/Fuse.Reactive.Bindings/Docs/DataBindingRemarks.md
@@ -33,12 +33,12 @@ Similarly, you can bind to collections:
 		</JavaScript>
 		<StackPanel>
 			<Each Items="{data}">
-				<Text Value="{}" />
+				<Text Value="{= data () }" />
 			</Each>
 		</StackPanel>
 	</App>
 
-This will predictably list out the text strings 1, 2 and 3. When binding the `Text Value` `{}` means _this data context_. Typically, you will bind to more complex data sources, so each element will have something interesting to bind to:
+This will predictably list out the text strings 1, 2 and 3. When binding the `Text Value` `{= data()}` means _the prime data context_, in this case the enumerated item from `Each`. Typically, you will bind to more complex data sources, so each element will have something interesting to bind to:
 
 	<App>
 		<JavaScript>

--- a/Source/Fuse.Reactive.Bindings/EventRecord.uno
+++ b/Source/Fuse.Reactive.Bindings/EventRecord.uno
@@ -21,7 +21,7 @@ namespace Fuse.Reactive
 
 			if (_node != null)
 			{
-				_node.TryGetFirstData( out _data ); //okay as null if not found
+				_node.TryGetPrimeDataContext( out _data ); //okay as null if not found
 				if (_node.Name != null) _sender = _node.Name;
 			}
 

--- a/Source/Fuse.Reactive.Bindings/Instantiator.uno
+++ b/Source/Fuse.Reactive.Bindings/Instantiator.uno
@@ -435,20 +435,23 @@ namespace Fuse.Reactive
 
 		internal int DataCount { get { return _watcher.GetDataCount(); } }
 		
-		object Node.ISubtreeDataProvider.GetData(Node n)
+		ContextDataResult ISubtreeDataProvider.TryGetDataProvider( Node n, DataType type, out object provider )
 		{
+			provider = null;
+			
 			WindowItem v;
 			if (_dataMap.TryGetValue(n, out v))
 			{
 				//https://github.com/fusetools/fuselibs/issues/3312
 				//`Count` does not introduce data items
 				if (v.Data is NoContextItem)
-					return null;
+					return ContextDataResult.Continue;
 					
-				return v.CurrentData;
+				provider = v.CurrentData;
+				return type == DataType.Prime ? ContextDataResult.NullProvider : ContextDataResult.Continue;
 			}
 
-			return null;
+			return ContextDataResult.Continue;
 		}
 		
 		Node GetLastNodeFromIndex(int windowIndex)

--- a/Source/Fuse.Reactive.Bindings/Let.uno
+++ b/Source/Fuse.Reactive.Bindings/Let.uno
@@ -114,9 +114,10 @@ namespace Fuse.Reactive
 			base.OnUnrooted();
 		}		
 		
-		object Node.ISiblingDataProvider.Data
+		ContextDataResult ISiblingDataProvider.TryGetDataProvider( DataType type, out object provider )
 		{
-			get { return this; }
+			provider = type != DataType.Key ? null : this;
+			return ContextDataResult.Continue;
 		}
 		
 		bool IObject.ContainsKey(string key)

--- a/Source/Fuse.Reactive.Bindings/Subscription/DataSubscription.uno
+++ b/Source/Fuse.Reactive.Bindings/Subscription/DataSubscription.uno
@@ -102,7 +102,6 @@ namespace Fuse.Reactive
 		{
 			DisposeSubscription();
 			ClearDiagnostic();
-			_origin.RemoveDataListener(_key, this);
 			_origin = null;
 			_source = null;
 			_listener = null;

--- a/Source/Fuse.Reactive.Bindings/Tests/Data.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/Data.Test.uno
@@ -1,0 +1,22 @@
+using Uno;
+using Uno.UX;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Reactive.Bindings.Test
+{
+	public class DataTest : TestBase
+	{
+		[Test]
+		public void ExcludeJS()
+		{
+			var p = new UX.Data.ExcludeJS();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("hi", GetRecursiveText(p));
+			}
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Bindings/Tests/DataSubscription.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/DataSubscription.Test.uno
@@ -32,5 +32,32 @@ namespace Fuse.Reactive.Bindings.Test
 				Assert.AreEqual( "B", p.b2.Value );
 			}
 		}
+		
+		[Test]
+		//covers the deprecated support for {} bindings
+		public void Deprecated()
+		{
+			var p = new UX.DataSubscription.Deprecated();
+			using (var dg = new RecordDiagnosticGuard())
+			{
+				try
+				{
+					using (var root = TestRootPanel.CreateWithChild(p))
+					{
+						root.StepFrameJS();
+						Assert.AreEqual( "hi", p.a.Value );
+						Assert.AreEqual( "1", GetText(p.b));
+						Assert.AreEqual( "2", GetText(p.c));
+						Assert.AreEqual( "3,4", GetText(p.d));
+					}
+				}
+				finally
+				{
+					var dm = dg.DequeueAll();
+					foreach (var d in dm) 
+						Assert.IsTrue( d.Message.IndexOf( "deprecated" ) != -1 );
+				}
+			}
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Bindings/Tests/EventBinding.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/EventBinding.Test.uno
@@ -20,7 +20,7 @@ namespace Fuse.Reactive.Test
 			void IScriptEvent.Serialize(IEventSerializer s)
 			{
 				object data;
-				if (!Node.TryGetFirstData(out data))
+				if (!Node.TryGetPrimeDataContext(out data))
 					throw new Exception( "Missing data" );
 				s.AddObject("dataContext", data);
 			}

--- a/Source/Fuse.Reactive.Bindings/Tests/EventBinding.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/EventBinding.Test.uno
@@ -19,7 +19,10 @@ namespace Fuse.Reactive.Test
 
 			void IScriptEvent.Serialize(IEventSerializer s)
 			{
-				s.AddObject("dataContext", Node.GetFirstData());
+				object data;
+				if (!Node.TryGetFirstData(out data))
+					throw new Exception( "Missing data" );
+				s.AddObject("dataContext", data);
 			}
 		}
 

--- a/Source/Fuse.Reactive.Bindings/Tests/EventBinding.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/EventBinding.Test.uno
@@ -49,7 +49,7 @@ namespace Fuse.Reactive.Test
 				e.Run.Perform();
 				root.StepFrameJS();
 
-				Assert.AreEqual("\"bar\"", e.Text.Value);
+				Assert.AreEqual("\"bar\"-bar", e.Text.Value);
 			}
 		}
 		

--- a/Source/Fuse.Reactive.Bindings/Tests/EventBinding.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/EventBinding.Test.uno
@@ -42,7 +42,7 @@ namespace Fuse.Reactive.Test
 		[Test]
 		public void SerializeObject()
 		{
-			var e = new UX.EventBinding();
+			var e = new UX.EventBinding.Serialize();
 			using (var root = TestRootPanel.CreateWithChild(e))
 			{
 				root.StepFrameJS();
@@ -50,6 +50,24 @@ namespace Fuse.Reactive.Test
 				root.StepFrameJS();
 
 				Assert.AreEqual("\"bar\"", e.Text.Value);
+			}
+		}
+		
+		[Test]
+		public void StandardData()
+		{
+			var e = new UX.EventBinding.Data();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+				
+				e.goWith.Perform();
+				e.c.FirstChild<FuseTest.Invoke>().Perform();
+				for (var c = e.a.FirstChild<Panel>(); c != null; c = c .NextSibling<Panel>()) 
+					c.FirstChild<FuseTest.Invoke>().Perform();
+				root.StepFrameJS();
+				
+				Assert.AreEqual( "si-la-one-two-", e.r.StringValue );
 			}
 		}
 	}

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Data.ExcludeJS.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Data.ExcludeJS.ux
@@ -1,0 +1,15 @@
+<Panel ux:Class="UX.Data.ExcludeJS">
+	<JavaScript>
+		exports.one = {
+			a: "hi",
+		}
+	</JavaScript>
+	<With Data="{one}">
+		<Panel>
+			<JavaScript>
+				exports.a = "bye"
+			</JavaScript>
+			<Text Value="{= data().a }"/>
+		</Panel>
+	</With>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/DataSubscription.Deprecated.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/DataSubscription.Deprecated.ux
@@ -1,0 +1,34 @@
+<Panel ux:Class="UX.DataSubscription.Deprecated">
+	<JavaScript>
+		exports.one = 1
+		exports.two = {
+			value: 2,
+		}
+		exports.items = [ 3,4]
+	</JavaScript>
+	<Panel>
+		<JavaScript>
+			module.exports = "hi"
+		</JavaScript>
+		<!-- This has no replacement, but we doesn't have a legitimate use-case either -->
+		<Text Value="{}" ux:Name="a"/>
+	</Panel>
+	
+	<Panel ux:Name="b">
+		<With Data="{one}">
+			<Text Value="{}"/>
+		</With>
+	</Panel>
+	
+	<Panel ux:Name="c">
+		<Instance Item="{two.value}">
+			<Text Value="{}"/>
+		</Instance>
+	</Panel>
+	
+	<Panel ux:Name="d">
+		<Each Items="{items}">
+			<Text Value="{}"/>
+		</Each>
+	</Panel>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Each.Fail.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Each.Fail.ux
@@ -22,7 +22,7 @@
 			<Text Value="fail"/>
 		</WhileFailed>
 		<Each Items="{items}">
-			<Text Value="{}"/>
+			<Text Value="{= data() }"/>
 		</Each>
 	</StackPanel>
 	

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Each.Issue3312.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Each.Issue3312.ux
@@ -7,7 +7,7 @@
 	<StackPanel ux:Class="WithTemplate">
 		<Each Items="{obs}">
 			<Each Count="1" TemplateSource="this" TemplateKey="irrelevant">
-				<Text Value="{}"/>
+				<Text Value="{= data() }"/>
 			</Each>
 		</Each>
 	</StackPanel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Each.Issue3430.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Each.Issue3430.ux
@@ -17,7 +17,7 @@
 	<FuseTest.Invoke Handler="{decrement}" ux:Name="decrement"/>
 	<StackPanel ux:Name="S">
 		<Each Items="{numbers}">
-			<Text Value="{}"/>
+			<Text Value="{= data() }"/>
 		</Each>
 	</StackPanel>
 

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Each.ObjectIdString.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Each.ObjectIdString.ux
@@ -17,7 +17,7 @@
 	</JavaScript>
 	<StackPanel ux:Name="s">
 		<Each Items="{items}" Offset="0" Limit="5" ux:Name="e" Identity="Object">
-			<FuseTest.DudElement StringValue="{}" Height="10">
+			<FuseTest.DudElement StringValue="{= data() }" Height="10">
 				<RemovingAnimation>
 					<Nothing Duration="1"/>
 				</RemovingAnimation>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Each.Offset.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Each.Offset.ux
@@ -4,6 +4,6 @@
 		exports.items = Observable(0,1,2,3,4,5,6,7,8,9)
 	</JavaScript>
 	<Each Items="{items}" Offset="3">
-		<Text Value="{}"/>
+		<Text Value="{= data() }"/>
 	</Each>
 </Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Each.ReplaceWithLessData.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Each.ReplaceWithLessData.ux
@@ -18,8 +18,8 @@
 	<Slider ux:Name="monthsToMaturitySlider" Minimum="1" Maximum="1000" Value="{monthsToMaturity}" ValueChanged="{calculate}"  />
 	<Grid ux:Name="grid" ColumnCount="5">
 		<Each Items="{payments}">
-			<Text Value="A{}" />
-			<Text Value="B{}" />
+			<Text Value="A{= data()}" />
+			<Text Value="B{= data()}" />
 		</Each>
 	</Grid>
 </Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Each.ReuseRemove.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Each.ReuseRemove.ux
@@ -13,7 +13,7 @@
 	</JavaScript>
 	<StackPanel ux:Name="s">
 		<Each Items="{items}" Reuse="Frame">
-			<FuseTest.DudElement Value="{}"/>
+			<FuseTest.DudElement Value="{= data()}"/>
 		</Each>
 	</StackPanel>
 	

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/EventBinding.Data.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/EventBinding.Data.ux
@@ -1,0 +1,51 @@
+<Panel ux:Class="UX.EventBinding.Data">
+	<JavaScript>
+		var Observable = require("FuseJS/Observable")
+		
+		exports.single = {
+			pep: "si"
+		}
+		
+		exports.items = Observable({
+			value: "one",
+		}, {
+			value: "two",
+		})
+		
+		exports.item = {
+			co: "la",
+		}
+		
+		exports.result = Observable("")
+		
+		exports.goEach = function(args) {
+			exports.result.value += args.data.value + "-"
+		}
+		exports.goWith = function(args) {
+			exports.result.value += args.data.pep + "-"
+		}
+		exports.goInstance = function(args) {
+			exports.result.value += args.data.co + "-"
+		}
+	</JavaScript>
+	
+	<Panel ux:Name="a">
+		<Each Items="{items}">
+			<Panel>
+				<FuseTest.Invoke Handler="{goEach}"/>
+			</Panel>
+		</Each>
+	</Panel>
+	
+	<With Data="{single}">
+		<FuseTest.Invoke Handler="{goWith}" ux:Name="goWith"/>
+	</With>
+	
+	<Panel ux:Name="c">
+		<Instance Item="{item}">
+			<FuseTest.Invoke Handler="{goInstance}"/>
+		</Instance>
+	</Panel>
+	
+	<FuseTest.DudElement StringValue="{result}" ux:Name="r"/>
+</Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/EventBinding.Serialize.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/EventBinding.Serialize.ux
@@ -4,11 +4,18 @@
 		var result = Observable("nothing");
 		module.exports = {
 			result: result,
-			foo: "bar",
-			run: function(args) { result.value = "dataContext" in args ? JSON.stringify(args.dataContext.foo) : "ERROR"; }
+			ctx: {
+				foo: "bar",
+			},
+			run: function(args) { 
+				result.value = "dataContext" in args ? JSON.stringify(args.dataContext.foo) : "ERROR";
+				result.value += "-" + args.data.foo
+			}
 		};
 	</JavaScript>
 
-	<Fuse.Reactive.Test.EventBindingTest.DummyBehavior ux:Name="Run" Handler="{run}" />
+	<With Data="{ctx}">
+		<Fuse.Reactive.Test.EventBindingTest.DummyBehavior ux:Name="Run" Handler="{run}" />
+	</With>
 	<Text ux:Name="Text" Value="{result}" />
 </Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/EventBinding.Serialize.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/EventBinding.Serialize.ux
@@ -1,4 +1,4 @@
-<Panel ux:Class="UX.EventBinding">
+<Panel ux:Class="UX.EventBinding.Serialize">
 	<JavaScript>
 		var Observable = require("FuseJS/Observable");
 		var result = Observable("nothing");

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Instance.RootItems.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Instance.RootItems.ux
@@ -1,5 +1,5 @@
 <Panel ux:Class="UX.Instance.RootItems">
 	<Fuse.Reactive.Bindings.Test.RootInstantiator>
-		<FuseTest.DudElement Value="{}"/>
+		<FuseTest.DudElement Value="data()"/>
 	</Fuse.Reactive.Bindings.Test.RootInstantiator>
 </Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Array.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Array.ux
@@ -3,6 +3,6 @@
 	<!-- Also just Value="1,2,3,4,5" should work -->
 	<!-- <Let ux:Name="arr" Value="{= 1,2,3,4,5 }"/> -->
 	<Each Items="{arr}">
-		<FuseTest.DudElement StringValue="{}"/>
+		<FuseTest.DudElement StringValue="{= data() }"/>
 	</Each>
 </Panel>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Observable.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/Let.Observable.ux
@@ -19,12 +19,12 @@
 	
 	<Panel ux:Name="e">
 		<Each Items="{pArray}">
-			<FuseTest.DudElement Value="{}"/>
+			<FuseTest.DudElement Value="{= data()}"/>
 		</Each>
 	</Panel>
 	<Panel ux:Name="ep">
 		<Each Items="{Property pArray.Value}">
-			<FuseTest.DudElement Value="{}"/>
+			<FuseTest.DudElement Value="{= data()}"/>
 		</Each>
 	</Panel>
 

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/With.ContextChange.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/With.ContextChange.ux
@@ -4,7 +4,7 @@
 		exports.menu = Observable({ type: "Text", value: "Hello" })
 	</JavaScript>
 	<With Data="{menu}">
-		<Instance Item="{}" MatchKey="type">
+		<Instance Item="{= data()}" MatchKey="type">
 			<Text ux:Template="Text" Value="{value}"/>
 		</Instance>
 	</With>

--- a/Source/Fuse.Reactive.Bindings/Tests/UX/With.ContextRef.ux
+++ b/Source/Fuse.Reactive.Bindings/Tests/UX/With.ContextRef.ux
@@ -13,7 +13,7 @@
 	
 	<Each Items="{items}">
 		<With Data="{data}">
-			<Instance Item="{}">
+			<Instance Item="data()">
 				<Text Value="{value}"/>
 			</Instance>
 		</With>

--- a/Source/Fuse.Reactive.Bindings/Tests/With.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/With.Test.uno
@@ -35,7 +35,6 @@ namespace Fuse.Test
 		}
 		
 		[Test]
-		[Ignore("Requires some reactive refactoring before it can be fixed")]
 		public void ContextRef()
 		{
 			var p = new UX.With.ContextRef();

--- a/Source/Fuse.Reactive.Bindings/With.uno
+++ b/Source/Fuse.Reactive.Bindings/With.uno
@@ -68,7 +68,11 @@ namespace Fuse.Reactive
 		}
 
 		object _subtreeData;
-		object ISubtreeDataProvider.GetData(Node n) { return _subtreeData; }
+		ContextDataResult ISubtreeDataProvider.TryGetDataProvider( Node child, DataType type, out object provider )
+		{
+			provider = _subtreeData;
+			return type == DataType.Prime ? ContextDataResult.NullProvider : ContextDataResult.Continue;
+		}
 
 		void ValueForwarder.IValueListener.NewValue(object value)
 		{

--- a/Source/Fuse.Scripting.JavaScript/JavaScript.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScript.uno
@@ -122,9 +122,10 @@ namespace Fuse.Reactive
 			if (Parent != null) Parent.BroadcastDataChange(oldSiblingData, data);
 		}
 
-		object Node.ISiblingDataProvider.Data
+		ContextDataResult ISiblingDataProvider.TryGetDataProvider( DataType type, out object provider )
 		{
-			get { return _siblingData; }
+			provider = type == DataType.Key ? _siblingData : null;
+			return ContextDataResult.Continue;
 		}
 
 		void DisposeSubscription()

--- a/Source/Fuse.Scripting.JavaScript/Tests/UX/PumpMessagesStackOverflow.ux
+++ b/Source/Fuse.Scripting.JavaScript/Tests/UX/PumpMessagesStackOverflow.ux
@@ -23,6 +23,6 @@
 
 	<TextInput Value="{foo}" />
 	<Each Items="{bar}">
-		<Text Value="{}" />
+		<Text Value="{= data() }" />
 	</Each>
 </Panel>

--- a/Source/Fuse.Scripting.JavaScript/Tests/UX/TreeObservable.Array.ux
+++ b/Source/Fuse.Scripting.JavaScript/Tests/UX/TreeObservable.Array.ux
@@ -36,7 +36,7 @@
 	</JavaScript>
 
 	<Each Items="{tree.foo}">
-		<Text Value="{}" />
+		<Text Value="{= data() }" />
 	</Each>
 
 	<FuseTest.Invoke ux:Name="setElement" Handler="{setElement}" />

--- a/Source/Fuse.Scripting.JavaScript/Tests/UXExpressionsTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/UXExpressionsTest.uno
@@ -10,9 +10,10 @@ namespace Fuse.Reactive.Test
 {
 	public class SynchronusDataSource: Node, Node.ISiblingDataProvider, IObject
 	{
-		object ISiblingDataProvider.Data
+		ContextDataResult ISiblingDataProvider.TryGetDataProvider( DataType type, out object provider )
 		{
-			get { return this; }
+			provider = this;
+			return ContextDataResult.Continue;
 		}
 
 		string[] IObject.Keys

--- a/Source/Fuse.Triggers/RemovingAnimation.uno
+++ b/Source/Fuse.Triggers/RemovingAnimation.uno
@@ -30,7 +30,7 @@ namespace Fuse.Triggers
 						<Rectangle Height="1" Alignment="Bottom">
 							<Stroke Color="#DDD" />
 						</Rectangle>
-						<Text Margin="10" Value="{}" />
+						<Text Margin="10" Value="data()" />
 						<RemovingAnimation>
 							<Move RelativeTo="Size" X="-1" Duration="0.4" Easing="CircularOut" />
 						</RemovingAnimation>

--- a/Tests/ManualTests/ManualTestingApp/Surface/Singles/LineGraph.ux
+++ b/Tests/ManualTests/ManualTestingApp/Surface/Singles/LineGraph.ux
@@ -65,12 +65,12 @@
 					</LinearGradient>
 				</Stroke>
 				<Each Items="{points}">
-					<CurvePoint At="{}"/>
+					<CurvePoint At="data()"/>
 				</Each>
 			</Curve>
 			<Curve Extrude="Bottom" Color="#AFF8" ux:Name="lineGraphFill">
 				<Each Items="{points}">
-					<CurvePoint At="{}"/>
+					<CurvePoint At="data()"/>
 				</Each>
 			</Curve>
 			


### PR DESCRIPTION
Removes some items deprecated in 1.6 (as I needed to change them).
Fixes https://github.com/fusetools/fuselibs-public/issues/986
Fixes https://github.com/fusetools/fuselibs-public/issues/892 by introducing a new `data()` binding.

This PR contains:
- [x] Changelog
- [ ] Documentation -- minimal updates, adding more now
- [x] Tests
