### PR TITLE
Model: Add Set polyfill

### DIFF
--- a/Source/Fuse.Models/Fuse.Models.unoproj
+++ b/Source/Fuse.Models/Fuse.Models.unoproj
@@ -21,5 +21,6 @@
     "FuseJS/Internal/ZonePatches.js:Bundle",
     "FuseJS/Internal/Model.js:Bundle",
     "FuseJS/Internal/ViewModelAdapter.js:Bundle",
+    "FuseJS/Internal/ArraySet.js:Bundle",
   ]
 }

--- a/Source/Fuse.Models/FuseJS/Internal/ArraySet.js
+++ b/Source/Fuse.Models/FuseJS/Internal/ArraySet.js
@@ -1,0 +1,72 @@
+"use strict";
+
+function ArraySet(initialItems) {
+	if (initialItems == null) {
+		initialItems = [];
+	}
+	else if(!(initialItems instanceof Array)) {
+		throw new Error("Only arrays may be used as initial ArraySet items.");
+	}
+	else {
+		initialItems = initialItems.slice();
+	}
+
+	Object.defineProperty(this, "_items", {
+		value: initialItems,
+		configurable: false,
+		enumerable: false,
+		writable: false,
+	});
+}
+
+ArraySet.prototype.has = function(item) {
+	return this._items.indexOf(item) >= 0;
+}
+
+ArraySet.prototype.clear = function() {
+	this._items.length = 0;
+}
+
+ArraySet.prototype.add = function(item) {
+	if(this.has(item)) {
+		return;
+	}
+	this._items.push(item);
+
+	return this;
+}
+
+ArraySet.prototype.delete = function(item) {
+	var index = this._items.indexOf(item);
+	if (index < 0) {
+		return false;
+	}
+	this._items.splice(index, 1);
+	return true;
+}
+
+Object.defineProperties(ArraySet.prototype, {
+	size: {
+		get: function() {
+			return this._items.length;
+		}
+	}
+});
+
+function notImplemented(fname) {
+	throw new Error("ArraySet.prototype." + fname + " is not implemented");
+}
+
+ArraySet.prototype.values = function() {
+	notImplemented("values");
+}
+
+ArraySet.prototype.entries = function() {
+	notImplemented("entries");
+}
+
+ArraySet.prototype.forEach = function() {
+	notImplemented("forEach");
+}
+
+module.exports = ArraySet;

--- a/Source/Fuse.Models/FuseJS/Internal/Model.js
+++ b/Source/Fuse.Models/FuseJS/Internal/Model.js
@@ -3,6 +3,12 @@ var TreeObservable = require("FuseJS/TreeObservable")
 require("Polyfills/Window");
 require("./ZonePatches");
 
+// Polyfill for the ES6 Set type
+var Set = window.Set;
+if(!(Set instanceof Function)) {
+	Set = require("./ArraySet");
+}
+
 var rootZone = Zone.current;
 
 function shouldEmitProperty(key) {


### PR DESCRIPTION
This adds an implementation of ES6 Set that uses an array internally,
and chooses this implementation if the native Set is unavailable.

The polyfill is only applied locally in Model.js, and does not pollute
the global object.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
