### PR TITLE
Fixes DockPanel layout, and ManualTestApp invalid layouts

### DIFF
--- a/Source/Fuse.Common/Tests/FuseTest/InterceptPanel.uno
+++ b/Source/Fuse.Common/Tests/FuseTest/InterceptPanel.uno
@@ -1,0 +1,26 @@
+using Uno;
+using Uno.UX;
+
+using Fuse;
+using Fuse.Controls;
+
+namespace FuseTest
+{
+	/**
+		Can intercept and count certain events. This assists in tracking performance expectations that would otherwise not be visible.
+	*/
+	public class InterceptPanel : LayoutControl
+	{
+		public int GetContentSizeCount = 0;
+		protected override float2 GetContentSize( LayoutParams lp )
+		{
+			GetContentSizeCount++;
+			return base.GetContentSize(lp);
+		}
+		
+		public void Reset()
+		{
+			GetContentSizeCount = 0;
+		}
+	}
+}

--- a/Source/Fuse.Controls.Panels/Layouts/DockLayout.uno
+++ b/Source/Fuse.Controls.Panels/Layouts/DockLayout.uno
@@ -123,7 +123,7 @@ namespace Fuse.Layouts
 				var d = GetDock(c);
 				var horz =  d== Dock.Left || d == Dock.Right;
 				nlp.SetSize(availableSize,!horz,horz);
-				var desiredSize = c.GetMarginSize( nlp );
+				var desiredSize = d != Dock.Fill ? c.GetMarginSize( nlp ) : float2(0);
 
 				switch (d)
 				{

--- a/Source/Fuse.Controls.Panels/Tests/DockPanel.Test.uno
+++ b/Source/Fuse.Controls.Panels/Tests/DockPanel.Test.uno
@@ -266,6 +266,16 @@ namespace Fuse.Controls.Test
 			}
 		}
 		
