### PR TITLE
update issue-links to match repo rename

### DIFF
--- a/Source/Fuse.Android.TextRenderer/TextRenderer.uno
+++ b/Source/Fuse.Android.TextRenderer/TextRenderer.uno
@@ -328,7 +328,7 @@ namespace Fuse.Android
 			var position = (float2)_textLayout.PixelBounds.Position / _control.Viewport.PixelsPerPoint
 				+ dposition;
 			//align oversize correctly in container
-			//TODO: https://github.com/fusetools/fuselibs/issues/780
+			//TODO: https://github.com/fusetools/fuselibs-private/issues/780
 			//there is simply no point unless that issue is fixed
 			/*if (pointSize.X > size.X)
 			{

--- a/Source/Fuse.Animations/Player.uno
+++ b/Source/Fuse.Animations/Player.uno
@@ -59,7 +59,7 @@ namespace Fuse.Animations
 		{
 			Source = Current;
 			//If currently animating then the current frame must still be considerd for animation
-			//this is important for issues like  https://github.com/fusetools/fuselibs/issues/788
+			//this is important for issues like  https://github.com/fusetools/fuselibs-private/issues/788
 			//the time check is to avoid double stepping if animation already done this frame
 			if (isAnimating && _stepTime < Time.FrameTime)
 				SourceTime = Time.FrameTime - (Time.FrameInterval * _timeMultiplier);

--- a/Source/Fuse.Animations/RangeAdapter.uno
+++ b/Source/Fuse.Animations/RangeAdapter.uno
@@ -9,7 +9,7 @@ namespace Fuse.Animations
 	}
 
 	/*
-		TODO: https://github.com/fusetools/fuselibs/issues/1344
+		TODO: https://github.com/fusetools/fuselibs-private/issues/1344
 		This is really meant to have the `Value` as just a `double`, not a generic. In particular for
 		the Source/ValueRange properties.
 	*/

--- a/Source/Fuse.Controls.Navigation/Navigator.uno
+++ b/Source/Fuse.Controls.Navigation/Navigator.uno
@@ -217,7 +217,7 @@ namespace Fuse.Controls
 					routerPage.Context == curPage.RouterPage.Context)
 					return new PrepareResult{ Page = curPage, Routing = RoutingResult.NoChange };
 					
-				// https://github.com/fusetools/fuselibs/issues/2982
+				// https://github.com/fusetools/fuselibs-private/issues/2982
 				var compat = CommonNavigation.CompatibleParameter(routerPage.Parameter, curPage.RouterPage.Parameter) && routerPage.Context == curPage.RouterPage.Context;
 					
 				//reusable page with parameter change
@@ -251,7 +251,7 @@ namespace Fuse.Controls
 			}
 			
 			Visual useVisual = null;
-			if (routerPage.Path == null) //this is a valid path element  https://github.com/fusetools/fuselibs/issues/1869
+			if (routerPage.Path == null) //this is a valid path element  https://github.com/fusetools/fuselibs-private/issues/1869
 			{
 				useVisual = null;
 			}

--- a/Source/Fuse.Controls.Navigation/PageControl.uno
+++ b/Source/Fuse.Controls.Navigation/PageControl.uno
@@ -105,7 +105,7 @@ namespace Fuse.Controls
 		
 		public PageControl()
 		{
-			//https://github.com/fusetools/fuselibs/issues/1548
+			//https://github.com/fusetools/fuselibs-private/issues/1548
 			HitTestMode = HitTestMode.LocalBounds | HitTestMode.Children;
 			
 			//defaults for NavigationControl

--- a/Source/Fuse.Controls.Navigation/Tests/Navigator.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Navigator.Test.uno
@@ -218,7 +218,7 @@ namespace Fuse.Navigation.Test
 		}
 		
 		[Test]
-		//https://github.com/fusetools/fuselibs/issues/2982
+		//https://github.com/fusetools/fuselibs-private/issues/2982
 		public void EmptyParameter()
 		{
 			var p = new UX.Navigator.EmptyParameter();
@@ -321,7 +321,7 @@ namespace Fuse.Navigation.Test
 		}
 		
 		[Test]
-		// https://github.com/fusetools/fuselibs/issues/4256
+		// https://github.com/fusetools/fuselibs-private/issues/4256
 		public void RootingCache1()
 		{
 			var p =  new UX.Navigator.RootingCache();

--- a/Source/Fuse.Controls.Navigation/Tests/PageControl.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/PageControl.Test.uno
@@ -89,7 +89,7 @@ namespace Fuse.Controls.Test
 					(p as INavigation).PageProgress,
 					root.StepIncrement * speed / 1000 + ZeroTolerance);
 					
-				//trying to check jitter https://github.com/fusetools/fuselibs/issues/3597
+				//trying to check jitter https://github.com/fusetools/fuselibs-private/issues/3597
 				//the test doesn't produce "actual" jitter though, but it does detect the extra calls to progress changed
 				Assert.IsTrue(_absChangedSum < 0.25);
 				Assert.IsTrue(_progressCount < (250/*dist*/ / speed / root.StepIncrement + 1) );

--- a/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
+++ b/Source/Fuse.Controls.Navigation/Tests/Router.Test.uno
@@ -192,7 +192,7 @@ namespace Fuse.Navigation.Test
 		}
 		
 		[Test]
