### PR TITLE
NativeMember thread-cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Fuse.Scripting
+- Marked `NativeMember.Context` as Obsolete. Either use passed-down `Context`, or dispatch to `ThreadWorker` instead.
+
 ## Node Data Context
 - Deprecated and removed several functions which were not meant to be public. The deprecated ones will be removed shortly, as the current interface cannot be supported in the future.   `ISiblingDataProvider`, `ISubtreeDataProvider`, `IDataEnumerator`, `Node.GetFirstData`, `Node.EnumerateData`, `Node.BroadcastDataChange`, `Node.IDataListenere`, `Node.OnDataChanged`, `Node.AddDataListener`, `Node.RemoveDataListener`, `IObject`, `IArray`
 

--- a/Source/Fuse.Scripting/NativeEvent.uno
+++ b/Source/Fuse.Scripting/NativeEvent.uno
@@ -19,7 +19,7 @@ namespace Fuse.Scripting
 		protected override void SetProperty(Scripting.Function function)
 		{
 			_jsFunction = function;
-			DispatchQueue(Context.ThreadWorker);
+			DispatchQueue(ThreadWorker);
 		}
 
 		protected override Scripting.Function GetProperty()
@@ -61,7 +61,7 @@ namespace Fuse.Scripting
 
 		public void RaiseAsync(IThreadWorker threadWorker, params object[] args)
 		{
-			if(Context != null || _queueEventsBeforeEvaluation)
+			if (ThreadWorker != null || _queueEventsBeforeEvaluation)
 				_eventArgsQueue.Enqueue(args);
 
 			DispatchQueue(threadWorker);

--- a/Source/Fuse.Scripting/NativeFunction.uno
+++ b/Source/Fuse.Scripting/NativeFunction.uno
@@ -9,9 +9,9 @@ namespace Fuse.Scripting
 	{
 		NativeCallback _nativeCallback;
 
-		protected override object CreateObject()
+		protected override object CreateObject(Context context)
 		{
-			return (Callback)(new NativeFunctionClosure(_nativeCallback, Context).Callback);
+			return (Callback)(new NativeFunctionClosure(_nativeCallback, context).Callback);
 		}
 
 		public NativeFunction(string name, NativeCallback callback): base(name)

--- a/Source/Fuse.Scripting/NativeFunction.uno
+++ b/Source/Fuse.Scripting/NativeFunction.uno
@@ -11,11 +11,6 @@ namespace Fuse.Scripting
 
 		protected override object CreateObject()
 		{
-			return CreateCallback();
-		}
-
-		internal Callback CreateCallback()
-		{
 			return (Callback)(new NativeFunctionClosure(_nativeCallback, Context).Callback);
 		}
 

--- a/Source/Fuse.Scripting/NativeMember.uno
+++ b/Source/Fuse.Scripting/NativeMember.uno
@@ -7,6 +7,7 @@ namespace Fuse.Scripting
 	{
 		protected string Name { get; private set; }
 		public Context Context { get; private set; }
+		public IThreadWorker ThreadWorker { get; private set; }
 		protected Object ModuleObject { get; private set; }
 		protected internal NativeMember(string name) { Name = name; }
 
@@ -20,6 +21,7 @@ namespace Fuse.Scripting
 
 			ModuleObject = obj;
 			Context = context;
+			ThreadWorker = context.ThreadWorker;
 
 			var member = CreateObject(context);
 			if(member != null)

--- a/Source/Fuse.Scripting/NativeMember.uno
+++ b/Source/Fuse.Scripting/NativeMember.uno
@@ -20,11 +20,12 @@ namespace Fuse.Scripting
 
 			ModuleObject = obj;
 			Context = context;
-			var member = CreateObject();
+
+			var member = CreateObject(context);
 			if(member != null)
 				ModuleObject[Name] = member;
 		}
 
-		protected abstract object CreateObject();
+		protected abstract object CreateObject(Context context);
 	}
 }

--- a/Source/Fuse.Scripting/NativeMember.uno
+++ b/Source/Fuse.Scripting/NativeMember.uno
@@ -6,10 +6,13 @@ namespace Fuse.Scripting
 	public abstract class NativeMember
 	{
 		protected string Name { get; private set; }
-		public Context Context { get; private set; }
 		public IThreadWorker ThreadWorker { get; private set; }
 		protected Object ModuleObject { get; private set; }
 		protected internal NativeMember(string name) { Name = name; }
+
+		Context _context;
+		[Obsolete("Either use passed-down Context, or dispatch to ThreadWorker")]
+		public Context Context { get { return _context; } }
 
 		internal void Create(Object obj, Context context)
 		{
@@ -20,8 +23,9 @@ namespace Fuse.Scripting
 				throw new ArgumentNullException(nameof(context));
 
 			ModuleObject = obj;
-			Context = context;
 			ThreadWorker = context.ThreadWorker;
+
+			_context = context;
 
 			var member = CreateObject(context);
 			if(member != null)

--- a/Source/Fuse.Scripting/NativeMember.uno
+++ b/Source/Fuse.Scripting/NativeMember.uno
@@ -12,6 +12,12 @@ namespace Fuse.Scripting
 
 		internal void Create(Object obj, Context context)
 		{
+			if (obj == null)
+				throw new ArgumentNullException(nameof(obj));
+
+			if (context == null)
+				throw new ArgumentNullException(nameof(context));
+
 			ModuleObject = obj;
 			Context = context;
 			var member = CreateObject();

--- a/Source/Fuse.Scripting/NativePromise.uno
+++ b/Source/Fuse.Scripting/NativePromise.uno
@@ -63,7 +63,7 @@ namespace Fuse.Scripting
 			_resultConverter = resultConverter;
 		}
 
-		protected override object CreateObject()
+		protected override object CreateObject(Context context)
 		{ 
 			return (Callback)new ContextClosure(_futureFactory, _resultConverter).CreatePromise;
 		}

--- a/Source/Fuse.Scripting/NativeProperty.uno
+++ b/Source/Fuse.Scripting/NativeProperty.uno
@@ -56,7 +56,7 @@ namespace Fuse.Scripting
 				_getHandler = GetProperty;
 
 			if(_valueConverter != null)
-				return _valueConverter(Context, _getHandler());
+				return _valueConverter(context, _getHandler());
 			
 			return _getHandler();
 		}

--- a/Source/Fuse.Scripting/NativeProperty.uno
+++ b/Source/Fuse.Scripting/NativeProperty.uno
@@ -30,12 +30,12 @@ namespace Fuse.Scripting
 			_valueConverter = valueConverter;
 		}
 
-		protected override object CreateObject()
+		protected override object CreateObject(Context context)
 		{
 			if(_isReadonly)
-				Context.ObjectDefineProperty(ModuleObject, Name, _readonlyValue);
+				context.ObjectDefineProperty(ModuleObject, Name, _readonlyValue);
 			else
-				Context.ObjectDefineProperty(ModuleObject, Name, (Callback)GetProperty, (Callback)SetProperty);
+				context.ObjectDefineProperty(ModuleObject, Name, (Callback)GetProperty, (Callback)SetProperty);
 
 			return null;
 		}


### PR DESCRIPTION
This restores the same thread-safety that the change that got reverted in #993 introduced, but without a hard API breakage.

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [ ] ~Tests~
