### PR TITLE
Merge missed patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,21 +81,38 @@
 
 # 1.7
 
-### 1.7.0
+## 1.7.4
 
-## PageControl
+### Restored missing bug-fixes
+- There were a few bug-fixes from 1.6 that somehow missed 1.7. Those have now been restored. In particular:
+  * Added back removed API `Context.Invoke(Action ...)`.
+  * Fixed a NullReferenceException in `NativeEvent.RaiseAsync(params object[])`.
+
+## 1.7.3
+
+### Router
+- Fixed a crash in `Router.GoUp` that could be seen when pressing the back button at the root page of navigation.
+
+## 1.7.1
+
+### Fuse.Nodes
+- Fixed a bug where triggering `onParameterChanged` on an element would lead to a crash.
+
+## 1.7.0
+
+### PageControl
 - Fixed a crash resulting from adding dynamic pages and binding by name
 
-## Partial Curves
+### Partial Curves
 - Added support for drawing partial curves to `Path` and `Curve`. Refer to the `PathStart`, `PathLength` and `PathEnd` properties.
 - Added the path expressions `pathPointAtDistance` and `pathTangentAngleAtDistance` for locating an offset along a `Path` or `Curve` and the heading.
 
-## Router
+### Router
 - Fixed `goBack` to properly modify the route with two duplicate routes in the history## JavaScript 
 - Several functions in `ScriptModule` and related classes have been marked `internal`. These were never meant to be part of the public API.
 - Added `JavaScript.Names` with option `Require` to prevent injecting names into the JavaScript code namespace
 
-## TextColor Opacity
+### TextColor Opacity
 - Fixed a failure to render translucent `TextColor` correctly
 - Fixed the rendering of opaque emoji when `TextColor` is translucent (they will not also be translucent, though still  use the font coloring)
 
@@ -143,6 +160,7 @@
 ### Fuse.Scripting
 - Restore accidentally broken NativeEvent.RaiseAsync() API.
 - Rolled back NativeProperty constructor API to the pre-1.6 state. Code updated to 1.6 needs to be rolled back as well.
+- Previous changes resulted in a breaking change we would rather avoid so we reintroduce `Invoke(Action ..)` so we can take it through the usual deprecation cycle.
 
 ## 1.6.0
 

--- a/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
@@ -739,6 +739,18 @@ namespace Fuse.Navigation.Test
 			}
 		}
 		
+		[Test]
+		//Crash in https://github.com/fusetools/fuselibs-public/issues/1066
+		public void Issue1066()
+		{
+			var p = new UX.Router.Issue1066();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				p.router.GoBack();
+				p.router.GoBack(); //shouldn't crash
+			}
+		}
+		
 	}
 }
 	

--- a/Source/Fuse.Controls.Navigation/Tests/UX/Router.Issue1066.ux
+++ b/Source/Fuse.Controls.Navigation/Tests/UX/Router.Issue1066.ux
@@ -1,0 +1,11 @@
+<Panel ux:Class="UX.Router.Issue1066">
+	<Router ux:Name="router"/>
+
+	<Navigator DefaultPath="home">
+		<Page ux:Template="home">
+			<PageControl>
+				<Page/>
+			</PageControl>	
+		</Page>
+	</Navigator>
+</Panel>

--- a/Source/Fuse.Navigation/Router.uno
+++ b/Source/Fuse.Navigation/Router.uno
@@ -275,6 +275,9 @@ namespace Fuse.Navigation
 		void GoUp()
 		{
 			var cur = GetCurrentRouterPageRoute();
+			if (cur == null) 
+				return;
+				
 			var up = cur.Up();
 			if (up == cur) 
 			{

--- a/Source/Fuse.Nodes/Tests/UX/Visual.OnParameterChanged.ux
+++ b/Source/Fuse.Nodes/Tests/UX/Visual.OnParameterChanged.ux
@@ -1,0 +1,12 @@
+<Panel ux:Class="UX.Visual.OnParameterChanged">
+	<JavaScript>
+		var Observable = require("FuseJS/Observable")
+		var currentParameter = Observable();
+		this.onParameterChanged(function(args) {
+			currentParameter.value = JSON.stringify(args);
+		})
+		module.exports = { currentParameter : currentParameter };
+	</JavaScript>
+
+	<FuseTest.DudElement ux:Name="CurrentParameter" StringValue="{currentParameter}" />
+</Panel>

--- a/Source/Fuse.Nodes/Tests/Visual.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Visual.Test.uno
@@ -119,5 +119,18 @@ namespace Fuse.Test
 				Assert.AreEqual(2, p.ParentB.Children.Count);
 			}
 		}
