### PR TITLE
Fixup pack.sh

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -66,7 +66,6 @@ cp -Rf Source/build \
     Stuff/.unopath \
     Stuff/uno \
     Stuff/uno.exe \
-    Stuff/uno.stuff \
     Stuff/stuff \
     Stuff/stuff.exe \
     release

--- a/pack.sh
+++ b/pack.sh
@@ -46,6 +46,7 @@ for f in Source/*; do
     project=$f/$name.unoproj
     if [ -f "$project" ]; then
         uno pack "$project" \
+            --version=$VERSION \
             --out-dir="$OUT" \
             $UNO_SUFFIX
     fi


### PR DESCRIPTION
This fixes two things:
- pack.sh was broken since we started using uno from nuget, as we no longer have uno.stuff.
- we also failed to pass --version to `uno pack`, leaving all packages with version 0.0.0.