### PR TITLE
ImageSource: Report more friendly error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Image loading errors
+- Added more info to the messages reported on failure during image loading.
+
 ## Fuse.Scripting
 - Marked `NativeMember.Context` as Obsolete. Either use passed-down `Context`, or dispatch to `ThreadWorker` instead.
 

--- a/Source/Fuse.Elements/Resources/FileImageSource.uno
+++ b/Source/Fuse.Elements/Resources/FileImageSource.uno
@@ -202,7 +202,7 @@ namespace Fuse.Resources
 			catch (Exception e)
 			{
 				Cleanup(CleanupReason.Failed);
-				OnError("BundleFileImageSource-failed-conversion", e);
+				OnError("Loading image from file failed. " + e.Message, e);
 			}
 		}
 
@@ -236,7 +236,7 @@ namespace Fuse.Resources
 		{
 			_loading = false;
 			Cleanup(CleanupReason.Failed);
-			OnError("BundleFileImageSource-failed-conversion", e);
+			OnError("Loading image from file failed. " + e.Message, e);
 		}
 
 		//NOTE: a copy from HttpImageSource.BackgroundLoad with minor changes

--- a/Source/Fuse.Elements/Resources/HttpImageSource.uno
+++ b/Source/Fuse.Elements/Resources/HttpImageSource.uno
@@ -115,7 +115,7 @@ namespace Fuse.Resources
 			}
 			catch( Exception e )
 			{
-				Fail("HttpImageSource-failed-request", e);
+				Fail("Loading image from '" + Url + "' failed. " + e.Message, e);
 			}
 		}
 
@@ -128,7 +128,7 @@ namespace Fuse.Resources
 		void FailureCallback(Exception e)
 		{
 			_loading = false;
-			Fail( "HttpImageSource-failed-conversion", e);
+			Fail("Loading image from HTTP failed. " + e.Message, e);
 		}
 
 		ImageOrientation _orientation = ImageOrientation.Identity;
@@ -141,7 +141,7 @@ namespace Fuse.Resources
 		{
 			if (response.StatusCode != 200)
 			{
-				Fail("HttpImageSource-failed-status: " + response.StatusCode + " " +
+				Fail("Loading image from HTTP failed with HTTP Status: " + response.StatusCode + " " +
 					response.ReasonPhrase);
 				return;
 			}
@@ -211,7 +211,7 @@ namespace Fuse.Resources
 
 		void LoadFailed( string reason )
 		{
-			Fail("HttpImageSource-protocol-failure for url '" + Url + "' : " + reason);
+			Fail("Loading image from '" + Url + "' failed: " + reason);
 		}
 
 		void Fail( string msg, Exception e = null )

--- a/Source/Fuse.Scripting.JavaScript/Tests/Various.Test.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/Various.Test.uno
@@ -462,7 +462,7 @@ namespace Fuse.Reactive.Test
 
 					var diagnostics = dg.DequeueAll();
 					Assert.AreEqual(1, diagnostics.Count);
-					Assert.Contains("BundleFileImageSource-failed-conversion", diagnostics[0].Message);
+					Assert.Contains("Loading image from file failed.", diagnostics[0].Message);
 				}
 			}
 		}


### PR DESCRIPTION
The Diagnostic API's intention is to report issues to the user, so the messages should be friendly and easy to act on. This PR fix the messages reported on image load failure. 

This PR contains:
- [x] Changelog