+		[Test]
+		public void Issue1082()
+		{
+			var p = new UX.DockPanel.Issue1082();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(0,p.ip.GetContentSizeCount);
+			}
+		}
+		
 
 		private void TestElementDockLayout(TestRootPanel root, Element element, Fuse.Layouts.Dock dock,
 			int2 rootSize, float2 expectActualSize, float2 expectActualPosition,

--- a/Source/Fuse.Controls.Panels/Tests/UX/DockPanel.Issue1082.ux
+++ b/Source/Fuse.Controls.Panels/Tests/UX/DockPanel.Issue1082.ux
@@ -1,0 +1,5 @@
+<Panel ux:Class="UX.DockPanel.Issue1082">
+	<DockPanel>
+		<FuseTest.InterceptPanel ux:Name="ip"/>
+	</DockPanel>
+</Panel>

--- a/Tests/ManualTests/ManualTestingApp/ActionTiming/ActionTiming.ux
+++ b/Tests/ManualTests/ManualTestingApp/ActionTiming/ActionTiming.ux
@@ -43,11 +43,11 @@
 				<Track Expect="2" Status="Status2" Delay="2"/>
 
 				<!-- triggers when backward starts -->
-				<Track Expect="2" Status="Status6" Direction="Backward"/>
+				<Track Expect="2" Status="Status6" When="Backward"/>
 				
-				<Track Expect="5" Status="Status5" Direction="Backward" AtProgress="0"/>
-				<Track Expect="3.5" Status="Status4" AtProgress="0.5" Direction="Backward"/>
-				<Track Expect="2" Status="Status3" Delay="3" Direction="Backward"/>
+				<Track Expect="5" Status="Status5" When="Backward" AtProgress="0"/>
+				<Track Expect="3.5" Status="Status4" AtProgress="0.5" When="Backward"/>
+				<Track Expect="2" Status="Status3" Delay="3" When="Backward"/>
 			</WhileTrue>
 
 			
@@ -72,10 +72,10 @@
 
 				<!-- triggers when backward starts -->
 				
-				<Track Expect="3" Status="StatusB6" Direction="Backward"/>
+				<Track Expect="3" Status="StatusB6" When="Backward"/>
 				
-				<Track Expect="6" Status="StatusB5" Direction="Backward" AtProgress="0"/>
-				<Track Expect="4.5" Status="StatusB4" AtProgress="0.5" Direction="Backward"/>
+				<Track Expect="6" Status="StatusB5" When="Backward" AtProgress="0"/>
+				<Track Expect="4.5" Status="StatusB4" AtProgress="0.5" When="Backward"/>
 			</WhileTrue>
 			
 		</StackPanel>

--- a/Tests/ManualTests/ManualTestingApp/BackButton/BackButtonView.ux
+++ b/Tests/ManualTests/ManualTestingApp/BackButton/BackButtonView.ux
@@ -10,7 +10,7 @@
 		</StackPanel>
 	</ScrollView>
 	<WhileActive>
-		<Callback Direction="Forward" Handler="EnableBack"/>
-		<Callback Direction="Backward" Handler="DisableBack"/>
+		<Callback When="Forward" Handler="EnableBack"/>
+		<Callback When="Backward" Handler="DisableBack"/>
 	</WhileActive>
 </Page>

--- a/Tests/ManualTests/ManualTestingApp/DeviceInfo/DeviceInfo.ux
+++ b/Tests/ManualTests/ManualTestingApp/DeviceInfo/DeviceInfo.ux
@@ -50,7 +50,7 @@
 				</WhileFalse>
 			</Panel>
 			
-			<Grid ColumnCount="3" Alignment="Center">
+			<Grid Columns="auto,auto,auto" Alignment="Center" DefaultRow="auto">
 				<PlatformCheck Label="Mobile" Value="isMobile()"/>
 				<PlatformCheck Label="iOS" Value="isIOS()"/>
 				<PlatformCheck Label="Android" Value="isAndroid()"/>

--- a/Tests/ManualTests/ManualTestingApp/Singles/AnimationControlTest2.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/AnimationControlTest2.ux
@@ -37,7 +37,7 @@
 				</LinearGradient>
 			</Rectangle>
 			
-			<Grid>
+			<Grid Columns="1*">
 				<Text Alignment="Center" FontSize="30" Visibility="Hidden" ux:Name="Label1">1</Text>
 				<Text Alignment="Center" FontSize="30" Visibility="Hidden" ux:Name="Label2">2</Text>
 				<Text Alignment="Center" FontSize="30" Visibility="Hidden" ux:Name="Label3">3</Text>

--- a/Tests/ManualTests/ManualTestingApp/Singles/Opacity.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/Opacity.ux
@@ -20,7 +20,8 @@
 		</NodeGroup>
 				
 		<StackPanel ItemSpacing="10">
-			<Grid Columns="auto,auto,30,30,30,30" Color="Black" CellSpacing="10" Padding="10">
+			<Grid Columns="auto,auto,30,30,30,30" Color="Black" CellSpacing="10" Padding="10"
+				DefaultRow="auto">
 				<OPTest Label="25% White on Black 😀" Color="#FFF4"/>
 				<OPTest Label="50% White on Black 😀" Color="#FFF8"/>
 				<OPTest Label="100% White on Black 😀" Color="#FFFF"/>
@@ -30,7 +31,8 @@
 				<OPTest Label="100% Green on Black 😀" Color="#0F0F"/>
 			</Grid>
 			
-			<Grid Columns="auto,auto,30,30,30,30" Color="White" Padding="10" CellSpacing="10">
+			<Grid Columns="auto,auto,30,30,30,30" Color="White" Padding="10" CellSpacing="10"
+				DefaultRow="auto">
 				<OPTest Label="25% Black on White 😀" Color="#0004"/>
 				<OPTest Label="50% Black on White 😀" Color="#0008"/>
 				<OPTest Label="100% Black on White 😀" Color="#000F"/>

--- a/Tests/ManualTests/ManualTestingApp/Singles/SwipeLimitPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/SwipeLimitPage.ux
@@ -70,13 +70,18 @@
 			<Image File="../Assets/small_icons_27/arrowright.png" Alignment="Right" Color="0,0.3,0.3,1"/>
 			
 			<Panel ux:Name="Numbers">
-				<Number Alignment="Center" ux:Name="LeftNum" Value="0" Opacity="0">
+				<Panel ux:Class="SLPNumber" Value="0">
+					<float ux:Property="Value"/>
+					<Text Value="{Property this.Value}"/>
+				</Panel>
+				
+				<SLPNumber Alignment="Center" ux:Name="LeftNum" Value="0" Opacity="0">
 					<Translation X="-100"/>
-				</Number>
-				<Number Alignment="Center" ux:Name="MidNum" Value="1" Opacity="1"/>
-				<Number Alignment="Center" ux:Name="RightNum" Value="2" Opacity="0">
+				</SLPNumber>
+				<SLPNumber Alignment="Center" ux:Name="MidNum" Value="1" Opacity="1"/>
+				<SLPNumber Alignment="Center" ux:Name="RightNum" Value="2" Opacity="0">
 					<Translation X="100"/>
-				</Number>
+				</SLPNumber>
 			</Panel>
 			
 			<SwipeGesture Direction="Left" ux:Name="NumSwipeLeft"/>

--- a/Tests/ManualTests/ManualTestingApp/Singles/VideoPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/VideoPage.ux
@@ -26,9 +26,9 @@
 				</ProgressAnimation>
 			</Slider>
 
-			<Grid Rows="auto" ColumnCount="2">
+			<Grid DefaultRow="auto" ColumnCount="2">
 				<StdButton ux:Name="_playButton" Text="Play">
-					<Clicked><Resume Target="_video" /></Clicked>
+					<Clicked><Play Target="_video" /></Clicked>
 				</StdButton>
 				<StdButton ux:Name="_pauseButton" Text="Pause" Visibility="Hidden">
 					<Clicked><Pause Target="_video" /></Clicked>


### PR DESCRIPTION
Fixes https://github.com/fusetools/fuselibs-public/issues/1082 in DockPanel
Cleanup warnings from ManualTestApp -- both deprecated and invalid layouts

This PR contains:
- [ ] ~Changelog~ nothing significant/noticeable (_maybe_ performance)
- [ ] ~Documentation~
- [x] Tests