-		//https://github.com/fusetools/fuselibs/issues/3689
+		//https://github.com/fusetools/fuselibs-private/issues/3689
 		public void RelativeNonCurrent()
 		{
 			var p = new UX.Router.RelativeNonCurrent();

--- a/Source/Fuse.Controls.Navigation/Transition.uno
+++ b/Source/Fuse.Controls.Navigation/Transition.uno
@@ -499,7 +499,7 @@ namespace Fuse.Triggers
 			{
 				//TODO: like GoProgress should this also delay? mortoray: my branch is meant to address
 				//such lag, so possibly not
-				//ref: https://github.com/fusetools/fuselibs/issues/2652
+				//ref: https://github.com/fusetools/fuselibs-private/issues/2652
 				PlayTo(p, d);
 			}
 			else if (args.Mode == NavigationMode.Seek)

--- a/Source/Fuse.Controls.Panels/Tests/Grid.Test.uno
+++ b/Source/Fuse.Controls.Panels/Tests/Grid.Test.uno
@@ -535,7 +535,7 @@ namespace Fuse.Controls.Test
 		public void Issue2964()
 		{
 			var g = new Grid();
-			//https://github.com/fusetools/fuselibs/issues/2694
+			//https://github.com/fusetools/fuselibs-private/issues/2694
 			g.Rows = null;
 			g.Columns = null;
 		}
@@ -602,7 +602,7 @@ namespace Fuse.Controls.Test
 				Assert.AreEqual(1, diagnostics.Count);
 				Assert.Contains("incompatible", diagnostics[0].Message);
 				
-				//https://github.com/fusetools/fuselibs/issues/3286
+				//https://github.com/fusetools/fuselibs-private/issues/3286
 				//specifically set DefaultRow afterwards to trigger the defect
 				p.G1.DefaultRow = "auto";
 				root.StepFrame();

--- a/Source/Fuse.Controls.Panels/Tests/StackPanel.Test.uno
+++ b/Source/Fuse.Controls.Panels/Tests/StackPanel.Test.uno
@@ -221,7 +221,7 @@ namespace Fuse.Controls.Test
 		}
 		
 		[Test]
