### PR TITLE
 Model: Check if we are rooted before sending TreeObservable messages

### DIFF
--- a/Source/Fuse.Models/FuseJS/Internal/Model.js
+++ b/Source/Fuse.Models/FuseJS/Internal/Model.js
@@ -350,7 +350,11 @@ function Model(initialState, stateInitializer)
 
 			if (changeAccepted) {
 				state[key] = value;
-				setInternal(meta.getPath(), key, value);
+				var path = meta.getPath();
+				if (!path) {
+					return; // No longer attached to the model graph
+				}
+				setInternal(path, key, value);
 			}
 
 			meta.diff(new Set());
@@ -452,6 +456,9 @@ function Model(initialState, stateInitializer)
 		function set(key, value, omitStateChange)
 		{
 			var path = getPath();
+			if (!path) {
+				return; // No longer attached to the model graph
+			}
 			if (!setInternal(path, key, value, omitStateChange)) { return; }
 
 			var argPath = path.concat(key, value instanceof Array ? [value] : value);
@@ -480,7 +487,10 @@ function Model(initialState, stateInitializer)
 			}
 			node.splice(index, count);
 			updateArrayParentIndices(index, -count);
-
+			var path = getPath();
+			if(!path) {
+				return; // No longer attached to the model graph
+			}
 			var removePath = getPath().concat(index);
 			for (var i = 0; i < count; i++) {
 				TreeObservable.removeAt.apply(store, removePath);
@@ -509,7 +519,12 @@ function Model(initialState, stateInitializer)
 			
 			updateArrayParentIndices(index+1, 1);
 
-			TreeObservable.insertAt.apply(store, getPath().concat([index, item]));
+			var path =  getPath();
+			if(!path) {
+				return; // No longer attached to the model graph
+			}
+
+			TreeObservable.insertAt.apply(store, path.concat([index, item]));
 			changesDetected++;
 		}
 

--- a/Source/Fuse.Models/FuseJS/Internal/Model.js
+++ b/Source/Fuse.Models/FuseJS/Internal/Model.js
@@ -421,7 +421,7 @@ function Model(initialState, stateInitializer)
 
 		var cachedPath = null;
 		function getPath(visited) {
-			if (cachedPath === null) { cachedPath = computePath(visited); }
+			if (cachedPath == null) { cachedPath = computePath(visited); }
 			return cachedPath;
 		} 
 		

--- a/Source/Fuse.Models/Tests/Model.Test.uno
+++ b/Source/Fuse.Models/Tests/Model.Test.uno
@@ -12,6 +12,26 @@ namespace Fuse.Models.Test
 	public class ModelTest : ModelTestBase
 	{
 		[Test]
+		public void UpdateDisconnectedAfterPromise()
+		{
+			var e = new UX.Model.UpdateDisconnectedAfterPromise();
+			using (var root = TestRootPanel.CreateWithChild(e))
+			{
+				root.StepFrameJS();
+
+				e.disconnect.Perform();
+				root.StepFrameJS();
+				
+				e.resolvePromise.Perform();
+				root.StepFrameJS();
+				
+				e.connect.Perform();
+				root.StepFrameJS();
+				Assert.AreEqual("foo", e.promisedValue.StringValue);
+			}
+		}
+
+		[Test]
 		public void ArgsSingleVectorArg()
 		{
 			var e = new UX.Model.Args.SingleVectorArg();

--- a/Source/Fuse.Models/Tests/UX/UpdateDisconnectedAfterPromise.js
+++ b/Source/Fuse.Models/Tests/UX/UpdateDisconnectedAfterPromise.js
@@ -1,0 +1,27 @@
+
+class Thing {
+	constructor() {
+		this.resolvePromise = () => { throw new Error("resolvePromise was called before promise was created") };
+		this.promise = new Promise(resolve => {
+			this.resolvePromise = () => resolve("foo");
+		});
+	}
+}
+
+let throwFromGetter = false;
+let disconnectedThing = new Thing();
+
+export default class {
+	constructor() {
+		this.thing = disconnectedThing;
+		this.resolvePromise = () => disconnectedThing.resolvePromise();
+	}
+
+	connect() {
+		this.thing = disconnectedThing;
+	}
+
+	disconnect() {
+		this.thing = null;
+	}
+}

--- a/Source/Fuse.Models/Tests/UX/UpdateDisconnectedAfterPromise.ux
+++ b/Source/Fuse.Models/Tests/UX/UpdateDisconnectedAfterPromise.ux
@@ -1,0 +1,6 @@
+<Panel ux:Class="UX.Model.UpdateDisconnectedAfterPromise" Model="UX/UpdateDisconnectedAfterPromise">
+	<FuseTest.Invoke ux:Name="resolvePromise" Handler="{resolvePromise}" />
+	<FuseTest.Invoke ux:Name="disconnect" Handler="{disconnect}" />
+	<FuseTest.Invoke ux:Name="connect" Handler="{connect}" />
+	<FuseTest.DudElement ux:Name="promisedValue" StringValue="{thing.promise}" />
+</Panel>


### PR DESCRIPTION
This fixes a class of bugs where we would attempt to invoke TreeObservable operations, even if the node was no longer part of the graph. We now check that we have a valid path to the root object before performing an operation on the TreeObservable.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [x] Tests
