### PR TITLE
Fix/dot net gradient path overflow

### DIFF
--- a/CHANGELOG/dotnet_gradient_endpoints.md
+++ b/CHANGELOG/dotnet_gradient_endpoints.md
@@ -1,0 +1,2 @@
+## DotNet/Preview Gradients
+- Gradient rendering in preview previously had some limitations in the ranges of `StartPoint` and `EndPoint` it could accept. This has been fixed: points inside and outside of the element render correctly now.

--- a/Source/Fuse.Common/Collision.uno
+++ b/Source/Fuse.Common/Collision.uno
@@ -107,5 +107,37 @@ namespace Fuse
 
 			return true;
 		}
+
+		/**
+			Calculate the intersection of two lines.  `p1`/`p2` are a point on the lines. `v1`/`v2` are the slopes of the lines (they need not be normalized).
+			
+			@return true if `r` contains the intersection point, false if the lines are parallel or coincident.
+		*/
+		public static bool LineLineIntersection( float2 p1, float2 v1, float2 p2, float2 v2, out float2 r )
+		{
+			// Get A,B,C of first line - points : ps1 to pe1
+			float A1 = v1.Y;
+			float B1 = -v1.X;
+			float C1 = A1*p1.X + B1*p1.Y;
+
+			// Get A,B,C of second line - points : ps2 to pe2
+			float A2 = v2.Y;
+			float B2 = -v2.X;
+			float C2 = A2*p2.X + B2*p2.Y;
+
+			// Get delta and check if the lines are parallel
+			float delta = A1*B2 - A2*B1;
+			if( Math.Abs(delta) < 1e-4 )
+			{
+				r = float2(0);
+				return false;
+			}
+
+			// now return the Vector2 intersection point
+			r = float2(
+				(B2*C1 - B1*C2)/delta,
+				(A1*C2 - A2*C1)/delta);
+			return true;
+		}
 	}
 }

--- a/Source/Fuse.Common/Tests/Fuse.Common.Test/Collision.Test.uno
+++ b/Source/Fuse.Common/Tests/Fuse.Common.Test/Collision.Test.uno
@@ -1,0 +1,31 @@
+using Fuse.Internal;
+using Uno;
+using Uno.Testing;
+
+using FuseTest;
+
+namespace Fuse.Test
+{
+	public class CollisionTest : TestBase
+	{
+
+		[Test]
+		public void LineLineIntersection()
+		{
+			float2 r;
+			Assert.IsTrue( Collision.LineLineIntersection( 
+				float2(1), float2(2,1), 
+				float2(4,5), float2(-1,5), out r));
+			Assert.AreEqual( float2(4.4545f, 2.7272f), r, 1e-4f);
+			
+			Assert.IsTrue( Collision.LineLineIntersection( 
+				float2(0), float2(0,1), 
+				float2(-2,-1), float2(1,1), out r));
+			Assert.AreEqual( float2(0,1), r, 1e-4f);
+			
+			Assert.IsFalse( Collision.LineLineIntersection(
+				float2(2,4), float2(2,3),
+				float2(2,5), float2(2,3), out r ));
+		}
+	}
+}

--- a/Source/Fuse.Common/Tests/Fuse.Common.Test/Collision.Test.uno
+++ b/Source/Fuse.Common/Tests/Fuse.Common.Test/Collision.Test.uno
@@ -26,6 +26,11 @@ namespace Fuse.Test
 			Assert.IsFalse( Collision.LineLineIntersection(
 				float2(2,4), float2(2,3),
 				float2(2,5), float2(2,3), out r ));
+				
+			Assert.IsTrue( Collision.LineLineIntersection(
+				float2(0), float2(1,-1),
+				float2(5), float2(1,1), out r ));
+			Assert.AreEqual( float2(0), r, 1e-4f );
 		}
 	}
 }

--- a/Source/Fuse.Drawing.Surface/DotNetSurface.uno
+++ b/Source/Fuse.Drawing.Surface/DotNetSurface.uno
@@ -32,6 +32,95 @@ namespace Fuse.Drawing
 		
 		This also keeps the API minimal. There are no convenience functions in this class. Those are provided via higher-level classes, such as `LineSegments` or `SurfaceUtil`.
 	*/
