### PR TITLE
Fix models after 1.6 merge

### DIFF
--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -12,7 +12,6 @@ namespace Fuse.Models.Test
 	public class ModelTest : ModelTestBase
 	{
 		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs-public/issues/1006")]
 		public void NestedArray()
 		{
 			var e = new UX.Model.NestedArray();

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -25,6 +25,7 @@ namespace Fuse.Models.Test
 			}
 		}
 
+		[Test]
 		public void ArrayParentMeta()
 		{
 			var e = new UX.Model.ArrayParentMeta();

--- a/Source/Fuse.Models/Tests/UX/NestedArray.ux
+++ b/Source/Fuse.Models/Tests/UX/NestedArray.ux
@@ -1,7 +1,7 @@
 <Panel ux:Class="UX.Model.NestedArray" Model="UX/NestedArray">
 	<Each Items="{array}">
-		<Each Items="{}">
-			<Text Value="{}" />
+		<Each Items="data()">
+			<Text Value="{=data()}" />
 		</Each>
 	</Each>
 	<FuseTest.Invoke ux:Name="push" Handler="{push}" />


### PR DESCRIPTION
This fixes models tests after they broke when merging `release-1.6` to `master`.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [x] Tests
