### PR TITLE
Model: Introduce ModelArgs property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ## Fuse.Scripting
 - Marked `NativeMember.Context` as Obsolete. Either use passed-down `Context`, or dispatch to `ThreadWorker` instead.
 
+## FuseJS
+- Added support for passing arguments from UX to the model constructor using the `ModelArgs` attribute.
+
 ## Node Data Context
 
 # 1.7

--- a/Source/Fuse.Models/ModelJavaScript.uno
+++ b/Source/Fuse.Models/ModelJavaScript.uno
@@ -16,6 +16,8 @@ namespace Fuse.Models
 		{
 			public string ModulePath;
 			public NameTable NameTable;
+			public IExpression Arguments;
+			public bool HasArguments = false;
 		}
 		static PropertyHandle _modelHandle = Properties.CreateHandle();
 		
@@ -46,6 +48,21 @@ namespace Fuse.Models
 		public static NameTable GetModelNameTable(Visual v)
 		{
 			return GetOrCreateModelData(v).NameTable;
+		}
+
+		[UXAttachedPropertySetter("ModelArgs")]
+		public static void SetModelArgs(Visual v, IExpression args)
+		{
+			var md = GetOrCreateModelData(v);
+			md.Arguments = args;
+			md.HasArguments = true;
+			OnModelDataChanged(md, v);
+		}
+
+		[UXAttachedPropertyGetter("ModelArgs")]
+		public static IExpression GetModelArgs(Visual v)
+		{
+			return GetOrCreateModelData(v).Arguments;
 		}
 
 		static void OnModelDataChanged(ModelData md, Visual v)
@@ -80,6 +97,39 @@ namespace Fuse.Models
 			rootVisualProvider.Root.Children.Add(appModel);
 		}
 
+		static IExpression[] UnpackArgs(IExpression argsExpr)
+		{
+			var vector = argsExpr as Reactive.Vector;
+			if (vector != null)
+			{
+				var vectorArgs = vector.Arguments;
+				var outputArgs = new IExpression[vectorArgs.Count];
+				for (var i = 0; i < vectorArgs.Count; ++i)
+					outputArgs[i] = vectorArgs[i];
+
+				return outputArgs;
+			}
+			
+			return new[] { argsExpr };
+		}
+
+		string GenerateArgsStringAndPopulateDependencies()
+		{
+			var argsString = "";
+			if (!_hasArgs)
+				return argsString;
+
+			var args = UnpackArgs(_args);
+			for (var i = 0; i < args.Length; ++i)
+			{
+				var depName = "__modelArg" + i;
+				argsString += ", " + depName;
+				Dependencies.Add(new Dependency(depName, args[i]));
+			}
+
+			return argsString;
+		}
+
 		void SetupModel()
 		{
 			if (_modulePath == null)
@@ -90,6 +140,7 @@ namespace Fuse.Models
 
 			ZoneJS.Initialize();
 
+			var argsString = GenerateArgsStringAndPopulateDependencies();
 			var code = 
 					"var Model = require('FuseJS/Internal/Model');\n"+
 					"var ViewModelAdapter = require('FuseJS/Internal/ViewModelAdapter')\n"+
@@ -99,7 +150,7 @@ namespace Fuse.Models
 					"if (!(modelClass instanceof Function)) { throw new Error('\"" + _modulePath + "\" does not export a class or function required to construct a Model'); }\n"+
 					"var modelInstance = Object.create(modelClass.prototype);\n"+
 					"module.exports = new Model(modelInstance, function() {\n"+
-					"    modelClass.call(modelInstance);\n"+
+					"    modelClass.call(modelInstance" + argsString + ");\n"+
 					"    ViewModelAdapter.adaptView(self, module, modelInstance);\n"+
 					"    return modelInstance;\n"+
 					"});\n";
@@ -135,18 +186,29 @@ namespace Fuse.Models
 		}
 		
 		string _modulePath;
