### PR TITLE
do not store version in unoprojs

### DIFF
--- a/Source/Android.ActivityUtils/Android.ActivityUtils.unoproj
+++ b/Source/Android.ActivityUtils/Android.ActivityUtils.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2016",
   "Description": "Helper Utils for interacting with android Activities",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Includes": [
       "*"
   ]

--- a/Source/Experimental.Http/Experimental.Http.unoproj
+++ b/Source/Experimental.Http/Experimental.Http.unoproj
@@ -2,7 +2,6 @@
   "Description": "Library for data caching",
   "Publisher": "Fusetools AS",
   "Copyright": "Copyright (c) Fusetools AS 2017",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Experimental.TextureLoader/Experimental.TextureLoader.unoproj
+++ b/Source/Experimental.TextureLoader/Experimental.TextureLoader.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2015",
   "Description": "Experimental.TextureLoader",
   "Publisher": "Fuse",
-  "Version": "1.8.0-rc1",
   "Includes": [
     "TextureLoader.uno:Source",
     "TextureLoaderImpl.uno:Source",

--- a/Source/Fuse.Alerts/Fuse.Alerts.unoproj
+++ b/Source/Fuse.Alerts/Fuse.Alerts.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native alerts and simple dialogs for mobile targets",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Android.TextRenderer/Fuse.Android.TextRenderer.unoproj
+++ b/Source/Fuse.Android.TextRenderer/Fuse.Android.TextRenderer.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Android TextRenderer",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Android/Fuse.Android.unoproj
+++ b/Source/Fuse.Android/Fuse.Android.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native bootstrapping for Android",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Animations/Fuse.Animations.unoproj
+++ b/Source/Fuse.Animations/Fuse.Animations.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Framework for general purpose animation",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Audio/Fuse.Audio.unoproj
+++ b/Source/Fuse.Audio/Fuse.Audio.unoproj
@@ -3,7 +3,6 @@
   "Description": "Audio playback support",
   "Publisher": "Fusetools AS",
   "Title": "Fuse.Audio",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.BasicTheme/Fuse.BasicTheme.unoproj
+++ b/Source/Fuse.BasicTheme/Fuse.BasicTheme.unoproj
@@ -2,7 +2,6 @@
   "Description": "This package is part of Fuse",
   "Publisher": "Fusetools AS",
   "Copyright": "Copyright (c) Fusetools AS 2017",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Camera/Fuse.Camera.unoproj
+++ b/Source/Fuse.Camera/Fuse.Camera.unoproj
@@ -3,7 +3,6 @@
   "Description": "Native Camera support",
   "Publisher": "Fusetools AS",
   "Title": "Fuse.Camera",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.CameraRoll/Fuse.CameraRoll.unoproj
+++ b/Source/Fuse.CameraRoll/Fuse.CameraRoll.unoproj
@@ -3,7 +3,6 @@
   "Description": "Nativ CameraRoll support",
   "Publisher": "Fusetools AS",
   "Title": "Fuse.CameraRoll",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Common/Fuse.Common.unoproj
+++ b/Source/Fuse.Common/Fuse.Common.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "User experience design and tooling platform (core package)",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Controls.DatePicker/Fuse.Controls.DatePicker.unoproj
+++ b/Source/Fuse.Controls.DatePicker/Fuse.Controls.DatePicker.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native DatePicker",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Controls.Native/Fuse.Controls.Native.unoproj
+++ b/Source/Fuse.Controls.Native/Fuse.Controls.Native.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Abstraction over platform-specific native controls",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Controls.Navigation/Fuse.Controls.Navigation.unoproj
+++ b/Source/Fuse.Controls.Navigation/Fuse.Controls.Navigation.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Navigation controls",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Controls.Panels/Fuse.Controls.Panels.unoproj
+++ b/Source/Fuse.Controls.Panels/Fuse.Controls.Panels.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Primitives",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Controls.Primitives/Fuse.Controls.Primitives.unoproj
+++ b/Source/Fuse.Controls.Primitives/Fuse.Controls.Primitives.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Primitives",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Controls.ScrollView/Fuse.Controls.ScrollView.unoproj
+++ b/Source/Fuse.Controls.ScrollView/Fuse.Controls.ScrollView.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Primitives",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Controls.TimePicker/Fuse.Controls.TimePicker.unoproj
+++ b/Source/Fuse.Controls.TimePicker/Fuse.Controls.TimePicker.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native TimePicker",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Controls.Video/Fuse.Controls.Video.unoproj
+++ b/Source/Fuse.Controls.Video/Fuse.Controls.Video.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Video",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Controls.WebView/Fuse.Controls.WebView.unoproj
+++ b/Source/Fuse.Controls.WebView/Fuse.Controls.WebView.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "WebView",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },
@@ -43,4 +42,3 @@
     "Android/ScrollableWebView.java:Java:Android"
   ]
 }
-

