### PR TITLE
UX source tests for fuselibs objects

### DIFF
--- a/Source/Fuse.Controls.Panels/Tests/ColumnLayout.Test.uno
+++ b/Source/Fuse.Controls.Panels/Tests/ColumnLayout.Test.uno
@@ -23,6 +23,8 @@ namespace Fuse.Controls.Test
 				Assert.AreEqual(float2(55,0), p.P2.ActualPosition);
 				Assert.AreEqual(float2(0,55), p.P3.ActualPosition);
 				Assert.AreEqual(float2(0,120), p.P4.ActualPosition);
+				Assert.AreEqual(2, p.L.SourceLineNumber);
+				Assert.AreEqual("UX/ColumnLayout1.ux", p.L.SourceFileName);
 			}
 		}
 		
@@ -39,6 +41,8 @@ namespace Fuse.Controls.Test
 				Assert.AreEqual(float2(0,75), p.P4.ActualPosition);
 				Assert.AreEqual(float2(90,75), p.P5.ActualPosition);
 				Assert.AreEqual(float2(100,0), p.P6.ActualPosition);
+				Assert.AreEqual(2, p.L.SourceLineNumber);
+				Assert.AreEqual("UX/ColumnLayout2.ux", p.L.SourceFileName);
 			}
 		}
 		
@@ -55,6 +59,8 @@ namespace Fuse.Controls.Test
 				Assert.AreEqual(float2(100,0), p.P2.ActualPosition);
 				Assert.AreEqual(float2(0,50), p.P3.ActualPosition);
 				Assert.AreEqual(float2(100,50), p.P4.ActualPosition);
+				Assert.AreEqual(2, p.L.SourceLineNumber);
+				Assert.AreEqual("UX/ColumnLayout3.ux", p.L.SourceFileName);
 			}
 		}
 		
@@ -66,6 +72,8 @@ namespace Fuse.Controls.Test
 			{
 				Assert.AreEqual(2,p.L.ColumnCount);
 				Assert.AreEqual(50,p.L.ColumnSize);
+				Assert.AreEqual(2, p.L.SourceLineNumber);
+				Assert.AreEqual("UX/ColumnLayout4.ux", p.L.SourceFileName);
 			}
 		}
 		
@@ -82,6 +90,8 @@ namespace Fuse.Controls.Test
 				Assert.AreEqual(float2(100,0), p.P2.ActualPosition);
 				Assert.AreEqual(float2(0,50), p.P3.ActualPosition);
 				Assert.AreEqual(float2(100,50), p.P4.ActualPosition);
+				Assert.AreEqual(2, p.L.SourceLineNumber);
+				Assert.AreEqual("UX/ColumnLayout5.ux", p.L.SourceFileName);
 			}
 		}
 		

--- a/Source/Fuse.Controls.Panels/Tests/UX/ColumnLayout1.ux
+++ b/Source/Fuse.Controls.Panels/Tests/UX/ColumnLayout1.ux
@@ -1,5 +1,5 @@
 <Panel ux:Class="UX.ColumnLayout1">
-	<ColumnLayout ColumnCount="2" ColumnSpacing="10" ItemSpacing="5"/>
+	<ColumnLayout ColumnCount="2" ColumnSpacing="10" ItemSpacing="5" ux:Name="L"/>
 	<Panel Height="50" ux:Name="P1"/>
 	<Panel Height="170" ux:Name="P2"/>
 	<Panel Height="60" ux:Name="P3"/>

--- a/Source/Fuse.Controls.Panels/Tests/UX/ColumnLayout2.ux
+++ b/Source/Fuse.Controls.Panels/Tests/UX/ColumnLayout2.ux
@@ -1,5 +1,5 @@
 <Panel ux:Class="UX.ColumnLayout2">
-	<ColumnLayout ColumnCount="4" Orientation="Horizontal"/>
+	<ColumnLayout ColumnCount="4" Orientation="Horizontal" ux:Name="L"/>
 	<Panel Width="100" ux:Name="P1"/>
 	<Panel Width="100" ux:Name="P2"/>
 	<Panel Width="100" ux:Name="P3"/>

--- a/Source/Fuse.Controls.Panels/Tests/UX/ColumnLayout3.ux
+++ b/Source/Fuse.Controls.Panels/Tests/UX/ColumnLayout3.ux
@@ -1,5 +1,5 @@
 <Panel ux:Class="UX.ColumnLayout3" Alignment="HorizontalCenter">
-	<ColumnLayout ColumnSize="100"/>
+	<ColumnLayout ColumnSize="100" ux:Name="L"/>
 	<Panel Height="50" ux:Name="P1"/>
 	<Panel Height="50" ux:Name="P2"/>
 	<Panel Height="50" ux:Name="P3"/>

--- a/Source/Fuse.Controls.Panels/Tests/UX/ColumnLayout5.ux
+++ b/Source/Fuse.Controls.Panels/Tests/UX/ColumnLayout5.ux
@@ -1,5 +1,5 @@
 <Panel ux:Class="UX.ColumnLayout5" Alignment="HorizontalCenter" MaxWidth="250">
-	<ColumnLayout ColumnSize="100"/>
+	<ColumnLayout ColumnSize="100" ux:Name="L"/>
 	<Panel Height="50" ux:Name="P1"/>
 	<Panel Height="50" ux:Name="P2"/>
 	<Panel Height="50" ux:Name="P3"/>

