### PR TITLE
Deprecate uno-http-test.azurewebsites.net

### DIFF
--- a/Tests/AutomaticTestApp/App/Parts/HttpJson.ux
+++ b/Tests/AutomaticTestApp/App/Parts/HttpJson.ux
@@ -3,7 +3,7 @@
     <JavaScript>
         var fw = require('/framework.js');
         fw.testStarted("HttpJson");
-        fetch('http://uno-http-test.azurewebsites.net/cors/json').then(function(result) {
+        fetch('http://s3-eu-west-1.amazonaws.com/fuselibs-testing/test-data.json').then(function(result) {
             result.json().then(function(parsed) {
                 fw.assertEqual(parsed.breakfast_menu.food[0].name, "Belgian Waffles");
                 router.goto("webSocket");

--- a/Tests/ManualTests/ManualTestingApp/HttpXml/HttpXmlView.ux.uno
+++ b/Tests/ManualTests/ManualTestingApp/HttpXml/HttpXmlView.ux.uno
@@ -9,7 +9,7 @@ using Uno.Net.Http;
 
 public partial class HttpXmlView 
 {
-    private const string _xmlExampleUrl = "http://uno-http-test.azurewebsites.net/cors/xml";
+    private const string _xmlExampleUrl = "http://s3-eu-west-1.amazonaws.com/fuselibs-testing/test-data.xml";
 
 	void OnActive(object sender, object args)
 	{

--- a/Tests/ManualTests/ManualTestingApp/Https/HttpsView.ux.uno
+++ b/Tests/ManualTests/ManualTestingApp/Https/HttpsView.ux.uno
@@ -9,7 +9,7 @@ using Uno.Net.Http;
 
 public partial class HttpsView 
 {
-    private const string _xmlExampleUrl = "https://uno-http-testing.azurewebsites.net/";
+    private const string _xmlExampleUrl = "https://s3-eu-west-1.amazonaws.com/fuselibs-testing/test-data.html";
 
     public HttpsView()
     {


### PR DESCRIPTION
The uno-http-test.azurewebsites.net app is part of some very old Azure legacy infrastructure that we'd like to decomission as soon as possible. ManualTestApp and AutomaticTestApp were depending on this app simply to download some documents to assert JSON/XML parsing and some HTTP/HTTPS functionality.

I've uploaded the documents to an S3-bucket and changed the URLs accordingly.

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
