### PR TITLE
Change some members from protected internal to just internal

### DIFF
--- a/CHANGELOG/protected_internal_apis.md
+++ b/CHANGELOG/protected_internal_apis.md
@@ -1,0 +1,7 @@
+## Internal APIs
+- The following `protected internal` members have been made just `internal`, as they refer to `internal` types and weren't meant to be available to derived types:
+    * `Fuse.Controls.TextInputControl.Editor`
+    * `Fuse.Controls.TextInputControl.TextInputControl(TextEdit)`
+    * `Fuse.Physics.ForceFieldTrigger.SetForce(Body, float)`
+    * `Fuse.Physics.ForceFieldEventTrigger.OnTriggered(Body)`
+    * `Fuse.Controls.TextControl._textRenderer`

--- a/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/ObservableList.uno
@@ -82,7 +82,7 @@ namespace FuseTest
 			get { return _observers != null && _observers.Count > 0; }
 		}
 		
-		virtual protected void OnSubscribe(IObserver observer)
+		virtual void OnSubscribe(IObserver observer)
 		{
 			observer.OnNewAll(this);
 		}
@@ -250,7 +250,7 @@ namespace FuseTest
 			_value = initialValue;
 		}
 		
-		protected override void OnSubscribe(IObserver observer)
+		override void OnSubscribe(IObserver observer)
 		{
 			observer.OnSet(_value);
 		}

--- a/Source/Fuse.Controls.Primitives/TextControls/TextControl.GraphicsText.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/TextControl.GraphicsText.uno
@@ -29,7 +29,7 @@ namespace Fuse.Controls
 			get { return Color; }
 		}
 
-		internal protected ITextRenderer _textRenderer;
+		internal ITextRenderer _textRenderer;
 
 		protected override void OnRooted()
 		{

--- a/Source/Fuse.Controls.Primitives/TextControls/TextInputControl.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/TextInputControl.uno
@@ -26,9 +26,9 @@ namespace Fuse.Controls
 	public abstract class TextInputControl: LayoutControl, IValue<string>
 	{
 		readonly TextEdit _editor;
-		protected internal TextEdit Editor { get { return _editor; } }
+		internal TextEdit Editor { get { return _editor; } }
 
-		protected internal TextInputControl(TextEdit editor)
+		internal TextInputControl(TextEdit editor)
 		{
 			Focus.SetIsFocusable(this, true);
 			Focus.SetDelegator(this, FocusDelegator);

--- a/Source/Fuse.Physics/ForceFieldTriggers.uno
+++ b/Source/Fuse.Physics/ForceFieldTriggers.uno
@@ -16,7 +16,7 @@ namespace Fuse.Physics
 			}
 		}
 
-		protected internal abstract void SetForce(Body n, float force);
+		internal abstract void SetForce(Body n, float force);
 	}
 
 	public class ForceFieldEventArgs : EventArgs
@@ -39,7 +39,7 @@ namespace Fuse.Physics
 	{
 		public event ForceFieldEventHandler Handler;
 
-		protected internal void OnTriggered(Body body)
+		internal void OnTriggered(Body body)
 		{
 			Pulse();
 			if (Handler != null)
@@ -80,7 +80,7 @@ namespace Fuse.Physics
 
 		float _oldForce;
 
-		protected internal override void SetForce(Body body, float force)
+		internal override void SetForce(Body body, float force)
 		{
 			if (_oldForce <= Threshold && force > Threshold) OnTriggered(body);
 			_oldForce = force;
@@ -117,7 +117,7 @@ namespace Fuse.Physics
 
 		float _oldForce;
 
-		protected internal override void SetForce(Body body, float force)
+		internal override void SetForce(Body body, float force)
 		{
 			if (_oldForce > Threshold && force <= Threshold) OnTriggered(body);
 			_oldForce = force;
@@ -170,7 +170,7 @@ namespace Fuse.Physics
 			To = 1;
 		}
 
-		protected internal override void SetForce(Body body, float force)
+		internal override void SetForce(Body body, float force)
 		{
 			var f = Math.Clamp((force - From) / (To-From), 0, 1);
 			Seek(f, Fuse.Animations.AnimationVariant.Forward);	


### PR DESCRIPTION
These protected internal members returned or took as parameter internal entities, which will soon be an error in Uno (matching C#). A member being protected internal means that it's visible to derived classes outside the package, but this wasn't really possible for these members since they were mentioning internal entities.

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
