### PR TITLE
Fix for the ticket #1156

### DIFF
--- a/Source/Fuse.Share/ShareModule.uno
+++ b/Source/Fuse.Share/ShareModule.uno
@@ -142,7 +142,7 @@ namespace Fuse.Share
 
 			if defined(android || iOS)
 			{
-				var description = args.Length>1 ? "" + args[1] : "";
+				var description = args.Length>1 ? "" + args[2] : "";
 				if defined(android)
 				{
 					AndroidShareImpl.ShareFile("file://" + path, type, description);
@@ -151,7 +151,7 @@ namespace Fuse.Share
 				else if defined(iOS)
 				{
 					float2 position = float2(0);
-					if (args.Length > 2 && TryGetPosition(args[2], out position))
+					if (args.Length > 2 && TryGetPosition(args[3], out position))
 						iOSShareImpl.ShareFile("file://" + path, type, description, position);
 					else
 						iOSShareImpl.ShareFile("file://" + path, type, description);

--- a/Source/Fuse.Share/ShareModule.uno
+++ b/Source/Fuse.Share/ShareModule.uno
@@ -142,7 +142,7 @@ namespace Fuse.Share
 
 			if defined(android || iOS)
 			{
-				var description = args.Length>1 ? "" + args[2] : "";
+				var description = args.Length>2 ? "" + args[2] : "";
 				if defined(android)
 				{
 					AndroidShareImpl.ShareFile("file://" + path, type, description);
@@ -151,7 +151,7 @@ namespace Fuse.Share
 				else if defined(iOS)
 				{
 					float2 position = float2(0);
-					if (args.Length > 2 && TryGetPosition(args[3], out position))
+					if (args.Length > 3 && TryGetPosition(args[3], out position))
 						iOSShareImpl.ShareFile("file://" + path, type, description, position);
 					else
 						iOSShareImpl.ShareFile("file://" + path, type, description);


### PR DESCRIPTION
1/ Create a script that calls this line:
Share.shareFile(image.path, "image/*", "Text To Share", ShareOrigin);
2/ Run it
=> Description is never shown, even in a simple email.

** Briefly describe changes and the motivation behind them here **

This PR contains:
- [ ] Changelog
- [ ] Documentation
- [ ] Tests
