### PR TITLE
Fix crash when user click on blue userLocation

### DIFF
--- a/CHANGELOG/mapview_curloc_crash.md
+++ b/CHANGELOG/mapview_curloc_crash.md
@@ -1,0 +1,2 @@
+## MapView
+- Fixed a crash when tapping the user's current location on iOS.

--- a/Source/Fuse.Maps/iOS/MapViewDelegate.m
+++ b/Source/Fuse.Maps/iOS/MapViewDelegate.m
@@ -170,9 +170,12 @@
 
 	-(void)mapView:(MKMapView *)mapView didSelectAnnotationView:(MKAnnotationView *)view
 	{
-		if(markerSelectBlock){
-			FusePinAnnotation* a = [view annotation];
-			markerSelectBlock(a.markerID, a.title);
+		id annotation = view.annotation;
+        	if (![annotation isKindOfClass:[MKUserLocation class]]) {
+			if(markerSelectBlock){
+				FusePinAnnotation* a = [view annotation];
+				markerSelectBlock(a.markerID, a.title);
+			}
 		}
 	}
 
@@ -285,6 +288,9 @@
 	}
 	-(MKAnnotationView *)mapView:(MKMapView *)theMapView viewForAnnotation:(id <MKAnnotation>)annotation
 	{
+		if ([annotation isKindOfClass:[MKUserLocation class]])
+            		return nil;  //return nil to use default blue dot view
+        
 		static NSString *SFAnnotationIdentifier = @"SFAnnotationIdentifier";
 		NSString* identifier = SFAnnotationIdentifier;
 		


### PR DESCRIPTION
MKUserLocation blue userLocation MKAnnotation causes app to crash if inadvertently touched.
This modifications fixe this issue by testing the kind of clicked marker.