+		IExpression _args;
+		bool _hasArgs;
 
 		private ModelJavaScript(ModelData md, string previewStateId = null)
 			: base(md.NameTable)
 		{
 			_previewStateModelId = previewStateId;
 			_modulePath = md.ModulePath;
+			_args = md.Arguments;
+			_hasArgs = md.HasArguments;
 			FileName = "(model-script)";
-			SetupModel();
 		}
 		
 		protected override void OnRooted()
 		{
+			// TODO: Doing anything prior to base.OnRooted is questionable.
+			// The UX compiler cannot guarantee a valid expression tree until
+			// rooting time, so we need to parse the arguments at root time.
+			// This is fine, however, since we are a subclass of JavaScript,
+			// we need to do this setup before JavaScript can initialize itself,
+			// which happens at rooting time as well.
+			SetupModel();
+
 			base.OnRooted();
 			
 			if (_previewStateModelId != null)

--- a/Source/Fuse.Models/ModelJavaScript.uno
+++ b/Source/Fuse.Models/ModelJavaScript.uno
@@ -199,17 +199,9 @@ namespace Fuse.Models
 			FileName = "(model-script)";
 		}
 		
-		protected override void OnRooted()
+		protected override void OnBeforeSubscribeToDependenciesAndDispatchEvaluate()
 		{
-			// TODO: Doing anything prior to base.OnRooted is questionable.
-			// The UX compiler cannot guarantee a valid expression tree until
-			// rooting time, so we need to parse the arguments at root time.
-			// This is fine, however, since we are a subclass of JavaScript,
-			// we need to do this setup before JavaScript can initialize itself,
-			// which happens at rooting time as well.
 			SetupModel();
-
-			base.OnRooted();
 			
 			if (_previewStateModelId != null)
 			{
@@ -217,11 +209,6 @@ namespace Fuse.Models
 				if (previewState != null)
 					previewState.AddSaver(this);
 			}
-		}
-		
-		protected override void OnUnrooted()
-		{
-			base.OnUnrooted();
 		}
 		
 		void IPreviewStateSaver.Save(PreviewStateData data)