+
+	static internal class DotNetUtil
+	{
+		/** 
+			Calculates end points needed to extend the start/end over the entire cover region. This is a utility function for CreateColorBlend that needs to workaround DotNet not supporting clamped gradients.
+		*/
+		static public float4 AdjustedEndPoints( float4 area, float2 start, float2 end )
+		{
+			var unit = Vector.Normalize(end - start);
+			var normal = float2(unit.Y,-unit.X);
+			var isSlopeNeg = unit.X * (-unit.Y) < 0;
+			
+			float2 cornerA, cornerB;
+			if (isSlopeNeg)
+			{
+				cornerA = area.XY;
+				cornerB = area.ZW;
+			}
+			else
+			{
+				cornerA = area.XW;
+				cornerB = area.ZY;
+			}
+			
+			//swap corners if the input strat/end is more oriented from B->A than A->B
+			//this could be logically be done with an angle copmarison on `unit`, but it's sensitive to the
+			//hard-condition of `isSlopeNeg`
+			if (Vector.Distance(end,cornerA) + Vector.Distance(start,cornerB) < 
+				Vector.Distance(end,cornerB) + Vector.Distance(start,cornerA))
+			{
+				var t = cornerA;
+				cornerA = cornerB;
+				cornerB = t;
+			}
+			
+			var ca = float2(0);
+			var cb = float2(0);
+			if (!Collision.LineLineIntersection(cornerA, normal, start, unit, out ca) ||
+				!Collision.LineLineIntersection(cornerB, normal, start, unit, out cb) )
+			{
+				//something funny with the input, sane fallback
+				return float4( start.X, start.Y, end.X, end.Y );
+			}
+			
+			return float4( ca.X, ca.Y, cb.X, cb.Y );
+		}
+		
+		/**
+			Calculate the adjusted offsets of points along a line given new endpoints of that line.
+			
+			If adjStart or adjEnd are already on the line it will use the input start/end as the endpoints instead.
+			
+			Returns a float2 (r) that can be used to calculate the adjusted offset on (p):
+			
+				(p * r[0]) + r[1]
+		*/
+		static public float2 AdjustedOffsets( float2 start, float2 end, ref float2 adjStart, ref float2 adjEnd )
+		{
+			var inLen = Vector.Distance(start,end);
+			var dir = end - start;
+			//distance along input line
+			float tAS = 0, tAE = 0;
+			if (Math.Abs(dir.X) > Math.Abs(dir.Y))
+			{
+				tAS = (adjStart.X - start.X) / dir.X;
+				tAE = (adjEnd.X - start.X) / dir.X;
+			}
+			else
+			{
+				tAS = (adjStart.Y - start.Y) / dir.Y;
+				tAE = (adjEnd.Y - start.Y) / dir.Y;
+			}
+			
+			if (tAS > 0)
+			{
+				adjStart = start;
+				tAS = 0;
+			}
+			if (tAE < 1)
+			{
+				adjEnd = end;
+				tAE = 1;
+			}
+			
+			var tLen = tAE - tAS;
+			
+			return float2( 1f / tLen, -tAS / tLen );
+		}
+	}
 	
 	[Require("Assembly", "System.Drawing")]
 	[extern(DOTNET) Require("Source.Include","XliPlatform/GL.h")]
@@ -47,7 +136,6 @@ namespace Fuse.Drawing
 		Bitmap _bitmap;
 		DotNetGraphics _graphics;
 		List<DotNetNative.Matrix> _transformStates = new List<DotNetNative.Matrix>();