-		public void StackLayoutCompat() //https://github.com/fusetools/fuselibs/issues/1484
+		public void StackLayoutCompat() //https://github.com/fusetools/fuselibs-private/issues/1484
 		{
 			using (var root = new TestRootPanel())
 			{

--- a/Source/Fuse.Controls.Primitives/Shapes/Arc.uno
+++ b/Source/Fuse.Controls.Primitives/Shapes/Arc.uno
@@ -15,10 +15,10 @@ namespace Fuse.Controls
 	*/
 	public partial class Arc : EllipticalShape
 	{
-		//https://github.com/fusetools/fuselibs/issues/3877
+		//https://github.com/fusetools/fuselibs-private/issues/3877
 		/*protected override IView CreateNativeView()
 		{
-			//https://github.com/fusetools/fuselibs/issues/3877
+			//https://github.com/fusetools/fuselibs-private/issues/3877
 			if defined(Android)
 			{
 				return new Fuse.Controls.Native.Android.Ellipse();

--- a/Source/Fuse.Controls.Primitives/Shapes/Curve.uno
+++ b/Source/Fuse.Controls.Primitives/Shapes/Curve.uno
@@ -27,7 +27,7 @@ namespace Fuse.Controls
 
 	//TODO: This should not be a `Node` sinec it's too heavy of an object
 	//it only needs to be a `PropertyObject`, but until `Each` supports non-node types we need to use `Node`
-	//https://github.com/fusetools/fuselibs/issues/3676
+	//https://github.com/fusetools/fuselibs-private/issues/3676
 	/**
 		Defines a point inside a @Curve
 		

--- a/Source/Fuse.Controls.Primitives/Shapes/Path.uno
+++ b/Source/Fuse.Controls.Primitives/Shapes/Path.uno
@@ -185,7 +185,7 @@ namespace Fuse.Controls
 
 		//TODO: This defniitely needs to be cached if the path itself has not changed (it is called often enough
 		//to make a difference)
-		//https://github.com/fusetools/fuselibs/issues/3718
+		//https://github.com/fusetools/fuselibs-private/issues/3718
 		Rect CalcNaturalExtents()
 		{
 			return LineMetrics.GetBounds(_segments);

--- a/Source/Fuse.Controls.Primitives/TextControls/FallbackTextRenderer/TextRenderer.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/FallbackTextRenderer/TextRenderer.uno
@@ -139,7 +139,7 @@ namespace Fuse.Controls.FallbackTextRenderer
 				height += _wrapInfo.LineHeight;
 			}
 
-			//TODO: https://github.com/fusetools/fuselibs/issues/1386
+			//TODO: https://github.com/fusetools/fuselibs-private/issues/1386
 			_textBounds = new Rect(float2(minX,0),float2(maxX, height));
 			_maxTextLength = maxTextLength;
 		}

--- a/Source/Fuse.Controls.Primitives/TextControls/TextControl.GraphicsText.uno
+++ b/Source/Fuse.Controls.Primitives/TextControls/TextControl.GraphicsText.uno
@@ -102,7 +102,7 @@ namespace Fuse.Controls
 
 			if (_textRenderer != null)
 			{
-				//Refer https://github.com/fusetools/fuselibs/issues/1766
+				//Refer https://github.com/fusetools/fuselibs-private/issues/1766
 				//local visuals do not include padding
 				_textRenderer.Arrange(float2(0), lp.Size);
 			}

--- a/Source/Fuse.Controls.ScrollView/ScrollView.Layout.uno
+++ b/Source/Fuse.Controls.ScrollView/ScrollView.Layout.uno
@@ -81,7 +81,7 @@ namespace Fuse.Controls
 				var diff = newOffset - oldOffset;
 				//gestures need the "diff" to offset their scrolling interaction
 				//don't exceed min/max though as to not trigger any ends animation
-				//https://github.com/fusetools/fuselibs/issues/2891
+				//https://github.com/fusetools/fuselibs-private/issues/2891
 				//var nsp = Math.Min( MaxScroll, Math.Max( MinScroll, ScrollPosition + diff ) );
 				var nsp = ScrollPosition + diff;
 				var ndiff = nsp - ScrollPosition;

--- a/Source/Fuse.Controls.ScrollView/Scroller.uno
+++ b/Source/Fuse.Controls.ScrollView/Scroller.uno
@@ -61,7 +61,7 @@ namespace Fuse.Gestures
 				throw new Exception( "Scroller can only be used in a ScrollView" );
 
 			_scrollable.AddPropertyListener(this);
-			//Set in ugly fashion, required by https://github.com/fusetools/fuselibs/issues/870
+			//Set in ugly fashion, required by https://github.com/fusetools/fuselibs-private/issues/870
 			//previously the ScrollView would just listen for added children, but this appears safer
 			_scrollable._scroller = this; 
 			_scrollable.RequestBringIntoView += OnRequestBringIntoView;

--- a/Source/Fuse.Controls.ScrollView/Tests/ScrollView.Test.uno
+++ b/Source/Fuse.Controls.ScrollView/Tests/ScrollView.Test.uno
@@ -119,7 +119,7 @@ namespace Fuse.Controls.ScrollViewTest
 		[Test]
 		public void ScrollIssue1595()
 		{
-			//https://github.com/fusetools/fuselibs/issues/1595
+			//https://github.com/fusetools/fuselibs-private/issues/1595
 			var p = new UX.ScrollIssue1595();
 			using (var root = TestRootPanel.CreateWithChild(p, int2(200, 500)))
 			{
@@ -287,7 +287,7 @@ namespace Fuse.Controls.ScrollViewTest
 				sv.T.Children.Insert(0,sv.P1);
 				root.StepFrame(5);
 				//50 is as far as it should go to be in range, see:
-				//https://github.com/fusetools/fuselibs/issues/2891
+				//https://github.com/fusetools/fuselibs-private/issues/2891
 				//tolerance needed due to tolerance check in `ScrollView.SetScrolPositionImpl`
 				Assert.AreEqual( 50, sv.S.ScrollPosition.Y, 1e-3 );
 

--- a/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollViewAlignment.ux
+++ b/Source/Fuse.Controls.ScrollView/Tests/UX/ScrollViewAlignment.ux
@@ -1,5 +1,5 @@
 <Panel ux:Class="UX.ScrollViewAlignment">
-	<!-- Note not padding is tested yet: https://github.com/fusetools/fuselibs/issues/1765 -->
+	<!-- Note not padding is tested yet: https://github.com/fusetools/fuselibs-private/issues/1765 -->
 	<ScrollView ux:Name="SV1">
 		<StackContent Alignment="Bottom" ux:Name="C1"/>
 	</ScrollView>

--- a/Source/Fuse.Controls/Tests/Viewbox.Test.uno
+++ b/Source/Fuse.Controls/Tests/Viewbox.Test.uno
@@ -27,7 +27,7 @@ namespace Fuse.Controls.Test
 			}
 		}
 		
-		//https://github.com/fusetools/fuselibs/issues/1506
+		//https://github.com/fusetools/fuselibs-private/issues/1506
 		[Test]
 		public void ContentResize()
 		{

--- a/Source/Fuse.Drawing/Stroke.uno
+++ b/Source/Fuse.Drawing/Stroke.uno
@@ -20,7 +20,7 @@ namespace Fuse.Drawing
 
 	public class Stroke: PropertyObject, IPropertyListener
 	{
-		//https://github.com/fusetools/fuselibs/issues/3655
+		//https://github.com/fusetools/fuselibs-private/issues/3655
 		static Selector _shadingName = "Shading";
 		void IPropertyListener.OnPropertyChanged(PropertyObject obj, Selector prop)
 		{

--- a/Source/Fuse.Drawing/Tests/UX/Brush.Binding.ux
+++ b/Source/Fuse.Drawing/Tests/UX/Brush.Binding.ux
@@ -7,6 +7,6 @@
 	<Rectangle Fill="{a}" ux:Name="A"/>
 	<Rectangle Fill="{b}" ux:Name="B"/>
 	<!-- just ensures it doesn't crash horribly -->
-	<!-- TODO: https://github.com/fusetools/fuselibs/issues/3540 -->
+	<!-- TODO: https://github.com/fusetools/fuselibs-private/issues/3540 -->
 <!-- 	<Rectangle Fill="{g}" ux:Name="G"/> -->
 </Panel>

--- a/Source/Fuse.Elements/Element.Bounds.uno
+++ b/Source/Fuse.Elements/Element.Bounds.uno
@@ -64,7 +64,7 @@ namespace Fuse.Elements
 
 		//how much of a pixel must be covered by a virtual pixel/bound to be considered as covering that pixel
 		//otherwise Floor/Ceil could round incorrectly on near exact values due to precision
-		//refer to: https://github.com/fusetools/fuselibs/issues/735
+		//refer to: https://github.com/fusetools/fuselibs-private/issues/735
 		const float pixelEpsilon = 0.005f;
 		
 		internal Recti GetViewportInvertPixelRect(DrawContext dc, Rect localRegion)

--- a/Source/Fuse.Elements/Tests/AspectSizing.Test.uno
+++ b/Source/Fuse.Elements/Tests/AspectSizing.Test.uno
@@ -60,7 +60,7 @@ namespace Fuse.Elements.Test
 		[Test]
 		public void DockMargin()
 		{
-			//https://github.com/fusetools/fuselibs/issues/1473
+			//https://github.com/fusetools/fuselibs-private/issues/1473
 			var p = new global::UX.DockAspect();
 			using (var root = new TestRootPanel())
 			{

--- a/Source/Fuse.Elements/Tests/ImageFill.Test.uno
+++ b/Source/Fuse.Elements/Tests/ImageFill.Test.uno
@@ -40,7 +40,7 @@ namespace Fuse.Elements.Test
 		
 		[Test]
 		//tests a variation that changes the resource, this caused the leak in 
-		//https://github.com/fusetools/fuselibs/issues/3502
+		//https://github.com/fusetools/fuselibs-private/issues/3502
 		public void ResourceReplace()
 		{
 			var p = new global::UX.ImageFill.ResourceReplace();
@@ -92,7 +92,7 @@ namespace Fuse.Elements.Test
 		}
 		
 		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs/issues/3511")]
+		[Ignore("https://github.com/fusetools/fuselibs-private/issues/3511")]
 		public void Calibrate()
 		{
 			var p = new global::UX.ImageFill.Calibrate();
@@ -139,7 +139,7 @@ namespace Fuse.Elements.Test
 		
 		[Test]
 		//Loading is immediately set, not waiting until first draw
-		//https://github.com/fusetools/fuselibs/issues/3514
+		//https://github.com/fusetools/fuselibs-private/issues/3514
 		public void Loading()
 		{
 			var p = new global::UX.ImageFill.Loading();

--- a/Source/Fuse.Elements/Tests/LayoutFunctions.Test.uno
+++ b/Source/Fuse.Elements/Tests/LayoutFunctions.Test.uno
@@ -9,7 +9,7 @@ namespace Fuse.Elements.Test
 	public class LayoutFunctionsTest : TestBase
 	{
 		[Test]
-		//https://github.com/fusetools/fuselibs/issues/4189
+		//https://github.com/fusetools/fuselibs-private/issues/4189
 		public void Issue4189()
 		{
 			var p = new global::UX.LayoutFunctions.Issue4189();

--- a/Source/Fuse.Gestures/Tests/Swipe.Test.uno
+++ b/Source/Fuse.Gestures/Tests/Swipe.Test.uno
@@ -49,7 +49,7 @@ namespace Fuse.Gestures.Test
 				Assert.AreEqual(1, p.SwipeInactive.PerformedCount);
 				
 				//swipe to full and release 
-				//https://github.com/fusetools/fuselibs/issues/1655
+				//https://github.com/fusetools/fuselibs-private/issues/1655
 				root.PointerSwipe( float2(500,200), float2(200,200), 500 );
 				//shouldn't need to stabilize
 				

--- a/Source/Fuse.Navigation/NavigationAnimations.uno
+++ b/Source/Fuse.Navigation/NavigationAnimations.uno
@@ -92,12 +92,12 @@ namespace Fuse.Navigation
 		double _delayProgress;
 		internal void GoProgress(double p, AnimationVariant variant, NavigationArgs state)
 		{
-			//https://github.com/fusetools/fuselibs/issues/1622
+			//https://github.com/fusetools/fuselibs-private/issues/1622
 			//do not optimize a check of if (p == Progress) return;
 
 			if (state.Mode == NavigationMode.Switch)
 			{
-				//a fix of https://github.com/fusetools/fuselibs/issues/2652
+				//a fix of https://github.com/fusetools/fuselibs-private/issues/2652
 				//PlayTo(p, variant);
 				_delayVariant = variant;
 				_delayProgress = p;

--- a/Source/Fuse.Navigation/NavigationPageProxy.uno
+++ b/Source/Fuse.Navigation/NavigationPageProxy.uno
@@ -55,7 +55,7 @@ namespace Fuse.Navigation
 			}
 
 			//defer setup until watched node is rooted
-			//https://github.com/fusetools/fuselibs/issues/1879
+			//https://github.com/fusetools/fuselibs-private/issues/1879
 			if (!Page.IsRootingStarted)
 			{
 				Page.RootingCompleted += OnPageRootingCompleted;

--- a/Source/Fuse.Navigation/StructuredNavigation.uno
+++ b/Source/Fuse.Navigation/StructuredNavigation.uno
@@ -51,11 +51,11 @@ namespace Fuse.Navigation
 		{
 			base.OnRooted();
 			//there's no real way to fix this "correctly" due to how HierarchicalNavigation works
-			//https://github.com/fusetools/fuselibs/issues/1701
+			//https://github.com/fusetools/fuselibs-private/issues/1701
 			if (_active != null && _active.Parent != null && Parent != _active.Parent)
 				SetActive(null);
 
-			// https://github.com/fusetools/fuselibs/issues/3427
+			// https://github.com/fusetools/fuselibs-private/issues/3427
 			if (_active != null && !Parent.Children.Contains(_active))
 				SetActive(null);
 				
@@ -111,7 +111,7 @@ namespace Fuse.Navigation
 
 		public void GotoImpl(Visual element, NavigationGotoMode mode)
 		{
-			//https://github.com/fusetools/fuselibs/issues/1701
+			//https://github.com/fusetools/fuselibs-private/issues/1701
 			if (element.Parent != null && element.Parent != Parent)
 			{
 				Fuse.Diagnostics.UserError( "Attempting to navigate to element with different parent", element );

--- a/Source/Fuse.Navigation/SwipeNavigate.uno
+++ b/Source/Fuse.Navigation/SwipeNavigate.uno
@@ -236,7 +236,7 @@ namespace Fuse.Navigation
 		bool _startedSeek;
 		void IGesture.OnCaptureChanged(PointerEventArgs args, CaptureType how, CaptureType prev)
 		{
-			//always reset coords to avoid jump (https://github.com/fusetools/fuselibs/issues/1175)
+			//always reset coords to avoid jump (https://github.com/fusetools/fuselibs-private/issues/1175)
 			_startCoord = _currentCoord = args.WindowPoint;
 			_prevDistance = 0;
 			_startTime = Time.FrameTime;

--- a/Source/Fuse.Navigation/Tests/Navigation.Test.uno
+++ b/Source/Fuse.Navigation/Tests/Navigation.Test.uno
@@ -115,7 +115,7 @@ namespace Fuse.Navigation.Test
 		
 		[Test]
 		/*
-			https://github.com/fusetools/fuselibs/issues/1804
+			https://github.com/fusetools/fuselibs-private/issues/1804
 			Ensure changed messages aren't published needlessly
 		*/
 		public void Stability()
@@ -282,7 +282,7 @@ namespace Fuse.Navigation.Test
 		}
 		
 		[Test]
-		//https://github.com/fusetools/fuselibs/issues/3761
+		//https://github.com/fusetools/fuselibs-private/issues/3761
 		public void RootScale()
 		{
 			var p = new UX.Navigation.Scale();

--- a/Source/Fuse.Nodes/Node.Rooting.uno
+++ b/Source/Fuse.Nodes/Node.Rooting.uno
@@ -99,7 +99,7 @@ namespace Fuse
 			
 		void RootInternalImpl(Visual parent)
 		{
-			//to help detect errors like https://github.com/fusetools/fuselibs/issues/2244
+			//to help detect errors like https://github.com/fusetools/fuselibs-private/issues/2244
 			if (_rootStage != RootStage.Unrooted)
 				throw new Exception( "Incomplete or duplicate rooting: " + this + "/" + Name );
 
@@ -126,7 +126,7 @@ namespace Fuse
 			if (RootingCompleted != null)
 				RootingCompleted();
 
-			//to help detect errors like https://github.com/fusetools/fuselibs/issues/2244
+			//to help detect errors like https://github.com/fusetools/fuselibs-private/issues/2244
 			if (_rootStage != RootStage.Completed)
 				throw new Exception( "Invalid RootStage post rooting: " + this + "/" + Name );
 		}

--- a/Source/Fuse.Nodes/RootViewport.uno
+++ b/Source/Fuse.Nodes/RootViewport.uno
@@ -181,7 +181,7 @@ namespace Fuse
 			var pixelSize = (float2)Application.Current.GraphicsController.Backbuffer.Size;
 
 			//workaround for empty size on some platforms while minimized
-			//https://github.com/fusetools/fuselibs/issues/1772
+			//https://github.com/fusetools/fuselibs-private/issues/1772
 			if (osPointSize.X < 1 || osPointSize.Y < 1)
 			{
 				_pixelSize = float2(0);

--- a/Source/Fuse.Nodes/Tests/Keyboard.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Keyboard.Test.uno
@@ -18,7 +18,7 @@ namespace Fuse.Test
 			using (var trp = new TestRootSingletonsGuard(root))
 			{
 				//should not crash
-				//https://github.com/fusetools/fuselibs/issues/2948
+				//https://github.com/fusetools/fuselibs-private/issues/2948
 				Keyboard.RaiseKeyPressed(Uno.Platform.Key.Left, false, false, false, false);
 				Assert.AreEqual(root.RootViewport, keyGlobal.LastKeyPressedArgs.Visual);
 				Assert.AreEqual(null, keyB.LastKeyPressedArgs);

--- a/Source/Fuse.Nodes/Tests/Rooting.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Rooting.Test.uno
@@ -39,7 +39,7 @@ namespace Fuse.Test
 		}
 
 		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs/issues/2244")]
+		[Ignore("https://github.com/fusetools/fuselibs-private/issues/2244")]
 		public void UnrootDuringRoot()
 		{
 			var p = new UX.UnrootDuringRoot();

--- a/Source/Fuse.Nodes/Tests/UX/TranslationRelative.ux
+++ b/Source/Fuse.Nodes/Tests/UX/TranslationRelative.ux
@@ -5,7 +5,7 @@
 		</Panel>
 	</Panel>
 	
-	<!-- forward references, https://github.com/fusetools/fuselibs/issues/1881 -->
+	<!-- forward references, https://github.com/fusetools/fuselibs-private/issues/1881 -->
 	<Panel ux:Name="P4">
 		<Translation Vector="1" RelativeTo="Size" RelativeNode="P2"/>
 	</Panel>

--- a/Source/Fuse.Nodes/Tests/Visual.Test.uno
+++ b/Source/Fuse.Nodes/Tests/Visual.Test.uno
@@ -86,7 +86,7 @@ namespace Fuse.Test
 		
 		[Test]
 		/*
-			Tests an invalidation issue https://github.com/fusetools/fuselibs/issues/2318
+			Tests an invalidation issue https://github.com/fusetools/fuselibs-private/issues/2318
 		*/
 		public void HitTestBounds2318()
 		{

--- a/Source/Fuse.Nodes/Visual.BeginRemove.uno
+++ b/Source/Fuse.Nodes/Visual.BeginRemove.uno
@@ -74,7 +74,7 @@ namespace Fuse
 				return;
 				
 			//refer to the issue, this needs to be fixed better
-			//https://github.com/fusetools/fuselibs/issues/1966
+			//https://github.com/fusetools/fuselibs-private/issues/1966
 			if (child.HasBit(FastProperty1.PendingRemove))
 				return;
 			

--- a/Source/Fuse.Reactive.Bindings/EventRecord.uno
+++ b/Source/Fuse.Reactive.Bindings/EventRecord.uno
@@ -16,7 +16,7 @@ namespace Fuse.Reactive
 		internal EventRecord(IScriptEvent args, object sender)
 		{
 			//data must be captured node since the node could be unrooted/changed prior to `Call`
-			//https://github.com/fusetools/fuselibs/issues/1995
+			//https://github.com/fusetools/fuselibs-private/issues/1995
 			_node = sender as Node;
 
 			if (_node != null)

--- a/Source/Fuse.Reactive.Bindings/Instantiator.uno
+++ b/Source/Fuse.Reactive.Bindings/Instantiator.uno
@@ -523,7 +523,7 @@ namespace Fuse.Reactive
 			WindowItem v;
 			if (_dataMap.TryGetValue(n, out v))
 			{
-				//https://github.com/fusetools/fuselibs/issues/3312
+				//https://github.com/fusetools/fuselibs-private/issues/3312
 				//`Count` does not introduce data items
 				if (v.Data is NoContextItem)
 					return ContextDataResult.Continue;

--- a/Source/Fuse.Reactive.Bindings/InstantiatorFunction.uno
+++ b/Source/Fuse.Reactive.Bindings/InstantiatorFunction.uno
@@ -6,7 +6,7 @@ using Fuse.Reactive;
 namespace Fuse.Reactive
 {
 	/* The use of VarArg is a workaround to 
-	https://github.com/fusetools/fuselibs/issues/4199 */
+	https://github.com/fusetools/fuselibs-private/issues/4199 */
 	
 	/** Common base for functions that work with an item in an instantiator */
 	public abstract class InstantiatorFunction : VarArgFunction

--- a/Source/Fuse.Reactive.Bindings/Tests/Each.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/Each.Test.uno
@@ -168,7 +168,7 @@ namespace Fuse.Reactive.Test
 		}
 		
 		[Test]
-		//variation on https://github.com/fusetools/fuselibs/issues/2802
+		//variation on https://github.com/fusetools/fuselibs-private/issues/2802
 		public void EachEach()
 		{
 			var e = new UX.Each.Each();
@@ -526,7 +526,7 @@ namespace Fuse.Reactive.Test
 		
 		[Test]
 		//there's no way to test this feature yet
-		[Ignore("https://github.com/fusetools/fuselibs/issues/4199")]
+		[Ignore("https://github.com/fusetools/fuselibs-private/issues/4199")]
 		public void FunctionDefault()
 		{
 			var e = new UX.Each.Function.Default();

--- a/Source/Fuse.Reactive.Bindings/Tests/Expression.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/Expression.Test.uno
@@ -42,7 +42,7 @@ namespace Fuse.Reactive.Bindings.Test
 		}
 		
 		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs/issues/3806")]
+		[Ignore("https://github.com/fusetools/fuselibs-private/issues/3806")]
 		public void Anchor()
 		{
 			var p = new UX.Expression.Anchor();

--- a/Source/Fuse.Reactive.Bindings/Tests/MatchCase.Test.uno
+++ b/Source/Fuse.Reactive.Bindings/Tests/MatchCase.Test.uno
@@ -66,7 +66,7 @@ namespace Fuse.Reactive.Test
 		}
 		
 		[Test]
-		/** https://github.com/fusetools/fuselibs/issues/2802 */
+		/** https://github.com/fusetools/fuselibs-private/issues/2802 */
 		public void MatchEachOrder()
 		{
 			var e = new UX.MatchEachOrder();

--- a/Source/Fuse.Scripting.JavaScript/FuseJS/Observable.js
+++ b/Source/Fuse.Scripting.JavaScript/FuseJS/Observable.js
@@ -413,7 +413,7 @@ Observable.prototype.onValueChanged = function(module, callback) {
 	}
 	
 	var subscriber = function(obs, cmd, origin, value) { 
-		//for simplicity just update the value always, see https://github.com/fusetools/fuselibs/issues/3556
+		//for simplicity just update the value always, see https://github.com/fusetools/fuselibs-private/issues/3556
 		callback(obs.value);
 	};
 	

--- a/Source/Fuse.Scripting.JavaScript/Tests/DataBindingTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/DataBindingTest.uno
@@ -13,7 +13,7 @@ namespace Fuse.Reactive.Test
 		public void BehaviorDataContext()
 		{
 			// Tests that nodes get correct data context even if injected elsewhere in the tree
-			// ref https://github.com/fusetools/fuselibs/issues/3211
+			// ref https://github.com/fusetools/fuselibs-private/issues/3211
 
 			var e = new UX.DataBinding.BehaviorDataContext();
 			using (var root = TestRootPanel.CreateWithChild(e))
@@ -127,7 +127,7 @@ namespace Fuse.Reactive.Test
 				Assert.AreEqual( p.A, p.Bind.Visual );
 				Assert.AreEqual( p.B, p.Bind.Trigger );
 				
-				//https://github.com/fusetools/fuselibs/issues/3538
+				//https://github.com/fusetools/fuselibs-private/issues/3538
 				//Assert.AreEqual( p.C, p.SBind.Node );
 				Assert.AreEqual( p.B, p.SBind.Trigger );
 			}

--- a/Source/Fuse.Scripting.JavaScript/Tests/JsErrorTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/JsErrorTest.uno
@@ -70,7 +70,7 @@ namespace Fuse.Reactive.Test
 		}
 		
 		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs/issues/2855")]
+		[Ignore("https://github.com/fusetools/fuselibs-private/issues/2855")]
 		/* Tests a particularly tricky place for an exception in JavaScript. */
 		public void OnValueChanged()
 		{

--- a/Source/Fuse.Scripting.JavaScript/Tests/ObservableTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/ObservableTest.uno
@@ -100,7 +100,7 @@ namespace Fuse.Reactive.Test
 		}
 		
 		[Test]
-		//catches https://github.com/fusetools/fuselibs/issues/3371
+		//catches https://github.com/fusetools/fuselibs-private/issues/3371
 		public void RefreshAll()
 		{
 			var p = new UX.Observable.RefreshAll();
@@ -1081,7 +1081,7 @@ namespace Fuse.Reactive.Test
 		}
 		
 		[Test]
-		//tests the originally reported problem in https://github.com/fusetools/fuselibs/issues/3695
+		//tests the originally reported problem in https://github.com/fusetools/fuselibs-private/issues/3695
 		public void Parameter()
 		{
 			var p = new UX.Observable.Parameter();

--- a/Source/Fuse.Scripting.JavaScript/Tests/UX/Observable.InnerDetach.ux
+++ b/Source/Fuse.Scripting.JavaScript/Tests/UX/Observable.InnerDetach.ux
@@ -1,5 +1,5 @@
 <Panel ux:Class="UX.Observable.InnerDetach">
-	<!-- This is the actual issue reported in https://github.com/fusetools/fuselibs/issues/3703 -->
+	<!-- This is the actual issue reported in https://github.com/fusetools/fuselibs-private/issues/3703 -->
 	<Panel>
 		<JavaScript>
 			var Observable = require('FuseJS/Observable');

--- a/Source/Fuse.Scripting.JavaScript/Tests/UXExpressionsTest.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/UXExpressionsTest.uno
@@ -219,7 +219,7 @@ namespace Fuse.Reactive.Test
 		}
 
 		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs/issues/3854")]
+		[Ignore("https://github.com/fusetools/fuselibs-private/issues/3854")]
 		public void DelayFunction()
 		{
 			var e = new UX.Expressions();

--- a/Source/Fuse.Scripting.JavaScript/Tests/Various.Test.uno
+++ b/Source/Fuse.Scripting.JavaScript/Tests/Various.Test.uno
@@ -348,7 +348,7 @@ namespace Fuse.Reactive.Test
 		}
 
 		[Test]
-		/* Tests https://github.com/fusetools/fuselibs/issues/2398 */
+		/* Tests https://github.com/fusetools/fuselibs-private/issues/2398 */
 		public void Issue2398()
 		{
 			var e = new UX.Issue2398();
@@ -468,7 +468,7 @@ namespace Fuse.Reactive.Test
 		}
 
 		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs/issues/2809")]
+		[Ignore("https://github.com/fusetools/fuselibs-private/issues/2809")]
 		public void PumpMessagesStackOverflow()
 		{
 			var e = new UX.PumpMessagesStackOverflow();

--- a/Source/Fuse.Selection/Tests/Selection.Test.uno
+++ b/Source/Fuse.Selection/Tests/Selection.Test.uno
@@ -276,7 +276,7 @@ namespace Fuse.Gestures.Test
 				var three = root.FindNodeByName("three") as Visual;
 				Assert.IsFalse(three == null);
 				
-				//https://github.com/fusetools/fuselibs/issues/3385
+				//https://github.com/fusetools/fuselibs-private/issues/3385
 				//this has been switch to a 0-duration animator for now
 				Assert.AreEqual(1,TriggerProgress(two.FirstChild<WhileSelected>()));
 				Assert.AreEqual(0,TriggerProgress(one.FirstChild<WhileSelected>()));

--- a/Source/Fuse.Triggers/AddingAnimation.uno
+++ b/Source/Fuse.Triggers/AddingAnimation.uno
@@ -53,7 +53,7 @@ namespace Fuse.Triggers
 		protected override void OnRooted()
 		{
 			base.OnRooted();
-			//https://github.com/fusetools/fuselibs/issues/1697
+			//https://github.com/fusetools/fuselibs-private/issues/1697
 			//delay a frame to avoid first frame delay stutter
 			BypassActivate();
 			if (DelayFrame)

--- a/Source/Fuse.Triggers/Tests/Busy.Test.uno
+++ b/Source/Fuse.Triggers/Tests/Busy.Test.uno
@@ -409,7 +409,7 @@ namespace Fuse.Triggers.Test
 		}
 		
 		[Test]
-		//minimal test for https://github.com/fusetools/fuselibs/issues/3532
+		//minimal test for https://github.com/fusetools/fuselibs-private/issues/3532
 		public void Removed()
 		{
 			var p = new UX.Busy.Removed();

--- a/Source/Fuse.Triggers/Tests/Deferred.Test.uno
+++ b/Source/Fuse.Triggers/Tests/Deferred.Test.uno
@@ -65,7 +65,7 @@ namespace Fuse.Test
 		}
 		
 		[Test]
-		//https://github.com/fusetools/fuselibs/issues/2806
+		//https://github.com/fusetools/fuselibs-private/issues/2806
 		public void Unroot()
 		{
 			var p = new UX.DeferredUnroot();

--- a/Source/Fuse.Triggers/Tests/MouseBased.Test.uno
+++ b/Source/Fuse.Triggers/Tests/MouseBased.Test.uno
@@ -59,7 +59,7 @@ namespace Fuse.Triggers.Test
 		}
 
 		[Test]
-		[Ignore("https://github.com/fusetools/fuselibs/issues/1751")]
+		[Ignore("https://github.com/fusetools/fuselibs-private/issues/1751")]
 		public void Tapped()
 		{
 			using (var root = CreateRoot())

--- a/Source/Fuse.Triggers/Tests/StateGroup.Test.uno
+++ b/Source/Fuse.Triggers/Tests/StateGroup.Test.uno
@@ -56,7 +56,7 @@ namespace Fuse.Triggers.Test
 		}
 		
 		[Test]
-		//a timing issue found in https://github.com/fusetools/fuselibs/issues/3489
+		//a timing issue found in https://github.com/fusetools/fuselibs-private/issues/3489
 		public void EmptyTiming()
 		{
 			var p = new UX.StateGroup.EmptyTiming();

--- a/Source/Fuse.Triggers/Tests/Trigger.Test.uno
+++ b/Source/Fuse.Triggers/Tests/Trigger.Test.uno
@@ -221,7 +221,7 @@ namespace Fuse.Triggers.Test
 				//the pulse turnaround could take 1 frame, it's uncertain if this an issue (the 2* is because
 				//or stepping may not line up precisely, thus 1-frame delayed as well)
 				//NOTE: This is probably an issue, since a pulse trigger takes longer than expected
-				//https://github.com/fusetools/fuselibs/issues/2005
+				//https://github.com/fusetools/fuselibs-private/issues/2005
 				var tolerance = 2*root.StepIncrement + _zeroTolerance;
 				Assert.AreEqual(0.5f,TriggerProgress(p.T1), tolerance);
 				Assert.AreEqual(0.5f,TriggerProgress(p.T2), tolerance);
@@ -461,7 +461,7 @@ namespace Fuse.Triggers.Test
 		[Test]
 		/**
 			Tests situations where an action has a delay beyond the end of the natural duration.
-			https://github.com/fusetools/fuselibs/issues/2472
+			https://github.com/fusetools/fuselibs-private/issues/2472
 			
 			The test here works with the actual playback, not just checking the duration, to ensure it matches the logical expectation, not the implementation detail.
 		*/

--- a/Tests/ManualTests/ManualTestingApp/Singles/HierarchicalNavigationPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/HierarchicalNavigationPage.ux
@@ -32,8 +32,8 @@
 				</WhileCanGoForward>
 			</StdButton>
 		</WrapPanel>
-		<!-- TODO: https://github.com/fusetools/fuselibs/issues/1203 -->
-		<!-- TODO: https://github.com/fusetools/fuselibs/issues/1204 -->
+		<!-- TODO: https://github.com/fusetools/fuselibs-private/issues/1203 -->
+		<!-- TODO: https://github.com/fusetools/fuselibs-private/issues/1204 -->
 		<PageIndicator Dock="Top" Navigation="Navi" Margin="0,3,0,6">
 			<StackPanel ux:Template="Dot" Orientation="Horizontal">
 				<Panel Margin="5,0,0,0">

--- a/Tests/ManualTests/ManualTestingApp/Singles/TextInputPage.ux
+++ b/Tests/ManualTests/ManualTestingApp/Singles/TextInputPage.ux
@@ -28,7 +28,7 @@
 			<h2 ColumnSpan="2">Single Line</h2>
 			<Indicator ux:Name="IndSingle"/>
 			<StdTextInput ux:Name="SingleInput" Value="Scroll page up/down while editing">
-			<!-- TODO:https://github.com/fusetools/fuselibs/issues/1465
+			<!-- TODO:https://github.com/fusetools/fuselibs-private/issues/1465
 				TextAlignment="Center" -->
 				<WhileFocusWithin><Change IndSingle.Value="true"/></WhileFocusWithin>
 			</StdTextInput>
@@ -37,7 +37,7 @@
 			<Indicator ux:Name="IndPassword"/>
 			<StdTextInput ux:Name="PasswordInput" IsPassword="true" PlaceholderText="Password"
 				Background="#FFc">
-				<!-- TODO: https://github.com/fusetools/fuselibs/issues/1387
+				<!-- TODO: https://github.com/fusetools/fuselibs-private/issues/1387
 					Alignment="Right" -->
 				<WhileFocusWithin><Change IndPassword.Value="true"/></WhileFocusWithin>
 			</StdTextInput>


### PR DESCRIPTION
The old `fuselibs`-project on GitHub has been renamed to
`fuselibs-private` a while back, and while the links will redirect, it's
nicer to have non-redirecting links.

So let's update these to the new name.
