### PR TITLE
Fix filename casing

### DIFF
--- a/Source/Experimental.TextureLoader/Experimental.TextureLoader.unoproj
+++ b/Source/Experimental.TextureLoader/Experimental.TextureLoader.unoproj
@@ -7,7 +7,7 @@
     "TextureLoaderImpl.uno:Source",
     "TextureLoaderImpl.js.uxl:Extensions",
     "TextureLoaderImpl.cpp.uxl:Extensions",
-    "CIL/CILTextureLoader.uno:Source",
+    "CIL/CilTextureLoader.uno:Source",
     "CIL/Uno/BufferAccessor.uno:Source"
   ]
 }

--- a/Source/Fuse.Platform/Fuse.Platform.unoproj
+++ b/Source/Fuse.Platform/Fuse.Platform.unoproj
@@ -25,7 +25,7 @@
     "SystemUI.uno:Source",
     "Android/SystemUI.uno:Source",
     "iOS/SystemUI.uno:Source",
-    "iOS/SystemUI.iOS.uxl:Extensions",
+    "iOS/SystemUI.ios.uxl:Extensions",
     "iOS/AppDelegateSoftKeyboard.h:File",
     "iOS/AppDelegateSoftKeyboard.mm:File",
     "iOS/AppDelegateStatusBar.h:File",


### PR DESCRIPTION
This fixes two instances of incorrect filename casings. This fixes the build on machines with a case-sensitive file system.
