### PR TITLE
Model: Add getters for Model and ModelNameTable properties

### DIFF
--- a/Source/Fuse.Models/ModelJavaScript.uno
+++ b/Source/Fuse.Models/ModelJavaScript.uno
@@ -25,10 +25,10 @@ namespace Fuse.Models
 		{
 			var md = GetOrCreateModelData(v);
 			md.ModulePath = modulePath;
-			Complete( md, v );
+			OnModelDataChanged(md, v);
 		}
 		
-		static void Complete( ModelData md, Visual v )
+		static void OnModelDataChanged(ModelData md, Visual v)
 		{
 			v.RemoveAllChildren<ModelJavaScript>();
 			
@@ -44,7 +44,7 @@ namespace Fuse.Models
 		{
 			var md = GetOrCreateModelData(v);
 			md.NameTable = nt;
-			Complete( md, v );
+			OnModelDataChanged(md, v);
 		}
 
 		static ModelData GetOrCreateModelData(Visual v)

--- a/Source/Fuse.Models/ModelJavaScript.uno
+++ b/Source/Fuse.Models/ModelJavaScript.uno
@@ -28,6 +28,14 @@ namespace Fuse.Models
 			OnModelDataChanged(md, v);
 		}
 		
+		[UXAttachedPropertySetter("ModelNameTable")]
+		public static void SetModelNameTable(Visual v, NameTable nt)
+		{
+			var md = GetOrCreateModelData(v);
+			md.NameTable = nt;
+			OnModelDataChanged(md, v);
+		}
+
 		static void OnModelDataChanged(ModelData md, Visual v)
 		{
 			v.RemoveAllChildren<ModelJavaScript>();
@@ -37,14 +45,6 @@ namespace Fuse.Models
 				return;
 			
 			v.Children.Add( new ModelJavaScript(md.NameTable, md.ModulePath, null) );
-		}
-		
-		[UXAttachedPropertySetter("ModelNameTable")]
-		public static void SetModelNameTable(Visual v, NameTable nt)
-		{
-			var md = GetOrCreateModelData(v);
-			md.NameTable = nt;
-			OnModelDataChanged(md, v);
 		}
 
 		static ModelData GetOrCreateModelData(Visual v)

--- a/Source/Fuse.Models/ModelJavaScript.uno
+++ b/Source/Fuse.Models/ModelJavaScript.uno
@@ -23,17 +23,8 @@ namespace Fuse.Models
 		[UXAttachedPropertySetter("JavaScript.Model"), UXAuxNameTable("ModelNameTable")]
 		public static void SetModel(Visual v, string modulePath)
 		{
-			var md = v.Properties.Get( _modelHandle ) as ModelData;
-			if (md == null)
-			{
-				md = new ModelData { ModulePath = modulePath };
-				v.Properties.Set( _modelHandle, md );
-			}
-			else
-			{
-				md.ModulePath = modulePath;
-			}
-			
+			var md = GetOrCreateModelData(v);
+			md.ModulePath = modulePath;
 			Complete( md, v );
 		}
 		
@@ -51,18 +42,20 @@ namespace Fuse.Models
 		[UXAttachedPropertySetter("ModelNameTable")]
 		public static void SetModelNameTable(Visual v, NameTable nt)
 		{
-			var md = v.Properties.Get( _modelHandle ) as ModelData;
+			var md = GetOrCreateModelData(v);
+			md.NameTable = nt;
+			Complete( md, v );
+		}
+
+		static ModelData GetOrCreateModelData(Visual v)
+		{
+			var md = v.Properties.Get(_modelHandle) as ModelData;
 			if (md == null)
 			{
-				md = new ModelData{ NameTable = nt };
-				v.Properties.Set( _modelHandle, md );
+				md = new ModelData();
+				v.Properties.Set(_modelHandle, md);
 			}
-			else
-			{
-				md.NameTable = nt;
-			}
-			
-			Complete( md, v );
+			return md;
 		}
 
 		//TODO: This should probably be JavaScript.Model, Preview would need to be adjusted as well

--- a/Source/Fuse.Models/ModelJavaScript.uno
+++ b/Source/Fuse.Models/ModelJavaScript.uno
@@ -27,6 +27,12 @@ namespace Fuse.Models
 			md.ModulePath = modulePath;
 			OnModelDataChanged(md, v);
 		}
+
+		[UXAttachedPropertyGetter("JavaScript.Model")]
+		public static string GetModel(Visual v)
+		{
+			return GetOrCreateModelData(v).ModulePath;
+		}
 		
 		[UXAttachedPropertySetter("ModelNameTable")]
 		public static void SetModelNameTable(Visual v, NameTable nt)
@@ -34,6 +40,12 @@ namespace Fuse.Models
 			var md = GetOrCreateModelData(v);
 			md.NameTable = nt;
 			OnModelDataChanged(md, v);
+		}
+
+		[UXAttachedPropertyGetter("ModelNameTable")]
+		public static NameTable GetModelNameTable(Visual v)
+		{
+			return GetOrCreateModelData(v).NameTable;
 		}
 
 		static void OnModelDataChanged(ModelData md, Visual v)


### PR DESCRIPTION
Depends on #999

Apparently preview dislikes attached properties without a getter,
although it hasn't been a problem with these properties for some
reason. Let's do it anyway for consistency.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