--- a/Source/Fuse.Models/Tests/Fuse.Models.Test.unoproj
+++ b/Source/Fuse.Models/Tests/Fuse.Models.Test.unoproj
@@ -1,6 +1,7 @@
 {
   "Packages": [
     "Fuse.Controls",
+    "Fuse.Controls.ScrollView",
     "Fuse.Controls.Panels",
     "Fuse.Controls.Primitives",
     "Fuse.Controls.Navigation",

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -40,7 +40,7 @@ namespace Fuse.Models.Test
 		public void ArgsScrollView()
 		{
 			var e = new UX.Model.Args.ScrollView();
-			using (var root = TestRootPanel.CreateWithChild(e))
+			using (var root = TestRootPanel.CreateWithChild(e, int2(200)))
 			{
 				root.StepFrameJS();
 				Assert.AreEqual(0, e.scrollView.ScrollPosition.Y);

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -13,7 +13,7 @@ namespace Fuse.Models.Test
 	{
 
 		[Test]
-		public void Args_Each()
+		public void ArgsEach()
 		{
 			var e = new UX.Model.Args.Each();
 			using (var root = TestRootPanel.CreateWithChild(e))
@@ -26,7 +26,7 @@ namespace Fuse.Models.Test
 		}
 
 		[Test]
-		public void Args_ScrollView()
+		public void ArgsScrollView()
 		{
 			var e = new UX.Model.Args.ScrollView();
 			using (var root = TestRootPanel.CreateWithChild(e))
@@ -42,7 +42,7 @@ namespace Fuse.Models.Test
 		}
 
 		[Test]
-		public void Args_Single()
+		public void ArgsSingle()
 		{
 			var e = new UX.Model.Args.Single();
 			using (var root = TestRootPanel.CreateWithChild(e))

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -11,6 +11,53 @@ namespace Fuse.Models.Test
 {
 	public class ModelTest : ModelTestBase
 	{
+
+		[Test]
+		public void Args_Each()
+		{
+			var e = new UX.Model.Args.Each();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("(foo),(bar),(baz)", GetRecursiveText(e));
+				Assert.AreEqual(3, e.innerInstanceCount.Value);
+				Assert.AreEqual(1, e.outerInstanceCount.Value);
+			}
+		}
+
+		[Test]
+		public void Args_ScrollView()
+		{
+			var e = new UX.Model.Args.ScrollView();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual(0, e.scrollView.ScrollPosition.Y);
+
+				e.doScroll.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual(1337, e.scrollView.ScrollPosition.Y);
+				Assert.AreEqual(1, e.instanceCount.Value);
+			}
+		}
+
+		[Test]
+		public void Args_Single()
+		{
+			var e = new UX.Model.Args.Single();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+				Assert.AreEqual("hello!", e.output.StringValue);
+				Assert.AreEqual(1, e.instanceCount.Value);
+
+				e.input.Value = "goodbye";
+				root.StepFrameJS();
+				Assert.AreEqual("goodbye!", e.output.StringValue);
+				Assert.AreEqual(2, e.instanceCount.Value);
+			}
+		}
+		
 		[Test]
 		public void NestedArray()
 		{

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -11,6 +11,17 @@ namespace Fuse.Models.Test
 {
 	public class ModelTest : ModelTestBase
 	{
+		[Test]
+		public void ArgsSingleVectorArg()
+		{
+			var e = new UX.Model.Args.SingleVectorArg();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+				var extObjVec = (Fuse.Scripting.External) e.result.ObjectValue;
+				Assert.AreEqual(e.vec, extObjVec.Object);
+			}
+		}
 
 		[Test]
 		public void ArgsEach()

--- a/Source/Fuse.Models/Tests/UX/Args.Each.Inner.js
+++ b/Source/Fuse.Models/Tests/UX/Args.Each.Inner.js
@@ -1,0 +1,6 @@
+export default class Inner {
+	constructor(id, onNewInnerInstance) {
+		this.message = `(${id})`;
+		onNewInnerInstance();
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/Args.Each.Outer.js
+++ b/Source/Fuse.Models/Tests/UX/Args.Each.Outer.js
@@ -1,0 +1,18 @@
+let globalOuterInstanceCount = 0;
+
+export default class Outer {
+	constructor() {
+		this.items = [
+			{ id: "foo" },
+			{ id: "bar" },
+			{ id: "baz" },
+		];
+		
+		this.outerInstanceCount = ++globalOuterInstanceCount;
+		this.innerInstanceCount = 0;
+	}
+
+	onNewInnerInstance() {
+		this.innerInstanceCount++;
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/Args.Each.ux
+++ b/Source/Fuse.Models/Tests/UX/Args.Each.ux
@@ -1,0 +1,12 @@
+<Panel ux:Class="UX.Model.Args.Each" Model="UX/Args.Each.Outer">
+	<StackPanel>
+		<Each Items="{items}">
+			<Panel ux:Name="p" Model="UX/Args.Each.Inner" ModelArgs="{id}, {onNewInnerInstance}">
+				<Text Value="{message}" />
+			</Panel>
+		</Each>
+	</StackPanel>
+
+	<FuseTest.DudElement ux:Name="innerInstanceCount" Value="{innerInstanceCount}" />
+	<FuseTest.DudElement ux:Name="outerInstanceCount" Value="{outerInstanceCount}" />
+</Panel>

--- a/Source/Fuse.Models/Tests/UX/Args.ScrollView.js
+++ b/Source/Fuse.Models/Tests/UX/Args.ScrollView.js
@@ -1,0 +1,12 @@
+let globalInstanceCount = 0;
+
+export default class {
+	constructor(scrollView) {
+		this.instanceCount = ++globalInstanceCount;
+		this.scrollView = scrollView;
+	}
+
+	doScroll() {
+		this.scrollView.seekTo(0, 1337);
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/Args.ScrollView.ux
+++ b/Source/Fuse.Models/Tests/UX/Args.ScrollView.ux
@@ -1,0 +1,8 @@
+<Panel ux:Class="UX.Model.Args.ScrollView" Model="UX/Args.ScrollView" ModelArgs="scrollView">
+	<ScrollView ux:Name="scrollView">
+		<Panel Height="4000" />
+	</ScrollView>
+
+	<FuseTest.Invoke ux:Name="doScroll" Handler="{doScroll}" />
+	<FuseTest.DudElement ux:Name="instanceCount" Value="{instanceCount}" />
+</Panel>

--- a/Source/Fuse.Models/Tests/UX/Args.Single.js
+++ b/Source/Fuse.Models/Tests/UX/Args.Single.js
@@ -1,0 +1,8 @@
+let globalInstanceCount = 0;
+
+export default class {
+	constructor(value) {
+		this.instanceCount = ++globalInstanceCount;
+		this.value = value + "!";
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/Args.Single.ux
+++ b/Source/Fuse.Models/Tests/UX/Args.Single.ux
@@ -1,0 +1,7 @@
+<Panel ux:Class="UX.Model.Args.Single"
+	Model="UX/Args.Single.js"
+	ModelArgs="{ReadProperty input.Value}">
+	<Text ux:Name="input" Value="hello" />
+	<FuseTest.DudElement ux:Name="output" StringValue="{value}" />
+	<FuseTest.DudElement ux:Name="instanceCount" Value="{instanceCount}" />
+</Panel>

--- a/Source/Fuse.Models/Tests/UX/Args.SingleVectorArg.js
+++ b/Source/Fuse.Models/Tests/UX/Args.SingleVectorArg.js
@@ -1,0 +1,5 @@
+export default class {
+	constructor(input) {
+		this.result = input.external_object;
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/Args.SingleVectorArg.ux
+++ b/Source/Fuse.Models/Tests/UX/Args.SingleVectorArg.ux
@@ -1,0 +1,9 @@
+<Panel ux:Class="UX.Model.Args.SingleVectorArg" xmlns:r="Fuse.Reactive">
+	<string ux:AutoBind="false" ux:Name="fooStr" ux:Value="foo" />
+	<r:Vector ux:Name="vec" ux:AutoBind="false">
+		<r:Constant ux:Binding="Arguments" Value="fooStr" />
+	</r:Vector>
+	<Panel Model="UX/Args.SingleVectorArg" ModelArgs="vec">
+		<FuseTest.DudElement ux:Name="result" ObjectValue="{result}" />
+	</Panel>
+</Panel>

--- a/Source/Fuse.Scripting.JavaScript/JavaScript.uno
+++ b/Source/Fuse.Scripting.JavaScript/JavaScript.uno
@@ -43,10 +43,15 @@ namespace Fuse.Reactive
 			_scriptModule = new Fuse.Scripting.JavaScript.RootableScriptModule(Worker, nameTable);
 		}
 
+		protected virtual void OnBeforeSubscribeToDependenciesAndDispatchEvaluate() {}
+
 		protected override void OnRooted()
 		{
 			base.OnRooted();
 			_javaScriptCounter++;
+
+			OnBeforeSubscribeToDependenciesAndDispatchEvaluate();
+
 			//for migration we could preserve the _moduleInstance across rooting
 			if (_moduleInstance == null || !_moduleInstance.ReflectExports())
 				SubscribeToDependenciesAndDispatchEvaluate();


### PR DESCRIPTION
Adds support for passing constructor arguments to the model class.

`MyComponent.ux`

    <Panel
        ux:Class="MyComponent"
        Model="Models/MyComponent"
        ModelArgs="this, {foo}, 123, {ReadProperty Title}"
    />

`Models/MyComponent.js`

    export default class {
        constructor(view, foo, oneTwoThree, titleProperty) {
            // ...
        }
    }

This is currently only implemented for component models, since
app-level model arguments would be a bit more convoluted
(state migration would need to be disabled in this case).


This PR contains:
- [x] Changelog
- [ ] Documentation (N/A, docs live in an article on fuse-docs)
- [x] Tests
