### PR TITLE
Fuse.Launcher: do not use deprecated APIs

### DIFF
--- a/Source/Fuse.Launcher.Email/Email/EmailLauncher.uno
+++ b/Source/Fuse.Launcher.Email/Email/EmailLauncher.uno
@@ -46,14 +46,14 @@ namespace Fuse.LauncherImpl
 			{
 				builder.Append("&");
 				builder.Append("subject=");
-				builder.Append(Uri.Encode(subject));
+				builder.Append(Uri.EscapeDataString(subject));
 			}
 
 			if(!String.IsNullOrEmpty(message))
 			{
 				builder.Append("&");
 				builder.Append("body=");
-				builder.Append(Uri.Encode(message));
+				builder.Append(Uri.EscapeDataString(message));
 			}
 			//mailto:foo@example.com?cc=bar@example.com&subject=Greetings%20from%20Cupertino!&body=Wish%20you%20were%20here!
 

--- a/Source/Fuse.Launcher.Maps/Maps/MapsLauncher.uno
+++ b/Source/Fuse.Launcher.Maps/Maps/MapsLauncher.uno
@@ -35,7 +35,7 @@ namespace Fuse.LauncherImpl
 
 		public static void LaunchMaps(string query)
 		{
-			query = Uri.Encode(query);
+			query = Uri.EscapeDataString(query);
 			if defined(Android)
 				LaunchMapsAndroid("geo:0,0?q=" + query);
 			else if defined(iOS)
@@ -47,7 +47,7 @@ namespace Fuse.LauncherImpl
 			if defined(Android || iOS)
 			{
 				var latlon = latitude.ToString() + "," + longitude.ToString();
-				query = Uri.Encode(query);
+				query = Uri.EscapeDataString(query);
 
 				if defined(Android)
 					LaunchMapsAndroid("geo:" + latlon + "?q=" + query);

--- a/Source/Fuse.Launcher.Phone/Phone/PhoneUriHelper.uno
+++ b/Source/Fuse.Launcher.Phone/Phone/PhoneUriHelper.uno
@@ -9,7 +9,7 @@ namespace Fuse
 		{
 			var builder = new StringBuilder();
 			builder.Append("tel:");
-			builder.Append(Uri.Encode(phoneNumber));
+			builder.Append(Uri.EscapeDataString(phoneNumber));
 			return builder.ToString();
 		}
 	}


### PR DESCRIPTION
`Uri.Encode(string)` is obsolete in favor of `Uri.EscapeDataString(string)`, so let's update this code also.

This gets rid of a few warnings.