### PR TITLE
Upgrade to Mono 5.4.1

### DIFF
--- a/.teamcity_set_versions.sh
+++ b/.teamcity_set_versions.sh
@@ -1,0 +1,1 @@
+echo "##teamcity[setParameter name='monoBinPath' value='/Library/Frameworks/Mono.framework/Versions/5.4.1/bin']"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 install:
   - sudo easy_install pip
   - pip install six
-  - wget https://files.fusetools.com/tooling/maYCJ8Vs0bD0-Mono.zip -O mono.zip &&
+  - wget https://files.fusetools.com/tooling/eTVvQ6T4pMUK-Mono.zip -O mono.zip &&
     unzip -d mono mono.zip &&
     export PATH=$PATH:$PWD/mono/bin
   - Stuff/stuff install Stuff

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In order to use Uno / Fuselibs, the following software must be installed:
 
 ### macOS
 
-* [Mono 4.4.2](https://download.mono-project.com/archive/4.4.2/macos-10-universal/MonoFramework-MDK-4.4.2.macos10.xamarin.universal.pkg)
+* [Mono 5.4.1](https://download.mono-project.com/archive/5.4.1/macos-10-universal/MonoFramework-MDK-5.4.1.7.macos10.xamarin.universal.pkg)
 * [XCode](https://developer.apple.com/xcode/)
 * [CMake](https://cmake.org/)
 


### PR DESCRIPTION
Everything required for upgrading Mono from 4.4.2 to 5.4.1.

This PR contains:
- [ ] Changelog - not really feature related, do we still put this in the changelog?
- [x] Documentation - changed the mono version pointed to from README.md
- [x] Tests - covered by same tests as before