### PR TITLE
TreeRenderer: add RenderBoundsChanged

### DIFF
--- a/CHANGELOG/native_path_rendering.md
+++ b/CHANGELOG/native_path_rendering.md
@@ -1,0 +1,2 @@
+### Path
+- Fixed bug where setting `Data` on a `Path` could end up not rendering inside a `NativeViewHost` on iOS

--- a/Source/Fuse.Controls.Panels/GraphicsView.ux.uno
+++ b/Source/Fuse.Controls.Panels/GraphicsView.ux.uno
@@ -57,6 +57,7 @@ namespace Fuse.Controls
 		public void BackgroundChanged(Element e, Brush background) {}
 		public void ZOrderChanged(Element e, Visual[] zorder) {}
 		public void HitTestModeChanged(Element e, bool enabled) {}
+		public void RenderBoundsChanged(Element e) {}
 		public bool Measure(Element e, LayoutParams lp, out float2 size) { size = float2(0.0f); return false; }
 
 	}
@@ -180,6 +181,8 @@ namespace Fuse.Controls
 		void ITreeRenderer.ClipToBoundsChanged(Element e, bool clipToBounds) { GetTreeRenderer(e).ClipToBoundsChanged(e, clipToBounds); }
 
 		void ITreeRenderer.HitTestModeChanged(Element e, bool enabled) { GetTreeRenderer(e).HitTestModeChanged(e, enabled); }
+
+		void ITreeRenderer.RenderBoundsChanged(Element e) { GetTreeRenderer(e).RenderBoundsChanged(e); }
 
 		void ITreeRenderer.ZOrderChanged(Element e, Visual[] zorder) { /*GetTreeRenderer(e).ZOrderChanged(e, zorder);*/ }
 

--- a/Source/Fuse.Controls.Panels/NativeViewHost.uno
+++ b/Source/Fuse.Controls.Panels/NativeViewHost.uno
@@ -271,6 +271,8 @@ namespace Fuse.Controls
 
 		void ITreeRenderer.ZOrderChanged(Element e, Visual[] zorder) { _nativeRenderer.ZOrderChanged(e, zorder); }
 
+		void ITreeRenderer.RenderBoundsChanged(Element e) { _nativeRenderer.RenderBoundsChanged(e); }
+
 		void ITreeRenderer.TransformChanged(Element e)
 		{
 			if (e == this)

--- a/Source/Fuse.Controls.Panels/SingleViewHost.uno
+++ b/Source/Fuse.Controls.Panels/SingleViewHost.uno
@@ -218,6 +218,7 @@ namespace Fuse.Controls
 		void ITreeRenderer.BackgroundChanged(Element e, Brush background) {}
 		void ITreeRenderer.ClipToBoundsChanged(Element e, bool clipToBounds) {}
 		void ITreeRenderer.ZOrderChanged(Element e, Visual[] zorder) {}
+		void ITreeRenderer.RenderBoundsChanged(Element e) { }
 
 		bool _isVisible = true;
 		void ITreeRenderer.IsVisibleChanged(Element e, bool isVisible)

--- a/Source/Fuse.Controls.Panels/TreeRenderer.Android.uno
+++ b/Source/Fuse.Controls.Panels/TreeRenderer.Android.uno
@@ -140,6 +140,8 @@ namespace Fuse.Controls
 			_elements[e].UpdateViewRect(actualPosition.X, actualPosition.Y, actualSize.X, actualSize.Y);
 		}
 
+		void ITreeRenderer.RenderBoundsChanged(Element e) {}
+
 		void ITreeRenderer.IsVisibleChanged(Element e, bool isVisible)
 		{
 			_elements[e].SetIsVisible(isVisible);

--- a/Source/Fuse.Controls.Panels/TreeRenderer.iOS.uno
+++ b/Source/Fuse.Controls.Panels/TreeRenderer.iOS.uno
@@ -84,6 +84,13 @@ namespace Fuse.Controls
 			viewHandle.SetTransform(transform);
 		}
 
+		void ITreeRenderer.RenderBoundsChanged(Element e)
+		{
+			var viewHandle = _elements[e];
+			if (viewHandle.NeedsRenderBounds)
+				viewHandle.SetSizeAndVisualBounds(e.ActualSize, e.RenderBoundsWithoutEffects);
+		}
+
 		void ITreeRenderer.Placed(Element e)
 		{
 			var viewHandle = _elements[e];

--- a/Source/Fuse.Elements/Element.ITreeRenderer.uno
+++ b/Source/Fuse.Elements/Element.ITreeRenderer.uno
@@ -20,6 +20,7 @@ namespace Fuse.Elements
 		void ClipToBoundsChanged(Element e, bool clipToBounds);
 		void ZOrderChanged(Element e, Visual[] zorder);
 		void HitTestModeChanged(Element e, bool enabled);
+		void RenderBoundsChanged(Element e);
 		bool Measure(Element e, LayoutParams lp, out float2 size);
 	}
 

