### PR TITLE
Fuse.Scripting: do not crash if Context is null

### DIFF
--- a/Source/Fuse.Scripting/NativeEvent.uno
+++ b/Source/Fuse.Scripting/NativeEvent.uno
@@ -56,7 +56,7 @@ namespace Fuse.Scripting
 			if(Context != null || _queueEventsBeforeEvaluation)
 				_eventArgsQueue.Enqueue(args);
 
-			DispatchQueue(Context.ThreadWorker);
+			DispatchQueue(Context != null ? Context.ThreadWorker : null);
 		}
 
 		public void RaiseAsync(IThreadWorker threadWorker, params object[] args)


### PR DESCRIPTION
Before the API-breakage here, we would crash if something was queued
*and* CreateObject had not yet been called. After restoring the API, we
would crash regardless of something being queued or not.

Let's revert the behavior to the way it was.

This method is obsolete anyway, so we don't care that it can lead to a
crash, as long as that's not a new crash.