### PR TITLE
onParamaterChanged crash-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 # 1.7
 
+### 1.7.1
+
+# Fuse.Nodes
+- Fixed a bug where triggering `onParameterChanged` on an element would lead to a crash.
+
 ### 1.7.0
 
 ## PageControl

--- a/Source/Fuse.Nodes/Tests/UX/Visual.OnParameterChanged.ux
+++ b/Source/Fuse.Nodes/Tests/UX/Visual.OnParameterChanged.ux
@@ -1,0 +1,12 @@
+<Panel ux:Class="UX.Visual.OnParameterChanged">
+	<JavaScript>
+		var Observable = require("FuseJS/Observable")
+		var currentParameter = Observable();
+		this.onParameterChanged(function(args) {
+			currentParameter.value = JSON.stringify(args);
+		})
+		module.exports = { currentParameter : currentParameter };
+	</JavaScript>
+
+	<FuseTest.DudElement ux:Name="CurrentParameter" StringValue="{currentParameter}" />
+</Panel>

--- a/Source/Fuse.Nodes/Tests/Visual.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Visual.Test.uno
@@ -119,5 +119,18 @@ namespace Fuse.Test
 				Assert.AreEqual(2, p.ParentB.Children.Count);
 			}
 		}
+
+		[Test]
+		public void OnParameterChanged()
+		{
+			var p = new UX.Visual.OnParameterChanged();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(null, p.CurrentParameter.StringValue);
+				p.Parameter = "{ \"foo\" : \"bar\" }";
+				root.StepFrameJS();
+				Assert.AreEqual("{\"foo\":\"bar\"}", p.CurrentParameter.StringValue);
+			}
+		}
 	}
 }

--- a/Source/Fuse.Nodes/Visual.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Visual.ScriptClass.uno
@@ -68,7 +68,9 @@ namespace Fuse
 		*/
 		static void onParameterChanged(Visual v, object[] args)
 		{
-			v.AddParameterChangedListener((Scripting.Function)args[0]);
+			var functionMirror = args[0] as Fuse.Scripting.IFunctionMirror;
+			if (functionMirror != null)
+				v.AddParameterChangedListener(functionMirror.Function);
 		}
 	}
 }

--- a/Source/Fuse.Scripting.JavaScript/FunctionMirror.uno
+++ b/Source/Fuse.Scripting.JavaScript/FunctionMirror.uno
@@ -7,7 +7,7 @@ using Fuse.Reactive;
 
 namespace Fuse.Scripting
 {
-	class FunctionMirror: DiagnosticSubject, IEventHandler, IRaw
+	class FunctionMirror: DiagnosticSubject, IFunctionMirror, IEventHandler, IRaw
 	{
 		readonly Function _func;
 
@@ -18,6 +18,8 @@ namespace Fuse.Scripting
 		{
 			_func = func;
 		}
+
+		Function IFunctionMirror.Function { get { return _func; } }
 
 		class CallClosure
 		{

--- a/Source/Fuse.Scripting/Context.uno
+++ b/Source/Fuse.Scripting/Context.uno
@@ -12,6 +12,11 @@ namespace Fuse.Scripting
 		void Invoke(Uno.Action<Scripting.Context> action);
 	}
 
+	internal interface IFunctionMirror
+	{
+		Function Function { get; }
+	}
+
 	public abstract class Context: Uno.IDisposable
 	{
 		ConcurrentDictionary<string, ModuleResult> _moduleResults = new ConcurrentDictionary<string, ModuleResult>();

--- a/Source/Fuse.Scripting/Fuse.Scripting.unoproj
+++ b/Source/Fuse.Scripting/Fuse.Scripting.unoproj
@@ -7,7 +7,8 @@
     "ProjectUrl": "https://fusetools.com"
   },
   "InternalsVisibleTo": [
-    "Fuse.Scripting.JavaScript"
+    "Fuse.Scripting.JavaScript",
+    "Fuse.Nodes"
   ],
   "Packages": [
     "Uno.Collections",


### PR DESCRIPTION
Seems our change to always reflect the arguments to ScriptClass-methods lead to breakage of the `onParameterChanged`-API. But we had no test that would notice.

So let's fix that. In general, we should make FunctionMirror a bit less insane (somehow). But that's not so good for a stable-branch. So let's use some internal API trickery for now.

This PR contains:
- [x] Changelog
- [x] Tests