+
+		[Test]
+		public void OnParameterChanged()
+		{
+			var p = new UX.Visual.OnParameterChanged();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(null, p.CurrentParameter.StringValue);
+				p.Parameter = "{ \"foo\" : \"bar\" }";
+				root.StepFrameJS();
+				Assert.AreEqual("{\"foo\":\"bar\"}", p.CurrentParameter.StringValue);
+			}
+		}
 	}
 }

--- a/Source/Fuse.Nodes/Visual.ScriptClass.uno
+++ b/Source/Fuse.Nodes/Visual.ScriptClass.uno
@@ -68,7 +68,9 @@ namespace Fuse
 		*/
 		static void onParameterChanged(Visual v, object[] args)
 		{
-			v.AddParameterChangedListener((Scripting.Function)args[0]);
+			var functionMirror = args[0] as Fuse.Scripting.IFunctionMirror;
+			if (functionMirror != null)
+				v.AddParameterChangedListener(functionMirror.Function);
 		}
 	}
 }

--- a/Source/Fuse.Scripting.JavaScript/FunctionMirror.uno
+++ b/Source/Fuse.Scripting.JavaScript/FunctionMirror.uno
@@ -7,7 +7,7 @@ using Fuse.Reactive;
 
 namespace Fuse.Scripting
 {
-	class FunctionMirror: DiagnosticSubject, IEventHandler, IRaw
+	class FunctionMirror: DiagnosticSubject, IFunctionMirror, IEventHandler, IRaw
 	{
 		readonly Function _func;
 
@@ -18,6 +18,8 @@ namespace Fuse.Scripting
 		{
 			_func = func;
 		}
+
+		Function IFunctionMirror.Function { get { return _func; } }
 
 		class CallClosure
 		{

--- a/Source/Fuse.Scripting/Context.uno
+++ b/Source/Fuse.Scripting/Context.uno
@@ -10,6 +10,14 @@ namespace Fuse.Scripting
 	public interface IThreadWorker
 	{
 		void Invoke(Uno.Action<Scripting.Context> action);
+
+		[Obsolete("Use Invoke(Action<Context>) instead")]
+		void Invoke(Uno.Action action);
+	}
+
+	internal interface IFunctionMirror
+	{
+		Function Function { get; }
 	}
 
 	public abstract class Context: Uno.IDisposable
@@ -66,8 +74,13 @@ namespace Fuse.Scripting
 		public abstract object Unwrap(object obj);
 		public abstract object Reflect(object obj);
 
-
 		public void Invoke(Uno.Action<Scripting.Context> action)
+		{
+			ThreadWorker.Invoke(action);
+		}
+
+		[Obsolete("Use Invoke(Action<Context>) instead")]
+		public void Invoke(Uno.Action action)
 		{
 			ThreadWorker.Invoke(action);
 		}

--- a/Source/Fuse.Scripting/Fuse.Scripting.unoproj
+++ b/Source/Fuse.Scripting/Fuse.Scripting.unoproj
@@ -7,7 +7,8 @@
     "ProjectUrl": "https://fusetools.com"
   },
   "InternalsVisibleTo": [
-    "Fuse.Scripting.JavaScript"
+    "Fuse.Scripting.JavaScript",
+    "Fuse.Nodes"
   ],
   "Packages": [
     "Uno.Collections",

--- a/Source/Fuse.Scripting/NativeEvent.uno
+++ b/Source/Fuse.Scripting/NativeEvent.uno
@@ -56,7 +56,7 @@ namespace Fuse.Scripting
 			if(Context != null || _queueEventsBeforeEvaluation)
 				_eventArgsQueue.Enqueue(args);
 
-			DispatchQueue(Context.ThreadWorker);
+			DispatchQueue(Context != null ? Context.ThreadWorker : null);
 		}
 
 		public void RaiseAsync(IThreadWorker threadWorker, params object[] args)


### PR DESCRIPTION
These patches were part of a 1.6 patch release, but we missed merging them to master afterwards, and so they've missed 1.7 and the 1.8 branch-out. 

After [merging 1.6 into 1.7](https://github.com/fusetools/fuselibs-public/pull/1074), this PR merges 1.7 into 1.8, so everything should be up to date.