-
 
 		public DotNetSurface()
 		{
@@ -591,22 +679,12 @@ namespace Fuse.Drawing
 			colors[numberOfColorPoints - 1] = endColor;
 			offsets[numberOfColorPoints - 1] = 1.0f;
 
-			var inVec = Vector.Normalize(inEnd - inStart);
-			var inLen = Vector.Length(inEnd - inStart);
-			//safety
-			if (inLen < 0.1f) {
-				inVec = float2(1); //this affects only gStart/gEnd so okay to be incorrect in nonsense case
-				inLen = 1;
-			}
-
-			var minLen = Vector.Length( float2(bounds.Width, bounds.Height) );
-			//extra length needed to extend line to cover whole region
-			var extraLen = Math.Max(minLen - inLen,0);
-			var exOff = extraLen / inLen;
-			var exLen = inLen * exOff;
-			//the 0/1 input offsets as offsets in the adjusted line
-			var inOffStart = exOff / (1 + 2 * exOff);
-			var inOffEnd = (1+exOff) / (1 + 2 * exOff);
+			var newEnds = DotNetUtil.AdjustedEndPoints( 
+				float4( bounds.X, bounds.Y, bounds.X + bounds.Width, bounds.Y + bounds.Height ),
+				inStart, inEnd );
+			gStart = newEnds.XY;
+			gEnd = newEnds.ZW;
+			var adjust = DotNetUtil.AdjustedOffsets( inStart, inEnd, ref gStart, ref gEnd );
 
 			for (int i=0; i < stops.Length; ++i)
 			{
@@ -615,11 +693,8 @@ namespace Fuse.Drawing
 				// our indexes in the storing array are offset by 1
 				// since we have manually filled the first spot
 				colors[i + 1] = ColorFromFloat4(stop.Color);
-				offsets[i + 1] = inOffStart + (stop.Offset * (inOffEnd-inOffStart));
+				offsets[i + 1] = stop.Offset * adjust[0] + adjust[1];
 			}
-
-			gStart = inStart - inVec * exLen;
-			gEnd = inEnd + inVec * exLen;
 			
 			ColorBlend blend = new ColorBlend();
 			blend.Positions = offsets; 

--- a/Source/Fuse.Drawing.Surface/Tests/Surface.Test.uno
+++ b/Source/Fuse.Drawing.Surface/Tests/Surface.Test.uno
@@ -23,5 +23,54 @@ namespace Fuse.Test
 			
 			//TODO: If we supported GetNames on the enum we could ensure the count as well
 		}
+		
+		[Test]
+		public void DotNetAdjustedEndPoints()
+		{
+			//these tests have the bounds Y-inverted since I drew them on my graph paper that way. :/
+			Assert.AreEqual( float4(4.0588f, 7.2352f, 8.6470f, -0.4117f), 
+				DotNetUtil.AdjustedEndPoints( float4(2,1, 11, 6), float2(6,4), float2(9,-1) ), 1e-4f );
+				
+			Assert.AreEqual( float4(12.4137f, 4.9655f, 2.0689f, 0.8275f), 
+				DotNetUtil.AdjustedEndPoints( float4(2,1, 12, 6), float2(10,4), float2(5,2) ), 1e-4f );
+			
+			Assert.AreEqual( float4(12.8648f, -0.8108f, 13.9189f, 5.5135f), 
+				DotNetUtil.AdjustedEndPoints( float4(2,1, 11, 6), float2(13,0), float2(14,6) ), 1e-4f );
+				
+			Assert.AreEqual( float4(-5,0, 10,0),
+				DotNetUtil.AdjustedEndPoints( float4(-5,-3, 10,-6), float2(0,0), float2(1,0)), 1e-4f );
+				
+			Assert.AreEqual( float4(1,2, 1,8),
+				DotNetUtil.AdjustedEndPoints( float4(0,8, 5,2), float2(1,0), float2(1,10)), 1e-4f );
+	
+			//not these
+			Assert.AreEqual( float4(0,0,200,200),
+				DotNetUtil.AdjustedEndPoints( float4(0,0,200,200), float2(80,80), float2(300,300)), 1e-4f );
+		}
+		
+		[Test]
+		public void DotNetAdjustedOffsets()
+		{
+			float2 s = float2(0);
+			float2 e = float2(5);
+			Assert.AreEqual( float2(1f/2.5f,0.4f), 
+				DotNetUtil.AdjustedOffsets( float2(2), float2(4), ref s, ref e ), 1e-4f );
+				
+			s = float2(1,0);
+			e = float2(9,0);
+			Assert.AreEqual( float2(1f/2f,0f), 
+				DotNetUtil.AdjustedOffsets( float2(-1,0), float2(4,0), ref s, ref e ), 1e-4f );
+				
+			s = float2(4,7);
+			e = float2(4,0);
+			Assert.AreEqual( float2(6f/8f,0.25f), 
+				DotNetUtil.AdjustedOffsets( float2(4,5), float2(4,-1), ref s, ref e ), 1e-4f );
+				
+			s = float2(100);
+			e = float2(0);
+			Assert.AreEqual( float2(1f/2,0.25f), 
+				DotNetUtil.AdjustedOffsets( float2(75), float2(25), ref s, ref e ), 1e-4f );
+		}
 	}
+	
 }


### PR DESCRIPTION
A rather complex fix for a simple problem -- an expanded workaround to DotNet/Mono not supporting clamped gradients. :(

This PR contains:
- [x] Changelog
- [ ] ~Documentation~
- [x] Tests (I also ran my gradient playground)