--- a/Source/Fuse.Controls/Fuse.Controls.unoproj
+++ b/Source/Fuse.Controls/Fuse.Controls.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Library of user interface and layout controls",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Designer/Fuse.Designer.unoproj
+++ b/Source/Fuse.Designer/Fuse.Designer.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Attributes and classes for building Fuse Designer-friendly components",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Desktop/Fuse.Desktop.unoproj
+++ b/Source/Fuse.Desktop/Fuse.Desktop.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Default bootstrapping for desktop platforms",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Drawing.Planar/Fuse.Drawing.Planar.unoproj
+++ b/Source/Fuse.Drawing.Planar/Fuse.Drawing.Planar.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Fuse.Drawing",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Drawing.Primitives/Fuse.Drawing.Primitives.unoproj
+++ b/Source/Fuse.Drawing.Primitives/Fuse.Drawing.Primitives.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Fuse.Drawing",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Drawing.Surface/Fuse.Drawing.Surface.unoproj
+++ b/Source/Fuse.Drawing.Surface/Fuse.Drawing.Surface.unoproj
@@ -3,7 +3,6 @@
   "Description": "Library of vector drawing and surface",
   "Publisher": "Fusetools AS",
   "Title": "Fuse.Drawing.Surface",
-  "Version": "1.8.0-rc1",
   "InternalsVisibleTo": [
     "Fuse.Controls.Panels",
     "Fuse.Controls.Primitives",

--- a/Source/Fuse.Drawing/Fuse.Drawing.unoproj
+++ b/Source/Fuse.Drawing/Fuse.Drawing.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Fuse.Drawing",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Effects/Fuse.Effects.unoproj
+++ b/Source/Fuse.Effects/Fuse.Effects.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Library of user interface effects",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Elements/Fuse.Elements.unoproj
+++ b/Source/Fuse.Elements/Fuse.Elements.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Multi-platform UI library based on 2D elements",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.FileSystem/Fuse.FileSystem.unoproj
+++ b/Source/Fuse.FileSystem/Fuse.FileSystem.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native Storage",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.GeoLocation/Fuse.GeoLocation.unoproj
+++ b/Source/Fuse.GeoLocation/Fuse.GeoLocation.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native Location",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Gestures/Fuse.Gestures.unoproj
+++ b/Source/Fuse.Gestures/Fuse.Gestures.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Library of common input gesture recognizers",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.ImageTools/Fuse.ImageTools.unoproj
+++ b/Source/Fuse.ImageTools/Fuse.ImageTools.unoproj
@@ -3,7 +3,6 @@
   "Description": "Native image utilities",
   "Publisher": "Fusetools AS",
   "Title": "Fuse.ImageTools",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Launcher.Email/Fuse.Launcher.Email.unoproj
+++ b/Source/Fuse.Launcher.Email/Fuse.Launcher.Email.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native Launcher",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Launcher.InterApp/Fuse.Launcher.InterApp.unoproj
+++ b/Source/Fuse.Launcher.InterApp/Fuse.Launcher.InterApp.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native Launcher",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Launcher.Maps/Fuse.Launcher.Maps.unoproj
+++ b/Source/Fuse.Launcher.Maps/Fuse.Launcher.Maps.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native Launcher",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Launcher.Phone/Fuse.Launcher.Phone.unoproj
+++ b/Source/Fuse.Launcher.Phone/Fuse.Launcher.Phone.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native Launcher",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Launcher/Fuse.Launcher.unoproj
+++ b/Source/Fuse.Launcher/Fuse.Launcher.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native Launcher",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.LocalNotifications/Fuse.LocalNotifications.unoproj
+++ b/Source/Fuse.LocalNotifications/Fuse.LocalNotifications.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Support for Local Notifications On Mobile",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Maps/Fuse.Maps.unoproj
+++ b/Source/Fuse.Maps/Fuse.Maps.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "MapView",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Marshal/Fuse.Marshal.unoproj
+++ b/Source/Fuse.Marshal/Fuse.Marshal.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Allows marshalling and arithmetic between boxed value types",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Models/Fuse.Models.unoproj
+++ b/Source/Fuse.Models/Fuse.Models.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Models",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Motion/Fuse.Motion.unoproj
+++ b/Source/Fuse.Motion/Fuse.Motion.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Library for control motion and simulated physics for UI",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Navigation/Fuse.Navigation.unoproj
+++ b/Source/Fuse.Navigation/Fuse.Navigation.unoproj
@@ -3,7 +3,6 @@
   "Description": "Library of common trigger behaviors for UIs",
   "Publisher": "Fusetools AS",
   "Title": "Fuse.Triggers",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Nodes/Fuse.Nodes.unoproj
+++ b/Source/Fuse.Nodes/Fuse.Nodes.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Low-level Node and Visual framework",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Physics/Fuse.Physics.unoproj
+++ b/Source/Fuse.Physics/Fuse.Physics.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Library for physics-based UI Effects",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Platform/Fuse.Platform.unoproj
+++ b/Source/Fuse.Platform/Fuse.Platform.unoproj
@@ -2,7 +2,6 @@
   "Description": "This package is part of Fuse",
   "Publisher": "Fusetools AS",
   "Copyright": "Copyright (c) Fusetools AS 2017",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
+++ b/Source/Fuse.PushNotifications/Fuse.PushNotifications.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Support for Push Notifications On Mobile",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Reactive.Bindings/Fuse.Reactive.Bindings.unoproj
+++ b/Source/Fuse.Reactive.Bindings/Fuse.Reactive.Bindings.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Framework for reactive data binding",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Reactive.Expressions/Fuse.Reactive.Expressions.unoproj
+++ b/Source/Fuse.Reactive.Expressions/Fuse.Reactive.Expressions.unoproj
@@ -3,7 +3,6 @@
   "Description": "Framework for reactive expressions",
   "Publisher": "Fusetools AS",
   "IsTransitive": true,
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Reactive/Fuse.Reactive.unoproj
+++ b/Source/Fuse.Reactive/Fuse.Reactive.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Framework for reactive programming",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Scripting.JavaScript/Fuse.Scripting.JavaScript.unoproj
+++ b/Source/Fuse.Scripting.JavaScript/Fuse.Scripting.JavaScript.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Framework for reactive data binding",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Scripting/Fuse.Scripting.unoproj
+++ b/Source/Fuse.Scripting/Fuse.Scripting.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Abstract scripting framework",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Selection/Fuse.Selection.unoproj
+++ b/Source/Fuse.Selection/Fuse.Selection.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Library for selection behavior",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Share/Fuse.Share.unoproj
+++ b/Source/Fuse.Share/Fuse.Share.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Content sharing API",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Packages": [
     "Uno.Threading",
     "Uno.Permissions",

--- a/Source/Fuse.Storage/Fuse.Storage.unoproj
+++ b/Source/Fuse.Storage/Fuse.Storage.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native Storage",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Testing/Fuse.Testing.unoproj
+++ b/Source/Fuse.Testing/Fuse.Testing.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Testing API",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Packages": [
     "Uno.Testing",
     "Uno.Threading"

--- a/Source/Fuse.Text/Fuse.Text.unoproj
+++ b/Source/Fuse.Text/Fuse.Text.unoproj
@@ -1,7 +1,6 @@
 {
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Triggers/Fuse.Triggers.unoproj
+++ b/Source/Fuse.Triggers/Fuse.Triggers.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Library of common trigger behaviors for UIs",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.UserEvents/Fuse.UserEvents.unoproj
+++ b/Source/Fuse.UserEvents/Fuse.UserEvents.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Library for application messages",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.Vibration/Fuse.Vibration.unoproj
+++ b/Source/Fuse.Vibration/Fuse.Vibration.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native Vibration",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.WebSockets/Fuse.WebSockets.unoproj
+++ b/Source/Fuse.WebSockets/Fuse.WebSockets.unoproj
@@ -1,6 +1,5 @@
 {
   "Copyright": "Copyright (c) Fusetools AS 2017",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.iOS.LocationPermissions/Fuse.iOS.LocationPermissions.unoproj
+++ b/Source/Fuse.iOS.LocationPermissions/Fuse.iOS.LocationPermissions.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "PList entries for iOS location APIs",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.iOS.TextRenderer/Fuse.iOS.TextRenderer.unoproj
+++ b/Source/Fuse.iOS.TextRenderer/Fuse.iOS.TextRenderer.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "iOS TextRenderer",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse.iOS/Fuse.iOS.unoproj
+++ b/Source/Fuse.iOS/Fuse.iOS.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Native UI and bootstrapping for iOS",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/Source/Fuse/Fuse.unoproj
+++ b/Source/Fuse/Fuse.unoproj
@@ -1,6 +1,5 @@
 {
   "Copyright": "Copyright (c) Fusetools AS 2017",
-  "Version": "1.8.0-rc1",
   "Publisher": "Fusetools AS",
   "Description": "References the complete set of canonical, non-optional Fuse libraries",
   "Package": {

--- a/Source/FuseJS/FuseJS.unoproj
+++ b/Source/FuseJS/FuseJS.unoproj
@@ -1,6 +1,5 @@
 {
   "Copyright": "Copyright (c) Fusetools AS 2017",
-  "Version": "1.8.0-rc1",
   "Publisher": "Fusetools AS",
   "Description": "References FuseJS standard features",
   "Package": {

--- a/Source/Polyfills.Window/Polyfills.Window.unoproj
+++ b/Source/Polyfills.Window/Polyfills.Window.unoproj
@@ -2,7 +2,6 @@
   "Copyright": "Copyright (c) Fusetools AS 2017",
   "Description": "Browser window polyfill",
   "Publisher": "Fusetools AS",
-  "Version": "1.8.0-rc1",
   "Package": {
     "ProjectUrl": "https://fusetools.com"
   },

--- a/pack.sh
+++ b/pack.sh
@@ -38,7 +38,7 @@ esac
 
 stuff install Stuff
 bash Stuff/Devtools/update-version-numbers.sh --verify
-uno doctor --configuration=Release
+uno doctor --configuration=Release --build-number=$VERSION
 
 # Make packages
 for f in Source/*; do


### PR DESCRIPTION
We don't need to keep version numbers in each unoproj-folder; instead
we can pass the version number to uno doctor when building.

This reduces a lot of conflicts when merging release-branches.

We're doing the same in Uno, see fusetools/uno#1617.