### PR TITLE
Fuse.Drawing.Surface: avoid out-of-memory exception

### DIFF
--- a/Source/Fuse.Drawing.Surface/DotNetSurface.uno
+++ b/Source/Fuse.Drawing.Surface/DotNetSurface.uno
@@ -797,6 +797,9 @@ namespace Fuse.Drawing
 			ColorBlend blend = CreateColorBlend(lg, bounds, float2(startX, startY), float2(endX, endY),
 				out gStart, out gEnd);
 
+			if (Vector.Dot(gStart, gEnd) < 1e-10)
+				return;
+
 			var brush = new LinearGradientBrush(
 				new PointF(gStart.X, gStart.Y),
 				new PointF(gEnd.X, gEnd.Y),


### PR DESCRIPTION
It seems the .NET implementation of LinearGradientBrush doesn't really
like zero-length gradients, so we end up allocating a silly amount of
memory, eventually crashing.

We already have an early-out like this earlier, so let's add one more
to avoid crashing.

Fixes #1117.
