### PR TITLE
travis: update osx image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 os: osx
 
+osx_image: xcode9.2
+
 language: cpp
 
 compiler: clang


### PR DESCRIPTION
It seems that the default OSX image on travis is having some security
issues, causing builds to fail. So let's try to upgrade the OSX image to
the latest non-beta one, so builds will hopefully work again.