### PR TITLE
Exclude broken test from MSVC build

### DIFF
--- a/Source/Fuse.Scripting.JavaScript/Tests/JavaScriptTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/JavaScriptTest.uno
@@ -23,10 +23,13 @@ namespace Fuse.Reactive.Test
 			}
 		}
 		
+		// NOTE: This test is excluded on MSVC since the compiler used for that target apparently
+		// don't properly support unicode symbols. We're not using the [Ignore] attribute here
+		// since that won't exclude the test during compilation.
 		[Test]
 		//future-proofing any cleanup of exported names (this uses unusual, but valid JS names)
 		//refer to https://github.com/fusetools/fuselibs-public/issues/972
-		public void ExoticNames()
+		extern(!MSVC) public void ExoticNames()
 		{
 			var j = new UX.JavaScript.ExoticNames();
 			using (var root = TestRootPanel.CreateWithChild(j))


### PR DESCRIPTION
Running `Stuff/uno test Source/Fuse.Scripting.JavaScript/Tests/ -t=msvc` fails while compiling `UX.JavaScript.ExoticNames.ux`, which is used in the `JavaScriptTest.ExoticNames` test. This test was introduced in 882172eaa8a00c38d786308e52d861647e139a8a.

Excluding the test method with `extern(!MSVC)` fixes the problem, I assume this is because `UX.JavaScript.ExocticNames` then gets stripped away from the build.

This PR contains:
- ~Changelog~ No user-facing changes
- [x] Documentation (in source code)
- ~Tests~ N/A