--- a/Source/Fuse.Nodes/Tests/UX/UxCompiler.NodeSource.ux
+++ b/Source/Fuse.Nodes/Tests/UX/UxCompiler.NodeSource.ux
@@ -1,0 +1,5 @@
+<Panel ux:Class="UX.UxCompiler.NodeSource">
+	<Panel ux:Name="P1" />
+	<Panel ux:Name="P2" />
+	<Panel ux:Name="P3" />
+</Panel>

--- a/Source/Fuse.Nodes/Tests/UxCompiler.Test.uno
+++ b/Source/Fuse.Nodes/Tests/UxCompiler.Test.uno
@@ -18,5 +18,23 @@ namespace Fuse.Test
 				Assert.AreEqual( "Hello", p.a.t.Value );
 			}
 		}
+
+		[Test]
+		// All Node types should have source information available, so let's make some nodes and double-check that this is set up correctly by the UX compiler
+		public void NodeSourceInfo()
+		{
+			var p = new UX.UxCompiler.NodeSource();
+			using (var r = TestRootPanel.CreateWithChild(p))
+			{
+				Assert.AreEqual(1, p.SourceLineNumber);
+				Assert.AreEqual("UX/UxCompiler.NodeSource.ux", p.SourceFileName);
+				Assert.AreEqual(2, p.P1.SourceLineNumber);
+				Assert.AreEqual("UX/UxCompiler.NodeSource.ux", p.P1.SourceFileName);
+				Assert.AreEqual(3, p.P2.SourceLineNumber);
+				Assert.AreEqual("UX/UxCompiler.NodeSource.ux", p.P2.SourceFileName);
+				Assert.AreEqual(4, p.P3.SourceLineNumber);
+				Assert.AreEqual("UX/UxCompiler.NodeSource.ux", p.P3.SourceFileName);
+			}
+		}
 	}
 }

--- a/Source/Fuse.Reactive.Expressions/Tests/ExpressionSources.Test.uno
+++ b/Source/Fuse.Reactive.Expressions/Tests/ExpressionSources.Test.uno
@@ -1,0 +1,47 @@
+using Uno;
+using Uno.UX;
+using Uno.Testing;
+
+using Fuse.Reactive;
+
+using FuseTest;
+
+namespace Fuse.Reactive.Test
+{
+	public class ExpressionSourcesTest : TestBase
+	{
+		[Test]
+		// Expressions are objects that are created by the UX compiler and not explicitly declared as UX objects, so we should double-check that
+		//  correct source information is generated for them.
+		public void ExpressionSources()
+		{
+			var p = new UX.ExpressionSources();
+			using (var root = TestRootPanel.CreateWithChild(p))
+			{
+				// Dig into expr object and make sure its sources are what we expect
+				var binding = (ExpressionBinding)p.V.Bindings[0];
+				var addExpr = (Add)binding.Key;
+				Assert.AreEqual(4, addExpr.SourceLineNumber);
+				Assert.AreEqual("UX/ExpressionSources.ux", addExpr.SourceFileName);
+				var lhsSin = (Sin)addExpr.Left;
+				Assert.AreEqual(4, lhsSin.SourceLineNumber);
+				Assert.AreEqual("UX/ExpressionSources.ux", lhsSin.SourceFileName);
+				var lhsProp = (Property)lhsSin.Operand;
+				Assert.AreEqual(4, lhsProp.SourceLineNumber);
+				Assert.AreEqual("UX/ExpressionSources.ux", lhsProp.SourceFileName);
+				var lhsConst = (Constant)lhsProp.Object;
+				Assert.AreEqual(4, lhsConst.SourceLineNumber);
+				Assert.AreEqual("UX/ExpressionSources.ux", lhsConst.SourceFileName);
+				var rhsCos = (Cos)addExpr.Right;
+				Assert.AreEqual(4, rhsCos.SourceLineNumber);
+				Assert.AreEqual("UX/ExpressionSources.ux", rhsCos.SourceFileName);
+				var rhsProp = (Property)rhsCos.Operand;
+				Assert.AreEqual(4, rhsProp.SourceLineNumber);
+				Assert.AreEqual("UX/ExpressionSources.ux", rhsProp.SourceFileName);
+				var rhsConst = (Constant)rhsProp.Object;
+				Assert.AreEqual(4, rhsConst.SourceLineNumber);
+				Assert.AreEqual("UX/ExpressionSources.ux", rhsConst.SourceFileName);
+			}
+		}
+	}
+}

--- a/Source/Fuse.Reactive.Expressions/Tests/UX/ExpressionSources.ux
+++ b/Source/Fuse.Reactive.Expressions/Tests/UX/ExpressionSources.ux
@@ -1,0 +1,5 @@
+<Panel ux:Class="UX.ExpressionSources">
+	<FuseTest.Value Integer="1" ux:Name="a"/>
+	<FuseTest.Value Float="0.5" ux:Name="b"/>
+	<FuseTest.Value Object="sin({Property a.Object}) + cos({Property b.Object})" ux:Name="V"/>
+</Panel>


### PR DESCRIPTION
Now that we'll get generated source information for several fuselibs objects for better error reporting after https://github.com/fusetools/uno/pull/1622 and https://github.com/fusetools/fuselibs-public/pull/1103, let's add some tests to make sure they're what we expect for these fuselibs objects specifically.

This PR contains:
- [ ] ~Changelog~
- [ ] ~Documentation~
- [x] Tests