--- a/Source/Fuse.Elements/Element.Validation.uno
+++ b/Source/Fuse.Elements/Element.Validation.uno
@@ -45,7 +45,22 @@ namespace Fuse.Elements
 			if (ElementBatchEntry != null)
 				ElementBatchEntry.InvalidateRenderBounds();
 
+			if (!_hasNotifiedRenderBoundsChanged)
+			{
+				UpdateManager.AddDeferredAction(NotifyRenderBoundsChanged, UpdateStage.Layout, LayoutPriority.Post);
+				_hasNotifiedRenderBoundsChanged = true;
+			}
+
 			return false;
+		}
+
+		bool _hasNotifiedRenderBoundsChanged = false;
+		void NotifyRenderBoundsChanged()
+		{
+			var t = TreeRenderer;
+			if (t != null)
+				t.RenderBoundsChanged(this);
+			_hasNotifiedRenderBoundsChanged = false;
 		}
 
 		void OnInvalidateRenderBoundsWithEffects()

--- a/Source/Fuse.Elements/Tests/Element.TreeRenderer.Test.uno
+++ b/Source/Fuse.Elements/Tests/Element.TreeRenderer.Test.uno
@@ -1,0 +1,71 @@
+using Uno;
+using Uno.Collections;
+using Uno.Testing;
+using Uno.UX;
+
+using Fuse.Controls;
+using Fuse.Drawing;
+
+using FuseTest;
+
+namespace Fuse.Elements.Test
+{
+	public class ElementTreeRendererTest : TestBase
+	{
+		[Test]
+		//https://github.com/fusetools/fuselibs-public/issues/1005
+		public void PathDataChanged()
+		{
+			var p = new global::UX.ElementTreeRenderer.PathRenderBounds();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				var q = p.a.RenderBoundsWithoutEffects; //grab them, otherwise a change won't trigger
+				p.Reset();
+				p.a.Data = "M0,0 L100,100";
+				root.StepFrame(); //dispatch is done as part of layout, thus PumpDeferred is not enough
+				
+				Assert.IsTrue( p.RenderBoundsChangedElements.Contains( p.a ) );
+			}
+		}	
+	}
+	
+	public class TreeRendererPanel : Panel, ITreeRenderer
+	{
+		public override ITreeRenderer TreeRenderer
+		{
+			get { return this; }
+		}
+		
+		void ITreeRenderer.RootingStarted(Element e) { }
+		void ITreeRenderer.Rooted(Element e) { }
+		void ITreeRenderer.Unrooted(Element e) { }
+		void ITreeRenderer.BackgroundChanged(Element e, Brush background) { }
+		void ITreeRenderer.TransformChanged(Element e) { }
+		void ITreeRenderer.Placed(Element e) { }
+		void ITreeRenderer.IsVisibleChanged(Element e, bool isVisible) { }
+		void ITreeRenderer.IsEnabledChanged(Element e, bool isEnabled) { }
+		void ITreeRenderer.OpacityChanged(Element e, float opacity) { }
+		void ITreeRenderer.ClipToBoundsChanged(Element e, bool clipToBounds) { }
+		void ITreeRenderer.ZOrderChanged(Element e, Visual[] zorder) { }
+		void ITreeRenderer.HitTestModeChanged(Element e, bool enabled) { }
+		
+		public HashSet<Element> RenderBoundsChangedElements = new HashSet<Element>();
+		void ITreeRenderer.RenderBoundsChanged(Element e) 
+		{ 
+			RenderBoundsChangedElements.Add( e );
+		}
+		
+		bool ITreeRenderer.Measure(Element e, LayoutParams lp, out float2 size) 
+		{ 
+			size = float2(0);
+			return false;
+		}
+		
+		public void Reset()
+		{
+			RenderBoundsChangedElements.Clear();
+		}
+	}
+	
+}
+

--- a/Source/Fuse.Elements/Tests/UX/ElementTreeRenderer.PathRenderBounds.ux
+++ b/Source/Fuse.Elements/Tests/UX/ElementTreeRenderer.PathRenderBounds.ux
@@ -1,0 +1,3 @@
+<Fuse.Elements.Test.TreeRendererPanel ux:Class="UX.ElementTreeRenderer.PathRenderBounds">
+	<Path ux:Name="a"/>
+</Fuse.Elements.Test.TreeRendererPanel>


### PR DESCRIPTION
The forwarding of renderoubnds relied on the Placed event triggering,
which might not happen when only RenderBounds are invalidated

This PR contains:
- [x] Changelog
- [ ] Documentation
- [ ] Tests
